### PR TITLE
Structured error UX: thiserror, Conflict Display, WAL dedup

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,0 +1,7 @@
+{
+  "threshold": 10,
+  "reporters": ["console"],
+  "ignore": ["**/benches/**"],
+  "minLines": 8,
+  "minTokens": 75
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Build & Test Commands
 
 ```bash
-cargo test -p minkowski --lib          # Unit tests (341 tests, fast)
+cargo test -p minkowski --lib          # Unit tests (344 tests, fast)
 cargo test -p minkowski                # All tests including doc tests
 cargo test -p minkowski -- entity      # Run tests matching a filter
 
@@ -209,6 +209,7 @@ The corollary is that forging an ID — constructing one from a raw integer with
 | `minkowski-persist` | WAL, snapshots, codec registry, `Durable<S>` wrapper |
 | `rkyv` (persist) | Zero-copy serialization for WAL records and snapshots |
 | `memmap2` (persist) | Memory-mapped file I/O for zero-copy snapshot loading |
+| `thiserror` (persist) | Derive macros for `std::error::Error` impls |
 | `criterion` (dev) | Benchmark harness |
 | `hecs` (dev) | Benchmark comparison target |
 | `fastrand` (examples) | Example RNG |

--- a/crates/minkowski-persist/Cargo.toml
+++ b/crates/minkowski-persist/Cargo.toml
@@ -9,6 +9,7 @@ rkyv = { version = "0.8", features = ["alloc", "bytecheck"] }
 memmap2 = "0.9"
 parking_lot = "0.12"
 fixedbitset = "0.5"
+thiserror = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/minkowski-persist/src/codec.rs
+++ b/crates/minkowski-persist/src/codec.rs
@@ -27,24 +27,18 @@ type SerializeSparseFn =
 /// Type-erased sparse insertion: deserializes bytes and inserts into World's sparse storage.
 type InsertSparseFn = fn(&mut World, Entity, &[u8]) -> Result<(), CodecError>;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum CodecError {
+    #[error("failed to serialize component: {0}")]
     Serialize(String),
+    #[error("failed to deserialize component: {0}")]
     Deserialize(String),
+    #[error(
+        "no codec registered for component id {0} — \
+         call `codecs.register::<T>(&mut world)` for each component type before persisting"
+    )]
     UnregisteredComponent(ComponentId),
 }
-
-impl std::fmt::Display for CodecError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Serialize(msg) => write!(f, "serialize: {msg}"),
-            Self::Deserialize(msg) => write!(f, "deserialize: {msg}"),
-            Self::UnregisteredComponent(id) => write!(f, "no codec for component {id}"),
-        }
-    }
-}
-
-impl std::error::Error for CodecError {}
 
 struct ComponentCodec {
     name: &'static str,

--- a/crates/minkowski-persist/src/format.rs
+++ b/crates/minkowski-persist/src/format.rs
@@ -1,15 +1,8 @@
 use crate::record::{SnapshotData, WalRecord};
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
+#[error("rkyv format error: {0}")]
 pub struct FormatError(pub String);
-
-impl std::fmt::Display for FormatError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "format: {}", self.0)
-    }
-}
-
-impl std::error::Error for FormatError {}
 
 pub fn serialize_record(record: &WalRecord) -> Result<Vec<u8>, FormatError> {
     rkyv::to_bytes::<rkyv::rancor::Error>(record)

--- a/crates/minkowski-persist/src/snapshot.rs
+++ b/crates/minkowski-persist/src/snapshot.rs
@@ -8,35 +8,14 @@ use crate::codec::{CodecError, CodecRegistry};
 use crate::format;
 use crate::record::*;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum SnapshotError {
-    Io(std::io::Error),
-    Codec(CodecError),
+    #[error("snapshot I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("snapshot codec error: {0}")]
+    Codec(#[from] CodecError),
+    #[error("snapshot format error: {0}")]
     Format(String),
-}
-
-impl std::fmt::Display for SnapshotError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Io(e) => write!(f, "snapshot I/O: {e}"),
-            Self::Codec(e) => write!(f, "snapshot codec: {e}"),
-            Self::Format(msg) => write!(f, "snapshot format: {msg}"),
-        }
-    }
-}
-
-impl std::error::Error for SnapshotError {}
-
-impl From<std::io::Error> for SnapshotError {
-    fn from(e: std::io::Error) -> Self {
-        Self::Io(e)
-    }
-}
-
-impl From<CodecError> for SnapshotError {
-    fn from(e: CodecError) -> Self {
-        Self::Codec(e)
-    }
 }
 
 /// Full-world snapshot: serialize all archetype data to disk and reconstruct on load.

--- a/crates/minkowski-persist/src/wal.rs
+++ b/crates/minkowski-persist/src/wal.rs
@@ -18,35 +18,14 @@ fn read_exact_at(file: &File, pos: u64, buf: &mut [u8]) -> io::Result<()> {
     f.read_exact(buf)
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum WalError {
-    Io(io::Error),
-    Codec(CodecError),
+    #[error("WAL I/O error: {0}")]
+    Io(#[from] io::Error),
+    #[error("WAL codec error: {0}")]
+    Codec(#[from] CodecError),
+    #[error("WAL format error: {0}")]
     Format(String),
-}
-
-impl std::fmt::Display for WalError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Io(e) => write!(f, "WAL I/O: {e}"),
-            Self::Codec(e) => write!(f, "WAL codec: {e}"),
-            Self::Format(msg) => write!(f, "WAL format: {msg}"),
-        }
-    }
-}
-
-impl std::error::Error for WalError {}
-
-impl From<io::Error> for WalError {
-    fn from(e: io::Error) -> Self {
-        Self::Io(e)
-    }
-}
-
-impl From<CodecError> for WalError {
-    fn from(e: CodecError) -> Self {
-        Self::Codec(e)
-    }
 }
 
 /// Append-only write-ahead log. Each record is an rkyv-serialized changeset
@@ -129,49 +108,55 @@ impl Wal {
         let mut pos: u64 = 0;
         let mut last_seq = if from_seq > 0 { from_seq - 1 } else { 0 };
 
-        loop {
-            let record_start = pos;
-            let mut len_buf = [0u8; 4];
-            match read_exact_at(&self.file, record_start, &mut len_buf) {
-                Ok(()) => {}
-                Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => {
-                    self.file.set_len(record_start)?;
-                    break;
-                }
-                Err(e) => return Err(e.into()),
-            }
-            let len = u32::from_le_bytes(len_buf) as usize;
-            let mut payload = vec![0u8; len];
-            match read_exact_at(&self.file, record_start + 4, &mut payload) {
-                Ok(()) => {}
-                Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => {
-                    self.file.set_len(record_start)?;
-                    break;
-                }
-                Err(e) => return Err(e.into()),
-            }
-
-            let record = match format::deserialize_record(&payload) {
-                Ok(r) => r,
-                Err(_) => {
-                    // Corrupted payload — treat as torn entry, truncate.
-                    self.file.set_len(record_start)?;
-                    break;
-                }
-            };
-
+        while let Some((record, next_pos)) = self.read_next_record(pos)? {
             if record.seq >= from_seq {
                 Self::apply_record(&record, world, codecs)?;
                 last_seq = record.seq;
             }
-
-            pos = record_start + 4 + len as u64;
+            pos = next_pos;
         }
 
         Ok(last_seq)
     }
 
     // ── Internal helpers ─────────────────────────────────────────────
+
+    /// Try to read and deserialize the next WAL record starting at `pos`.
+    ///
+    /// Returns `Ok(Some((record, next_pos)))` on success, `Ok(None)` if the
+    /// file ends cleanly or a torn/corrupt entry was found (truncated to
+    /// `pos`).
+    fn read_next_record(
+        &mut self,
+        pos: u64,
+    ) -> Result<Option<(crate::record::WalRecord, u64)>, WalError> {
+        let mut len_buf = [0u8; 4];
+        match read_exact_at(&self.file, pos, &mut len_buf) {
+            Ok(()) => {}
+            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => {
+                self.file.set_len(pos)?;
+                return Ok(None);
+            }
+            Err(e) => return Err(e.into()),
+        }
+        let len = u32::from_le_bytes(len_buf) as usize;
+        let mut payload = vec![0u8; len];
+        match read_exact_at(&self.file, pos + 4, &mut payload) {
+            Ok(()) => {}
+            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => {
+                self.file.set_len(pos)?;
+                return Ok(None);
+            }
+            Err(e) => return Err(e.into()),
+        }
+        match format::deserialize_record(&payload) {
+            Ok(record) => Ok(Some((record, pos + 4 + len as u64))),
+            Err(_) => {
+                self.file.set_len(pos)?;
+                Ok(None)
+            }
+        }
+    }
 
     fn changeset_to_record(
         seq: u64,
@@ -311,46 +296,11 @@ impl Wal {
     fn scan_last_seq(&mut self) -> Result<u64, WalError> {
         self.file.seek(SeekFrom::Start(0))?;
         let mut last_seq = 0u64;
-        let mut valid_end: u64 = 0;
+        let mut pos: u64 = 0;
 
-        loop {
-            let record_start = valid_end;
-            let mut len_buf = [0u8; 4];
-            match read_exact_at(&self.file, record_start, &mut len_buf) {
-                Ok(()) => {}
-                Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => {
-                    // Torn length prefix — truncate to last valid boundary
-                    self.file.set_len(valid_end)?;
-                    break;
-                }
-                Err(e) => return Err(e.into()),
-            }
-            let len = u32::from_le_bytes(len_buf) as usize;
-            let mut payload = vec![0u8; len];
-            match read_exact_at(&self.file, record_start + 4, &mut payload) {
-                Ok(()) => {}
-                Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => {
-                    // Torn payload — truncate to start of this record
-                    self.file.set_len(record_start)?;
-                    break;
-                }
-                Err(e) => return Err(e.into()),
-            }
-
-            match format::deserialize_record(&payload) {
-                Ok(record) => {
-                    last_seq = record.seq;
-                    valid_end = record_start + 4 + len as u64;
-                }
-                Err(_) => {
-                    // Corrupted payload — treat as torn entry, truncate.
-                    // A crash can produce a length-complete but content-corrupt
-                    // record. Truncating to the last valid boundary preserves
-                    // all prior records for replay.
-                    self.file.set_len(record_start)?;
-                    break;
-                }
-            }
+        while let Some((record, next_pos)) = self.read_next_record(pos)? {
+            last_seq = record.seq;
+            pos = next_pos;
         }
 
         Ok(last_seq)

--- a/crates/minkowski/src/transaction.rs
+++ b/crates/minkowski/src/transaction.rs
@@ -83,6 +83,41 @@ pub struct Conflict {
     pub component_ids: FixedBitSet,
 }
 
+impl Conflict {
+    /// Format the conflict with resolved component names from the World.
+    ///
+    /// Produces a human-readable message like:
+    /// `"transaction conflict on [Pos, Vel] — try increasing retries or switching to Pessimistic"`
+    pub fn display_with(&self, world: &World) -> String {
+        let names: Vec<&str> = self
+            .component_ids
+            .ones()
+            .filter_map(|id| world.component_name(id))
+            .collect();
+        if names.is_empty() {
+            return format!("{self}");
+        }
+        format!(
+            "transaction conflict on [{}] — \
+             try increasing retries or switching to Pessimistic strategy",
+            names.join(", ")
+        )
+    }
+}
+
+impl std::fmt::Display for Conflict {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let ids: Vec<usize> = self.component_ids.ones().collect();
+        write!(
+            f,
+            "transaction conflict on component columns {ids:?} — \
+             try increasing retries or switching to Pessimistic strategy"
+        )
+    }
+}
+
+impl std::error::Error for Conflict {}
+
 // ── TxCleanup + Tx ─────────────────────────────────────────────────
 
 /// Strategy-specific teardown logic invoked when a [`Tx`] is dropped
@@ -1110,5 +1145,52 @@ mod tests {
         let access = Access::of::<(&mut Pos,)>(&mut world_a);
         let strategy = Optimistic::new(&world_a);
         let _ = strategy.transact(&mut world_b, &access, |_tx, _world| {});
+    }
+
+    // ── Conflict display tests ──────────────────────────────────────
+
+    #[test]
+    fn conflict_display_shows_component_ids() {
+        let mut bits = FixedBitSet::with_capacity(8);
+        bits.insert(1);
+        bits.insert(5);
+        let conflict = Conflict {
+            component_ids: bits,
+        };
+        let msg = format!("{conflict}");
+        assert!(msg.contains("[1, 5]"), "should list component IDs: {msg}");
+        assert!(
+            msg.contains("Pessimistic"),
+            "should suggest alternative: {msg}"
+        );
+    }
+
+    #[test]
+    fn conflict_display_with_resolves_names() {
+        let mut world = World::new();
+        world.register_component::<Pos>();
+        world.register_component::<Vel>();
+        let mut bits = FixedBitSet::with_capacity(2);
+        bits.insert(0);
+        bits.insert(1);
+        let conflict = Conflict {
+            component_ids: bits,
+        };
+        let msg = conflict.display_with(&world);
+        assert!(msg.contains("Pos"), "should resolve Pos: {msg}");
+        assert!(msg.contains("Vel"), "should resolve Vel: {msg}");
+        assert!(
+            msg.contains("Pessimistic"),
+            "should suggest alternative: {msg}"
+        );
+    }
+
+    #[test]
+    fn conflict_is_std_error() {
+        let conflict = Conflict {
+            component_ids: FixedBitSet::new(),
+        };
+        // Verify Conflict implements std::error::Error (compiles = passes)
+        let _: &dyn std::error::Error = &conflict;
     }
 }


### PR DESCRIPTION
## Summary

- **thiserror in minkowski-persist** — replaces ~44 lines of hand-rolled `Display`/`Error`/`From` impls with derive macros. Enriches error messages with actionable suggestions (e.g. `UnregisteredComponent` now tells users to call `codecs.register::<T>()`). Adds proper `source()` chaining via `#[from]`.
- **`Display`/`Error` for `Conflict`** — enables `?` with `Box<dyn Error>`/anyhow. `display_with(&World)` resolves component IDs to names for human-readable messages. Plain `Display` falls back to numeric IDs.
- **WAL `read_next_record` helper** — deduplicates torn-entry handling between `replay_from` and `scan_last_seq` (~50 lines removed). Both now use clean `while let` loops.
- **`.jscpd.json`** — configures copy-paste detection (excludes benches, tunes thresholds for inline-test Rust codebases). Reduces noise from 67→16 clones.

## Test plan

- [x] `cargo test -p minkowski --lib` — 344 tests pass (3 new: `conflict_display_shows_component_ids`, `conflict_display_with_resolves_names`, `conflict_is_std_error`)
- [x] `cargo test -p minkowski-persist` — 40 tests pass (torn entry, corrupt payload, round-trip scenarios verify WAL refactor)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Self-audit: no mutation path, visibility, or edge case issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)