### PR TITLE
chore: Claude Code setup — conventions, slash commands, hooks

### DIFF
--- a/.claude/commands/design-doc.md
+++ b/.claude/commands/design-doc.md
@@ -1,0 +1,49 @@
+---
+description: Create a structured design doc for a new feature
+args:
+  - name: topic
+    description: Feature or system being designed
+    required: true
+allowed-tools: Bash, Read, Glob, Grep, Write, Edit
+---
+
+Create a design document for: $ARGUMENTS
+
+Follow these steps:
+
+1. Search the codebase to understand existing related code and patterns
+2. **Verify-before-design**: grep for any APIs, methods, or types that the design depends on. Confirm what exists vs what needs to be created. List findings explicitly.
+3. Create the doc at `docs/plans/<topic>.md` with this structure:
+
+```
+# <Topic> Design
+
+## Problem
+What problem does this solve? Why now?
+
+## Current State
+What exists today that's relevant? (with file paths)
+
+## Proposed Design
+### API Surface
+### Internal Architecture
+### Data Flow
+
+## Alternatives Considered
+At least 2 alternatives with tradeoffs
+
+## Semantic Review
+Answer the 7 checklist questions from CLAUDE.md Key Conventions:
+1. Can this be called with the wrong World?
+2. Can Drop observe inconsistent state?
+3. Can two threads reach this through `&self`?
+4. Does dedup/merge/collapse preserve the strongest invariant?
+5. What happens if this is abandoned halfway through?
+6. Can a type bound be violated by a legal generic instantiation?
+7. Does the API surface of this handle permit any operation not covered by the Access bitset?
+
+## Implementation Plan
+Ordered steps with file paths
+```
+
+4. Commit the design doc

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,15 @@
+---
+description: Create a PR with full test/lint validation
+allowed-tools: Bash, Read, Glob, Grep
+---
+
+Follow these steps to create a pull request:
+
+1. Run `cargo fmt --all -- --check` — fix any formatting issues
+2. Run `cargo clippy --workspace --all-targets -- -D warnings` — fix any lint issues
+3. Run `cargo test -p minkowski` — all tests must pass
+4. Run `git diff main...HEAD` to understand the full scope of changes
+5. Run `git log main..HEAD --oneline` to see all commits
+6. Summarize the changes: what was added/changed/fixed and why
+7. Create the PR with `gh pr create` using a concise title and structured body with Summary and Test Plan sections
+8. Return the PR URL

--- a/.claude/commands/validate-api.md
+++ b/.claude/commands/validate-api.md
@@ -1,0 +1,40 @@
+---
+description: Sketch API designs in a scratch file and validate soundness via cargo check
+args:
+  - name: feature
+    description: The feature or API surface to design and validate
+    required: true
+allowed-tools: Bash, Read, Glob, Grep, Write, Edit
+---
+
+Validate API design soundness for: $ARGUMENTS
+
+This workflow uses the Rust compiler as an automated design reviewer. Follow these steps:
+
+1. **Understand the context**: Search the codebase for related types, traits, and patterns that the new API will interact with.
+
+2. **Create scratch file**: Create `src/scratch_api.rs` (or in the appropriate crate's src/) with:
+   - Necessary imports from the crate
+   - Add `mod scratch_api;` to the crate's lib.rs (temporarily)
+
+3. **Sketch 2-3 alternative API designs** in the scratch file:
+   - For each design, write: type signatures, trait impls, and a usage example function
+   - Label each design clearly with comments (// Design A: ..., // Design B: ...)
+   - Focus on the borrow checker implications — lifetimes, mutability, Send/Sync bounds
+
+4. **Iterate with cargo check**: Run `cargo check -p <crate> 2>&1` after each design sketch.
+   - If it compiles: document WHY it's sound (what invariants does the type system enforce?)
+   - If it fails: analyze the error. Is this a fundamental soundness issue or a fixable syntax problem?
+   - Iterate each design until it either compiles or you can explain why it's fundamentally unsound
+
+5. **Semantic review**: For each compiling design, answer:
+   - Can this be called with the wrong World?
+   - Can two threads reach this through `&self`?
+   - What happens if this is abandoned halfway through?
+   - Does the type system actually prevent the misuse, or does it just happen to compile?
+
+6. **Report findings**: Summarize tradeoffs of each approach. Recommend which to use in the design doc.
+
+7. **Clean up**: Remove the scratch file and the `mod scratch_api;` line from lib.rs. Do NOT commit scratch files.
+
+IMPORTANT: The goal is to find designs that are REJECTED by the compiler when misused. A design that compiles when used correctly is necessary but not sufficient — it must also FAIL to compile when used incorrectly (e.g., trying to get &mut T through &World).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,28 @@ Typed reducers narrow what a closure *can* touch so that conflict freedom is pro
   6. Can a type bound be violated by a legal generic instantiation?
   7. Does the API surface of this handle permit any operation not covered by the Access bitset?
 - **Transaction safety invariants**: any query path reachable from `&World` must be bounded by `ReadOnlyWorldQuery`. Any shared structure between World and a strategy uses `Arc` with a `WorldId` check at every entry point. Lock privilege in a `ColumnLockSet` can only escalate, never downgrade. Drop is the abort path — if a transaction can allocate engine resources (entity IDs, locks), it must be able to release them from Drop without `&mut World`, which means those resources route through interior-mutable shared handles (`OrphanQueue`, `Mutex<ColumnLockTable>`).
+- **Verify-before-design rule**: before designing features that depend on existing APIs, `grep` for the actual current methods/types. Confirm which ones exist vs which need to be created. Past bugs: assuming `EntityAllocator::reserve()` had atomics (it didn't exist), proposing `&mut World` in reducer APIs (unsound). The type system doesn't catch "assumed this method exists" — verification does.
+- **Derive macro visibility rule**: after implementing or modifying derive macros or code generation, always test the generated code from an external example/binary target (`minkowski-examples`) to verify `pub` vs `pub(crate)` visibility is correct. In-crate tests won't catch `pub(crate)` leaking into generated code.
+- **Change detection audit rule**: when implementing change detection or mutation tracking, enumerate ALL mutation paths (spawn, get_mut, insert, remove, query `&mut T`, query_table_mut, query_table_raw, changeset apply, any new accessor) and verify each path triggers detection. Consider same-tick interleaving edge cases where two mutations in the same tick must both be visible.
+- **Bug fix workflow rule**: when a specific bug is reported, address it directly with targeted investigation — don't route through brainstorming or design exploration workflows. Brainstorming is for new features and design decisions, not concrete bugs with reproduction steps.
 - **Drop cleanup rule**: if Drop needs to clean up engine state, the cleanup path must be reachable from `&self`. This constrains where state can live. If it's on World, Drop can't reach it. If it's behind `Arc<Mutex<_>>` shared between World and the transaction, Drop can. Every future resource that transactions can allocate — entity IDs, archetype slots, reserved capacity — must follow this pattern or it will leak on abort.
+
+# Unifying principle behind every ID type in the system:
+
+| Type | Proof at construction | Residue after erasure |
+|---|---|---|
+| `ComponentId` | `T: Component`, layout, drop fn | `u32` |
+| `ArchetypeId` | Sorted component set, column allocation | `u32` |
+| `Entity` | Generational uniqueness, archetype placement | `u64` |
+| `ReducerId` | Typed closure, access set, resolved components, args type | `usize` |
+| `QueryReducerId` | `WorldQuery` bound, column access pattern | `usize` |
+| `WorldId` | Unique allocator identity | `u64` |
+| `TxId` | Transaction lifecycle, cleanup registration | `u64` |
+| `ChangeTick` | Monotonic ordering, causal relationship | `u64` |
+
+Every one of these is a small integer that stands in for a proof the type system already verified. The runtime never re-checks the proof — it trusts the integer because the only way to obtain it was through a typed construction path that enforced the invariants.
+
+The corollary is that forging an ID — constructing one from a raw integer without going through the typed path — is the one thing that can violate the system's guarantees. Which is why all the constructors are `pub(crate)` or behind registration APIs. The user can hold IDs, copy them, store them, send them. They can't fabricate them. The type system did its work at the gate and the ID is the stamp that says "verified."
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

Adds Claude Code tooling improvements based on insights report analysis across 4 sessions / 46 hours of ECS engine development.

### CLAUDE.md — 4 new conventions
- **Verify-before-design rule**: grep for actual APIs before designing features that depend on them. Prevents the "assumed EntityAllocator::reserve() exists" class of bugs.
- **Derive macro visibility rule**: test generated code from external targets (minkowski-examples) to catch pub(crate) leaking into derive macro output.
- **Change detection audit rule**: enumerate ALL mutation paths when implementing detection. Prevents missing paths like query_table_mut.
- **Bug fix workflow rule**: direct investigation for concrete bugs, not brainstorming workflows.

### 3 new slash commands
- `/pr` — runs fmt + clippy + tests, then creates a PR with structured body
- `/design-doc <topic>` — creates a design doc with semantic review checklist from CLAUDE.md
- `/validate-api <feature>` — compiler-as-design-reviewer: sketches 2-3 API designs in a scratch file, iterates with `cargo check`, validates that the type system *rejects* misuse

### Post-edit hook (local only, not committed)
- Auto-runs `cargo check --workspace --quiet` after every Edit/Write to catch compilation errors immediately

## Test Plan
No code changes — documentation and tooling only.