### PR TITLE
Replication groundwork: entity_count + doc fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Build & Test Commands
 
 ```bash
-cargo test -p minkowski --lib          # Unit tests (344 tests, fast)
+cargo test -p minkowski --lib          # Unit tests (368 tests, fast)
 cargo test -p minkowski                # All tests including doc tests
 cargo test -p minkowski -- entity      # Run tests matching a filter
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ registry.run(&mut world, move_id, ());
 
 Each unique combination of [component][component] types gets an [archetype][archetype] — a [struct of arrays][soa] where each column is a `BlobVec` (type-erased growable byte array with 64-byte alignment). Queries match archetypes via [bitset][bitset] subset checks, then iterate columns with raw pointer arithmetic. No virtual dispatch in the hot path.
 
-Entities are [generational][generational-index] `u64` IDs (32-bit index + 32-bit generation). Recycled indices get bumped generations to prevent use-after-free. O(1) lookup from entity to archetype row via `Vec<Option<EntityLocation>>`. Sparse components (`HashMap<Entity, T>`) are opt-in for tags and rarely-queried data, preventing archetype fragmentation.
+Entities are [generational][generational-index] `u64` IDs (32-bit index + 32-bit generation). Recycled indices get bumped generations to prevent use-after-free. O(1) lookup from entity to archetype row via `Vec<Option<EntityLocation>>`. Sparse components (paged sparse sets with O(1) lookup) are opt-in for tags and rarely-queried data, preventing archetype fragmentation.
 
 ```rust
 let mut world = World::new();
@@ -234,7 +234,7 @@ Design decisions are documented as ADRs in [`docs/adr/`](docs/adr/). Each record
 ## Building & Testing
 
 ```
-cargo test -p minkowski                # 320 tests
+cargo test -p minkowski                # 368 tests
 cargo clippy --workspace --all-targets -- -D warnings
 cargo bench -p minkowski               # criterion benchmarks vs hecs
 MIRIFLAGS="-Zmiri-tree-borrows" cargo +nightly miri test -p minkowski --lib   # UB check
@@ -247,6 +247,7 @@ CI runs fmt, clippy, test, and Miri sequentially on every PR. A `ci-pass` aggreg
 | Feature | Rationale |
 |---|---|
 | Replication & sync | Filtered WAL replay for read replicas and client mirrors |
+| Observability companion crate | `minkowski-observe`: pure consumer that calls `world.snapshot_metrics()`, diffs consecutive snapshots, computes rates (entity churn, changeset throughput, cache hit rates), and exports. Stretch within stretch: [ratatui][ratatui] TUI dashboard for live archetype sizes and sync diagnostics. Placed after replication because replication adds the most interesting metrics — sync latency, conflict rate across clients, changeset sizes over the wire |
 
 ## Glossary
 
@@ -291,4 +292,5 @@ This project is licensed under the [Mozilla Public License 2.0](https://www.mozi
 [soa]: https://en.wikipedia.org/wiki/AoS_and_SoA#Structure_of_arrays
 [tree-borrows]: https://perso.crans.org/vanille/treebor/
 [uniform-grid]: https://en.wikipedia.org/wiki/Grid_(spatial_index)
+[ratatui]: https://github.com/ratatui/ratatui
 [wal]: https://en.wikipedia.org/wiki/Write-ahead_logging

--- a/crates/minkowski/src/world.rs
+++ b/crates/minkowski/src/world.rs
@@ -1092,6 +1092,17 @@ impl World {
         QueryIter::new(fetches)
     }
 
+    // ── Introspection ─────────────────────────────────────────────────
+
+    /// Number of live (placed) entities across all archetypes.
+    pub fn entity_count(&self) -> usize {
+        self.archetypes
+            .archetypes
+            .iter()
+            .map(|arch| arch.len())
+            .sum()
+    }
+
     // ── Persistence accessors ────────────────────────────────────────
 
     /// Number of archetypes (for iteration bounds).
@@ -2235,5 +2246,18 @@ mod tests {
         });
         values.sort_by(|a, b| a.partial_cmp(b).unwrap());
         assert_eq!(values, vec![2.0, 4.0]);
+    }
+
+    #[test]
+    fn entity_count() {
+        let mut world = World::new();
+        assert_eq!(world.entity_count(), 0);
+
+        let a = world.spawn((Pos { x: 0.0, y: 0.0 },));
+        let _b = world.spawn((Pos { x: 1.0, y: 1.0 }, Vel { dx: 1.0, dy: 1.0 }));
+        assert_eq!(world.entity_count(), 2);
+
+        world.despawn(a);
+        assert_eq!(world.entity_count(), 1);
     }
 }


### PR DESCRIPTION
## Summary

- Add `World::entity_count()` — returns the number of live placed entities across all archetypes. Needed for replication sync handshakes and the future observability crate.
- Fix stale test counts: README (320→368), CLAUDE.md (344→368)
- Fix stale sparse storage description in README: `HashMap<Entity, T>` → paged sparse sets (landed in #42)
- Add observability companion crate (`minkowski-observe`) to roadmap as stretch goal after replication

## Test Plan

- [x] New `entity_count` test: empty world → spawn across two archetypes → despawn → verify count
- [x] `cargo test -p minkowski --lib` — 368 tests passing
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)