### PR TITLE
feat(lsm): Phase 1 — SortedRun format, FlushWriter, Reader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/minkowski", "crates/minkowski-derive", "crates/minkowski-persist", "crates/minkowski-observe", "crates/minkowski-py", "crates/minkowski-bench", "examples"]
+members = ["crates/minkowski", "crates/minkowski-derive", "crates/minkowski-persist", "crates/minkowski-observe", "crates/minkowski-py", "crates/minkowski-bench", "crates/minkowski-lsm", "examples"]
 exclude = ["fuzz"]
 
 [workspace.lints.rust]

--- a/crates/minkowski-lsm/Cargo.toml
+++ b/crates/minkowski-lsm/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "minkowski-lsm"
+version = "1.3.0"
+edition = "2024"
+
+[lints]
+workspace = true
+
+[dependencies]
+minkowski = { path = "../minkowski" }
+crc32fast = "1"
+memmap2 = "0.9"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/minkowski-lsm/src/error.rs
+++ b/crates/minkowski-lsm/src/error.rs
@@ -1,0 +1,1 @@
+// LSM error types — placeholder

--- a/crates/minkowski-lsm/src/error.rs
+++ b/crates/minkowski-lsm/src/error.rs
@@ -2,6 +2,7 @@ use std::io;
 
 /// Errors that can occur during LSM file operations.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum LsmError {
     /// Underlying I/O error.
     Io(io::Error),

--- a/crates/minkowski-lsm/src/error.rs
+++ b/crates/minkowski-lsm/src/error.rs
@@ -1,1 +1,51 @@
-// LSM error types — placeholder
+use std::io;
+
+/// Errors that can occur during LSM file operations.
+#[derive(Debug)]
+pub enum LsmError {
+    /// Underlying I/O error.
+    Io(io::Error),
+    /// File format violation (bad magic, unsupported version, truncated data, etc.).
+    Format(String),
+    /// CRC mismatch at a given file offset.
+    Crc {
+        /// Byte offset of the record whose checksum failed.
+        offset: u64,
+        /// Checksum stored in the file.
+        expected: u32,
+        /// Checksum computed over the actual bytes.
+        actual: u32,
+    },
+}
+
+impl std::fmt::Display for LsmError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "I/O error: {e}"),
+            Self::Format(msg) => write!(f, "format error: {msg}"),
+            Self::Crc {
+                offset,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "CRC mismatch at offset {offset}: expected {expected:#010x}, got {actual:#010x}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LsmError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            Self::Format(_) | Self::Crc { .. } => None,
+        }
+    }
+}
+
+impl From<io::Error> for LsmError {
+    fn from(e: io::Error) -> Self {
+        Self::Io(e)
+    }
+}

--- a/crates/minkowski-lsm/src/format.rs
+++ b/crates/minkowski-lsm/src/format.rs
@@ -285,6 +285,9 @@ mod tests {
         assert_eq!(recovered.page_index, 15);
         assert_eq!(recovered.row_count, 256);
         assert_eq!(recovered.page_crc32, 0x1234_5678);
-        assert_eq!(recovered._padding, 0);
+        #[allow(clippy::used_underscore_binding)]
+        {
+            assert_eq!(recovered._padding, 0);
+        }
     }
 }

--- a/crates/minkowski-lsm/src/format.rs
+++ b/crates/minkowski-lsm/src/format.rs
@@ -56,16 +56,11 @@ impl Header {
         unsafe { &*(self as *const Self as *const [u8; 64]) }
     }
 
-    /// Interpret a 64-byte slice as a `Header` reference.
-    ///
-    /// # Safety
-    /// The caller must ensure `bytes` is properly aligned for `Header`.
-    /// For unaligned reads (e.g., from a file buffer), copy into an aligned
-    /// value first or use the `as_bytes` + `clone`-by-value pattern.
-    pub fn from_bytes(bytes: &[u8; 64]) -> &Self {
-        // SAFETY: Header is #[repr(C)]; any 64-byte bit pattern is a valid
-        // representation (individual field semantics are validated separately).
-        unsafe { &*(bytes.as_ptr() as *const Self) }
+    /// Read a `Header` from a 64-byte slice. Handles unaligned input safely.
+    pub fn from_bytes(bytes: &[u8; 64]) -> Self {
+        // SAFETY: Header is #[repr(C)] and any 64-byte bit pattern is a valid
+        // representation. read_unaligned handles arbitrary alignment.
+        unsafe { std::ptr::read_unaligned(bytes.as_ptr() as *const Self) }
     }
 }
 
@@ -99,10 +94,9 @@ impl PageHeader {
         unsafe { &*(self as *const Self as *const [u8; 16]) }
     }
 
-    /// Interpret a 16-byte slice as a `PageHeader` reference.
-    pub fn from_bytes(bytes: &[u8; 16]) -> &Self {
-        // SAFETY: PageHeader is #[repr(C)]; any 16-byte bit pattern is valid.
-        unsafe { &*(bytes.as_ptr() as *const Self) }
+    /// Read a `PageHeader` from a 16-byte slice. Handles unaligned input safely.
+    pub fn from_bytes(bytes: &[u8; 16]) -> Self {
+        unsafe { std::ptr::read_unaligned(bytes.as_ptr() as *const Self) }
     }
 }
 
@@ -134,10 +128,9 @@ impl IndexEntry {
         unsafe { &*(self as *const Self as *const [u8; 16]) }
     }
 
-    /// Interpret a 16-byte slice as an `IndexEntry` reference.
-    pub fn from_bytes(bytes: &[u8; 16]) -> &Self {
-        // SAFETY: IndexEntry is #[repr(C)]; any 16-byte bit pattern is valid.
-        unsafe { &*(bytes.as_ptr() as *const Self) }
+    /// Read an `IndexEntry` from a 16-byte slice. Handles unaligned input safely.
+    pub fn from_bytes(bytes: &[u8; 16]) -> Self {
+        unsafe { std::ptr::read_unaligned(bytes.as_ptr() as *const Self) }
     }
 
     /// The sort key used for binary search.
@@ -194,10 +187,9 @@ impl Footer {
         unsafe { &*(self as *const Self as *const [u8; 64]) }
     }
 
-    /// Interpret a 64-byte slice as a `Footer` reference.
-    pub fn from_bytes(bytes: &[u8; 64]) -> &Self {
-        // SAFETY: Footer is #[repr(C)]; any 64-byte bit pattern is valid.
-        unsafe { &*(bytes.as_ptr() as *const Self) }
+    /// Read a `Footer` from a 64-byte slice. Handles unaligned input safely.
+    pub fn from_bytes(bytes: &[u8; 64]) -> Self {
+        unsafe { std::ptr::read_unaligned(bytes.as_ptr() as *const Self) }
     }
 }
 

--- a/crates/minkowski-lsm/src/format.rs
+++ b/crates/minkowski-lsm/src/format.rs
@@ -1,0 +1,1 @@
+// Sorted run file format — placeholder

--- a/crates/minkowski-lsm/src/format.rs
+++ b/crates/minkowski-lsm/src/format.rs
@@ -23,8 +23,8 @@ const _: () = assert!(std::mem::size_of::<Footer>() == 64);
 
 /// Fixed-size file header written at byte offset 0.
 ///
-/// The header is protected by `header_crc32`, computed over the first 60 bytes
-/// (i.e., everything before the CRC field itself and the reserved tail).
+/// The header is protected by `header_crc32`, computed over the first 40 bytes
+/// (i.e., everything before the CRC field itself: 8 + 4 + 4 + 8 + 8 + 8 = 40).
 #[repr(C)]
 pub struct Header {
     /// Must equal [`MAGIC`].
@@ -39,7 +39,7 @@ pub struct Header {
     pub sequence_lo: u64,
     /// Upper 64 bits of the WAL sequence range covered by this run.
     pub sequence_hi: u64,
-    /// CRC32 of the preceding 60 bytes of this header.
+    /// CRC32 of the preceding 40 bytes of this header.
     pub header_crc32: u32,
     /// Reserved for future use; must be zero on write.
     pub reserved: [u8; 20],

--- a/crates/minkowski-lsm/src/format.rs
+++ b/crates/minkowski-lsm/src/format.rs
@@ -1,1 +1,290 @@
-// Sorted run file format — placeholder
+/// On-disk magic bytes identifying a Minkowski LSM sorted-run file.
+pub const MAGIC: [u8; 8] = *b"MKLSM01\0";
+
+/// File format version.
+pub const VERSION: u32 = 1;
+
+/// Special `slot` value used in [`PageHeader`] and [`IndexEntry`] to identify
+/// entity-ID pages (as opposed to component-data pages).
+pub const ENTITY_SLOT: u16 = 0xFFFF;
+
+/// Number of rows per page — re-exported from the minkowski crate for
+/// convenience so callers do not need to depend on both crates.
+pub const PAGE_SIZE: usize = minkowski::PAGE_SIZE;
+
+// ── compile-time size assertions ────────────────────────────────────────────
+
+const _: () = assert!(std::mem::size_of::<Header>() == 64);
+const _: () = assert!(std::mem::size_of::<PageHeader>() == 16);
+const _: () = assert!(std::mem::size_of::<IndexEntry>() == 16);
+const _: () = assert!(std::mem::size_of::<Footer>() == 64);
+
+// ── File Header (64 bytes) ───────────────────────────────────────────────────
+
+/// Fixed-size file header written at byte offset 0.
+///
+/// The header is protected by `header_crc32`, computed over the first 60 bytes
+/// (i.e., everything before the CRC field itself and the reserved tail).
+#[repr(C)]
+pub struct Header {
+    /// Must equal [`MAGIC`].
+    pub magic: [u8; 8],
+    /// Must equal [`VERSION`].
+    pub version: u32,
+    /// Number of schema entries that follow the page data.
+    pub schema_count: u32,
+    /// Total number of data pages in this run.
+    pub page_count: u64,
+    /// Lower 64 bits of the WAL sequence range covered by this run.
+    pub sequence_lo: u64,
+    /// Upper 64 bits of the WAL sequence range covered by this run.
+    pub sequence_hi: u64,
+    /// CRC32 of the preceding 60 bytes of this header.
+    pub header_crc32: u32,
+    /// Reserved for future use; must be zero on write.
+    pub reserved: [u8; 20],
+}
+
+impl Header {
+    /// View this header as a 64-byte slice for I/O.
+    ///
+    /// # Safety
+    /// `Header` is `#[repr(C)]` with a compile-time-verified size of 64 bytes.
+    pub fn as_bytes(&self) -> &[u8; 64] {
+        // SAFETY: Header is #[repr(C)] and the compile-time assert above
+        // guarantees its size is exactly 64 bytes.
+        unsafe { &*(self as *const Self as *const [u8; 64]) }
+    }
+
+    /// Interpret a 64-byte slice as a `Header` reference.
+    ///
+    /// # Safety
+    /// The caller must ensure `bytes` is properly aligned for `Header`.
+    /// For unaligned reads (e.g., from a file buffer), copy into an aligned
+    /// value first or use the `as_bytes` + `clone`-by-value pattern.
+    pub fn from_bytes(bytes: &[u8; 64]) -> &Self {
+        // SAFETY: Header is #[repr(C)]; any 64-byte bit pattern is a valid
+        // representation (individual field semantics are validated separately).
+        unsafe { &*(bytes.as_ptr() as *const Self) }
+    }
+}
+
+// ── Page Header (16 bytes) ───────────────────────────────────────────────────
+
+/// Header prefixing each data page.
+///
+/// A data page contains `PAGE_SIZE` rows of a single component column for
+/// one archetype.  When `slot == ENTITY_SLOT` the page stores raw entity IDs.
+#[repr(C)]
+pub struct PageHeader {
+    /// Archetype index within this run.
+    pub arch_id: u16,
+    /// Component slot within the archetype, or [`ENTITY_SLOT`].
+    pub slot: u16,
+    /// Which page of the column (0-based).
+    pub page_index: u16,
+    /// Number of rows in this page (≤ [`PAGE_SIZE`]).
+    pub row_count: u16,
+    /// CRC32 of the page data bytes that immediately follow this header.
+    pub page_crc32: u32,
+    /// Explicit padding to reach 16 bytes; must be zero on write.
+    #[allow(clippy::pub_underscore_fields)]
+    pub _padding: u32,
+}
+
+impl PageHeader {
+    /// View this header as a 16-byte slice for I/O.
+    pub fn as_bytes(&self) -> &[u8; 16] {
+        // SAFETY: PageHeader is #[repr(C)] with compile-time-verified size 16.
+        unsafe { &*(self as *const Self as *const [u8; 16]) }
+    }
+
+    /// Interpret a 16-byte slice as a `PageHeader` reference.
+    pub fn from_bytes(bytes: &[u8; 16]) -> &Self {
+        // SAFETY: PageHeader is #[repr(C)]; any 16-byte bit pattern is valid.
+        unsafe { &*(bytes.as_ptr() as *const Self) }
+    }
+}
+
+// ── Index Entry (16 bytes) ───────────────────────────────────────────────────
+
+/// Sparse index entry mapping `(arch_id, slot, page_index)` to a file offset.
+///
+/// Entries are stored in sorted order so readers can binary-search for a page.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct IndexEntry {
+    /// Archetype index.
+    pub arch_id: u16,
+    /// Component slot, or [`ENTITY_SLOT`].
+    pub slot: u16,
+    /// Page index within the column.
+    pub page_index: u16,
+    /// Explicit padding; must be zero on write.
+    #[allow(clippy::pub_underscore_fields)]
+    pub _pad: u16,
+    /// Absolute byte offset of the [`PageHeader`] for this page.
+    pub file_offset: u64,
+}
+
+impl IndexEntry {
+    /// View this entry as a 16-byte slice for I/O.
+    pub fn as_bytes(&self) -> &[u8; 16] {
+        // SAFETY: IndexEntry is #[repr(C)] with compile-time-verified size 16.
+        unsafe { &*(self as *const Self as *const [u8; 16]) }
+    }
+
+    /// Interpret a 16-byte slice as an `IndexEntry` reference.
+    pub fn from_bytes(bytes: &[u8; 16]) -> &Self {
+        // SAFETY: IndexEntry is #[repr(C)]; any 16-byte bit pattern is valid.
+        unsafe { &*(bytes.as_ptr() as *const Self) }
+    }
+
+    /// The sort key used for binary search.
+    #[inline]
+    fn sort_key(&self) -> (u16, u16, u16) {
+        (self.arch_id, self.slot, self.page_index)
+    }
+}
+
+impl PartialEq for IndexEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.sort_key() == other.sort_key()
+    }
+}
+
+impl Eq for IndexEntry {}
+
+impl PartialOrd for IndexEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for IndexEntry {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.sort_key().cmp(&other.sort_key())
+    }
+}
+
+// ── File Footer (64 bytes) ───────────────────────────────────────────────────
+
+/// Fixed-size footer written at the end of the file, immediately before the
+/// final 8 bytes used to store the footer's own offset (not included here).
+#[repr(C)]
+pub struct Footer {
+    /// Absolute byte offset of the first [`IndexEntry`].
+    pub sparse_index_offset: u64,
+    /// Number of [`IndexEntry`] records.
+    pub sparse_index_count: u64,
+    /// Absolute byte offset of the schema section.
+    pub schema_offset: u64,
+    /// Absolute byte offset of the Bloom filter section (0 if absent).
+    pub bloom_filter_offset: u64,
+    /// CRC32 over all page data, headers, and the schema section.
+    pub total_crc32: u32,
+    /// Reserved for future use; must be zero on write.
+    pub reserved: [u8; 28],
+}
+
+impl Footer {
+    /// View this footer as a 64-byte slice for I/O.
+    pub fn as_bytes(&self) -> &[u8; 64] {
+        // SAFETY: Footer is #[repr(C)] with compile-time-verified size 64.
+        unsafe { &*(self as *const Self as *const [u8; 64]) }
+    }
+
+    /// Interpret a 64-byte slice as a `Footer` reference.
+    pub fn from_bytes(bytes: &[u8; 64]) -> &Self {
+        // SAFETY: Footer is #[repr(C)]; any 64-byte bit pattern is valid.
+        unsafe { &*(bytes.as_ptr() as *const Self) }
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn magic_bytes_are_correct() {
+        assert_eq!(&MAGIC, b"MKLSM01\0");
+    }
+
+    #[test]
+    fn struct_sizes_are_correct() {
+        assert_eq!(std::mem::size_of::<Header>(), 64);
+        assert_eq!(std::mem::size_of::<PageHeader>(), 16);
+        assert_eq!(std::mem::size_of::<IndexEntry>(), 16);
+        assert_eq!(std::mem::size_of::<Footer>(), 64);
+    }
+
+    #[test]
+    fn index_entry_ordering() {
+        let make = |arch_id, slot, page_index| IndexEntry {
+            arch_id,
+            slot,
+            page_index,
+            _pad: 0,
+            file_offset: 0,
+        };
+
+        let a = make(1, 2, 3);
+        let b = make(1, 2, 4);
+        let c = make(1, 3, 0);
+        let d = make(2, 0, 0);
+
+        assert!(a < b);
+        assert!(b < c);
+        assert!(c < d);
+        assert!(a < d);
+    }
+
+    #[test]
+    fn header_round_trip() {
+        let original = Header {
+            magic: MAGIC,
+            version: VERSION,
+            schema_count: 3,
+            page_count: 42,
+            sequence_lo: 100,
+            sequence_hi: 200,
+            header_crc32: 0xDEAD_BEEF,
+            reserved: [0u8; 20],
+        };
+
+        let bytes = original.as_bytes();
+        let recovered = Header::from_bytes(bytes);
+
+        assert_eq!(recovered.magic, MAGIC);
+        assert_eq!(recovered.version, VERSION);
+        assert_eq!(recovered.schema_count, 3);
+        assert_eq!(recovered.page_count, 42);
+        assert_eq!(recovered.sequence_lo, 100);
+        assert_eq!(recovered.sequence_hi, 200);
+        assert_eq!(recovered.header_crc32, 0xDEAD_BEEF);
+    }
+
+    #[test]
+    fn page_header_round_trip() {
+        let original = PageHeader {
+            arch_id: 7,
+            slot: ENTITY_SLOT,
+            page_index: 15,
+            row_count: 256,
+            page_crc32: 0x1234_5678,
+            _padding: 0,
+        };
+
+        let bytes = original.as_bytes();
+        let recovered = PageHeader::from_bytes(bytes);
+
+        assert_eq!(recovered.arch_id, 7);
+        assert_eq!(recovered.slot, ENTITY_SLOT);
+        assert_eq!(recovered.page_index, 15);
+        assert_eq!(recovered.row_count, 256);
+        assert_eq!(recovered.page_crc32, 0x1234_5678);
+        assert_eq!(recovered._padding, 0);
+    }
+}

--- a/crates/minkowski-lsm/src/lib.rs
+++ b/crates/minkowski-lsm/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod error;
+pub mod format;
+pub mod reader;
+pub mod schema;
+pub mod writer;

--- a/crates/minkowski-lsm/src/reader.rs
+++ b/crates/minkowski-lsm/src/reader.rs
@@ -1,1 +1,391 @@
-// Sorted run reader — placeholder
+use std::fs;
+use std::path::Path;
+
+use crate::error::LsmError;
+use crate::format::*;
+use crate::schema::SchemaSection;
+
+/// A reference to a page within a sorted run.
+pub struct PageRef<'a> {
+    /// Header describing the page metadata.
+    pub header: &'a PageHeader,
+    /// Raw page data bytes (full `PAGE_SIZE * item_size`, zero-padded).
+    pub data: &'a [u8],
+}
+
+// ── Internal mmap abstraction ───────────────────────────────────────────────
+
+enum MappedData {
+    #[cfg(not(miri))]
+    Mmap(memmap2::Mmap),
+    /// Used under Miri (which cannot mmap) and as a fallback.
+    #[expect(dead_code, reason = "constructed only under cfg(miri)")]
+    Vec(Vec<u8>),
+}
+
+impl MappedData {
+    fn as_slice(&self) -> &[u8] {
+        match self {
+            #[cfg(not(miri))]
+            Self::Mmap(m) => m.as_ref(),
+            Self::Vec(v) => v,
+        }
+    }
+}
+
+/// Reader for sorted run files. Memory-maps the file for zero-copy access.
+pub struct SortedRunReader {
+    data: MappedData,
+    schema: SchemaSection,
+    index: Vec<IndexEntry>,
+    sequence_range: (u64, u64),
+    page_count: u64,
+}
+
+/// Minimum file size: Header (64) + Footer (64).
+const MIN_FILE_SIZE: usize = 128;
+
+/// Parsed metadata extracted from a file buffer during validation.
+struct ParsedMetadata {
+    schema: SchemaSection,
+    index: Vec<IndexEntry>,
+    sequence_range: (u64, u64),
+    page_count: u64,
+}
+
+/// Validate and parse a sorted-run file buffer.
+///
+/// Separated from `SortedRunReader::open` so that the borrow on `buf` does not
+/// prevent moving `MappedData` into `Self`.
+fn validate_and_parse(buf: &[u8]) -> Result<ParsedMetadata, LsmError> {
+    // 2. Validate minimum size.
+    if buf.len() < MIN_FILE_SIZE {
+        return Err(LsmError::Format(format!(
+            "file too small: {} bytes (minimum {MIN_FILE_SIZE})",
+            buf.len(),
+        )));
+    }
+
+    // 3. Read header, validate magic and version.
+    let header = Header::from_bytes(buf[..64].try_into().expect("slice is 64 bytes"));
+
+    if header.magic != MAGIC {
+        return Err(LsmError::Format(format!(
+            "bad magic: expected {MAGIC:?}, got {:?}",
+            header.magic
+        )));
+    }
+    if header.version != VERSION {
+        return Err(LsmError::Format(format!(
+            "unsupported version: expected {VERSION}, got {}",
+            header.version
+        )));
+    }
+
+    // 4. Validate header CRC (covers first 40 bytes).
+    let computed_crc = crc32fast::hash(&buf[..40]);
+    if header.header_crc32 != computed_crc {
+        return Err(LsmError::Crc {
+            offset: 0,
+            expected: header.header_crc32,
+            actual: computed_crc,
+        });
+    }
+
+    let schema_count = header.schema_count;
+    let sequence_range = (header.sequence_lo, header.sequence_hi);
+    let page_count = header.page_count;
+
+    // 5. Read footer (last 64 bytes).
+    let footer_start = buf.len() - 64;
+    let footer = Footer::from_bytes(
+        buf[footer_start..footer_start + 64]
+            .try_into()
+            .expect("64 bytes"),
+    );
+
+    // 6. Read schema section.
+    let schema_data = &buf[footer.schema_offset as usize..];
+    let schema = SchemaSection::read_from(schema_data, schema_count)?;
+
+    // 7. Parse sparse index.
+    let idx_offset = footer.sparse_index_offset as usize;
+    let idx_count = footer.sparse_index_count as usize;
+    let idx_byte_len = idx_count * std::mem::size_of::<IndexEntry>();
+
+    if idx_offset + idx_byte_len > buf.len() {
+        return Err(LsmError::Format(
+            "sparse index extends beyond file".to_owned(),
+        ));
+    }
+
+    let mut index = Vec::with_capacity(idx_count);
+    for i in 0..idx_count {
+        let entry_start = idx_offset + i * 16;
+        let entry_bytes: &[u8; 16] = buf[entry_start..entry_start + 16]
+            .try_into()
+            .expect("16 bytes");
+        index.push(*IndexEntry::from_bytes(entry_bytes));
+    }
+
+    Ok(ParsedMetadata {
+        schema,
+        index,
+        sequence_range,
+        page_count,
+    })
+}
+
+impl SortedRunReader {
+    /// Open and validate a sorted run file.
+    pub fn open(path: &Path) -> Result<Self, LsmError> {
+        let data = Self::map_file(path)?;
+        let parsed = validate_and_parse(data.as_slice())?;
+
+        Ok(Self {
+            data,
+            schema: parsed.schema,
+            index: parsed.index,
+            sequence_range: parsed.sequence_range,
+            page_count: parsed.page_count,
+        })
+    }
+
+    /// Look up a page by `(arch_id, slot, page_index)`.
+    ///
+    /// Returns `None` if the page is not in this sorted run.
+    pub fn get_page(&self, arch_id: u16, slot: u16, page_index: u16) -> Option<PageRef<'_>> {
+        let key = (arch_id, slot, page_index);
+        let pos = self
+            .index
+            .binary_search_by_key(&key, |e| (e.arch_id, e.slot, e.page_index))
+            .ok()?;
+
+        let entry = &self.index[pos];
+        let buf = self.data.as_slice();
+        let offset = entry.file_offset as usize;
+
+        // Read PageHeader.
+        let header_bytes: &[u8; 16] = buf[offset..offset + 16].try_into().expect("16 bytes");
+        let header = PageHeader::from_bytes(header_bytes);
+
+        // Compute data length.
+        let item_size = self.item_size_for_slot(slot);
+        let data_len = PAGE_SIZE * item_size;
+
+        let data_start = offset + std::mem::size_of::<PageHeader>();
+        let data = &buf[data_start..data_start + data_len];
+
+        Some(PageRef { header, data })
+    }
+
+    /// Validate the CRC of a specific page.
+    ///
+    /// The CRC covers `row_count * item_size` bytes (the actual data, not
+    /// zero-padding).
+    pub fn validate_page_crc(&self, page: &PageRef<'_>) -> Result<(), LsmError> {
+        let item_size = self.item_size_for_slot(page.header.slot);
+        let actual_len = page.header.row_count as usize * item_size;
+        let computed = crc32fast::hash(&page.data[..actual_len]);
+
+        if computed != page.header.page_crc32 {
+            return Err(LsmError::Crc {
+                offset: 0,
+                expected: page.header.page_crc32,
+                actual: computed,
+            });
+        }
+        Ok(())
+    }
+
+    /// Get the schema section.
+    pub fn schema(&self) -> &SchemaSection {
+        &self.schema
+    }
+
+    /// WAL sequence range covered by this sorted run.
+    pub fn sequence_range(&self) -> (u64, u64) {
+        self.sequence_range
+    }
+
+    /// Total number of pages in this sorted run.
+    pub fn page_count(&self) -> u64 {
+        self.page_count
+    }
+
+    /// Number of entries in the sparse index.
+    pub fn index_len(&self) -> usize {
+        self.index.len()
+    }
+
+    // ── Private helpers ─────────────────────────────────────────────────────
+
+    /// Item size in bytes for a given slot.
+    fn item_size_for_slot(&self, slot: u16) -> usize {
+        if slot == ENTITY_SLOT {
+            std::mem::size_of::<u64>()
+        } else {
+            self.schema
+                .entry_for_slot(slot)
+                .expect("slot must exist in schema")
+                .item_size as usize
+        }
+    }
+
+    /// Memory-map the file (or read into Vec under Miri).
+    fn map_file(path: &Path) -> Result<MappedData, LsmError> {
+        #[cfg(miri)]
+        {
+            let bytes = fs::read(path)?;
+            Ok(MappedData::Vec(bytes))
+        }
+        #[cfg(not(miri))]
+        {
+            let file = fs::File::open(path)?;
+            // SAFETY: The file is opened read-only and we do not modify it.
+            // The mapping is valid for the lifetime of `SortedRunReader`.
+            let mmap = unsafe { memmap2::Mmap::map(&file)? };
+            Ok(MappedData::Mmap(mmap))
+        }
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::writer::flush;
+    use minkowski::World;
+
+    #[derive(Clone, Copy)]
+    struct Pos {
+        x: f32,
+        y: f32,
+    }
+
+    #[derive(Clone, Copy)]
+    struct Vel {
+        dx: f32,
+        dy: f32,
+    }
+
+    /// Helper: spawn entities and flush to a sorted run file.
+    fn flush_world_with_pos(n: usize) -> (tempfile::TempDir, std::path::PathBuf, World) {
+        let mut world = World::new();
+        for i in 0..n {
+            world.spawn((Pos {
+                x: i as f32,
+                y: i as f32 * 2.0,
+            },));
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let path = flush(&world, (10, 20), dir.path()).unwrap().unwrap();
+        (dir, path, world)
+    }
+
+    #[test]
+    fn open_valid_file() {
+        let (_dir, path, _world) = flush_world_with_pos(5);
+        let reader = SortedRunReader::open(&path).unwrap();
+
+        assert_eq!(reader.sequence_range(), (10, 20));
+        assert_eq!(reader.schema().len(), 1); // Pos only
+        assert!(reader.page_count() > 0);
+        assert!(reader.index_len() > 0);
+    }
+
+    #[test]
+    fn get_page_returns_data() {
+        let (_dir, path, _world) = flush_world_with_pos(3);
+        let reader = SortedRunReader::open(&path).unwrap();
+
+        // Find the first index entry to know a valid key.
+        assert!(reader.index_len() > 0);
+        let entry = &reader.index[0];
+        let page = reader
+            .get_page(entry.arch_id, entry.slot, entry.page_index)
+            .expect("page should exist");
+
+        assert!(page.header.row_count > 0);
+        assert!(!page.data.is_empty());
+    }
+
+    #[test]
+    fn get_nonexistent_page_returns_none() {
+        let (_dir, path, _world) = flush_world_with_pos(1);
+        let reader = SortedRunReader::open(&path).unwrap();
+
+        // Use an arch_id that cannot exist.
+        let result = reader.get_page(255, 255, 255);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn validate_page_crc_succeeds() {
+        let (_dir, path, _world) = flush_world_with_pos(5);
+        let reader = SortedRunReader::open(&path).unwrap();
+
+        // Validate CRC of every page in the index.
+        for entry in &reader.index {
+            let page = reader
+                .get_page(entry.arch_id, entry.slot, entry.page_index)
+                .unwrap();
+            reader.validate_page_crc(&page).unwrap();
+        }
+    }
+
+    #[test]
+    fn corrupted_magic_returns_error() {
+        let (_dir, path, _world) = flush_world_with_pos(1);
+
+        // Corrupt the first byte.
+        let mut data = std::fs::read(&path).unwrap();
+        data[0] = 0xFF;
+        std::fs::write(&path, &data).unwrap();
+
+        let result = SortedRunReader::open(&path);
+        assert!(
+            matches!(result, Err(LsmError::Format(_))),
+            "expected Format error for corrupted magic"
+        );
+    }
+
+    #[test]
+    fn multi_component_index_lookup() {
+        let mut world = World::new();
+        for i in 0..10 {
+            world.spawn((
+                Pos {
+                    x: i as f32,
+                    y: 0.0,
+                },
+                Vel {
+                    dx: 1.0,
+                    dy: i as f32,
+                },
+            ));
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = flush(&world, (0, 100), dir.path()).unwrap().unwrap();
+        let reader = SortedRunReader::open(&path).unwrap();
+
+        // Verify schema has 2 component entries.
+        assert_eq!(reader.schema().len(), 2);
+
+        // Verify every index entry is findable.
+        for entry in &reader.index {
+            let page = reader
+                .get_page(entry.arch_id, entry.slot, entry.page_index)
+                .expect("every indexed page must be findable");
+            reader
+                .validate_page_crc(&page)
+                .expect("every page CRC must be valid");
+        }
+
+        // Verify entity pages are present (slot == ENTITY_SLOT).
+        let has_entity_page = reader.index.iter().any(|e| e.slot == ENTITY_SLOT);
+        assert!(has_entity_page, "must have at least one entity page");
+    }
+}

--- a/crates/minkowski-lsm/src/reader.rs
+++ b/crates/minkowski-lsm/src/reader.rs
@@ -259,12 +259,14 @@ mod tests {
     use minkowski::World;
 
     #[derive(Clone, Copy)]
+    #[allow(dead_code)]
     struct Pos {
         x: f32,
         y: f32,
     }
 
     #[derive(Clone, Copy)]
+    #[allow(dead_code)]
     struct Vel {
         dx: f32,
         dy: f32,

--- a/crates/minkowski-lsm/src/reader.rs
+++ b/crates/minkowski-lsm/src/reader.rs
@@ -7,8 +7,8 @@ use crate::schema::SchemaSection;
 
 /// A reference to a page within a sorted run.
 pub struct PageRef<'a> {
-    /// Header describing the page metadata.
-    pub header: &'a PageHeader,
+    /// Header describing the page metadata (owned copy, read from file).
+    pub header: PageHeader,
     /// Raw page data bytes (full `PAGE_SIZE * item_size`, zero-padded).
     pub data: &'a [u8],
 }
@@ -105,7 +105,13 @@ fn validate_and_parse(buf: &[u8]) -> Result<ParsedMetadata, LsmError> {
     );
 
     // 6. Read schema section.
-    let schema_data = &buf[footer.schema_offset as usize..];
+    let schema_start = footer.schema_offset as usize;
+    if schema_start > buf.len() {
+        return Err(LsmError::Format(
+            "schema offset extends beyond file".to_owned(),
+        ));
+    }
+    let schema_data = &buf[schema_start..];
     let schema = SchemaSection::read_from(schema_data, schema_count)?;
 
     // 7. Parse sparse index.
@@ -125,7 +131,7 @@ fn validate_and_parse(buf: &[u8]) -> Result<ParsedMetadata, LsmError> {
         let entry_bytes: &[u8; 16] = buf[entry_start..entry_start + 16]
             .try_into()
             .expect("16 bytes");
-        index.push(*IndexEntry::from_bytes(entry_bytes));
+        index.push(IndexEntry::from_bytes(entry_bytes));
     }
 
     Ok(ParsedMetadata {
@@ -164,17 +170,29 @@ impl SortedRunReader {
         let entry = &self.index[pos];
         let buf = self.data.as_slice();
         let offset = entry.file_offset as usize;
+        let header_size = std::mem::size_of::<PageHeader>();
 
-        // Read PageHeader.
-        let header_bytes: &[u8; 16] = buf[offset..offset + 16].try_into().expect("16 bytes");
+        // Bounds-check header.
+        if offset
+            .checked_add(header_size)
+            .is_none_or(|end| end > buf.len())
+        {
+            return None;
+        }
+        let header_bytes: &[u8; 16] = buf[offset..offset + header_size]
+            .try_into()
+            .expect("16 bytes");
         let header = PageHeader::from_bytes(header_bytes);
 
-        // Compute data length.
+        // Compute and bounds-check data.
         let item_size = self.item_size_for_slot(slot);
-        let data_len = PAGE_SIZE * item_size;
-
-        let data_start = offset + std::mem::size_of::<PageHeader>();
-        let data = &buf[data_start..data_start + data_len];
+        let data_len = PAGE_SIZE.checked_mul(item_size)?;
+        let data_start = offset.checked_add(header_size)?;
+        let data_end = data_start.checked_add(data_len)?;
+        if data_end > buf.len() {
+            return None;
+        }
+        let data = &buf[data_start..data_end];
 
         Some(PageRef { header, data })
     }

--- a/crates/minkowski-lsm/src/reader.rs
+++ b/crates/minkowski-lsm/src/reader.rs
@@ -11,6 +11,8 @@ pub struct PageRef<'a> {
     pub header: PageHeader,
     /// Raw page data bytes (full `PAGE_SIZE * item_size`, zero-padded).
     pub data: &'a [u8],
+    /// Absolute byte offset of this page's header within the file.
+    pub file_offset: u64,
 }
 
 // ── Internal mmap abstraction ───────────────────────────────────────────────
@@ -104,6 +106,22 @@ fn validate_and_parse(buf: &[u8]) -> Result<ParsedMetadata, LsmError> {
             .expect("64 bytes"),
     );
 
+    // 5b. Validate total CRC (covers entire file with total_crc32 field zeroed).
+    // total_crc32 is at footer_start + 32 (4 * u64 = 32 bytes into footer).
+    let total_crc32_offset = footer_start + 32;
+    {
+        let mut check_buf = buf.to_vec();
+        check_buf[total_crc32_offset..total_crc32_offset + 4].copy_from_slice(&[0, 0, 0, 0]);
+        let computed_total = crc32fast::hash(&check_buf);
+        if footer.total_crc32 != computed_total {
+            return Err(LsmError::Crc {
+                offset: total_crc32_offset as u64,
+                expected: footer.total_crc32,
+                actual: computed_total,
+            });
+        }
+    }
+
     // 6. Read schema section.
     let schema_start = footer.schema_offset as usize;
     if schema_start > buf.len() {
@@ -159,13 +177,22 @@ impl SortedRunReader {
 
     /// Look up a page by `(arch_id, slot, page_index)`.
     ///
-    /// Returns `None` if the page is not in this sorted run.
-    pub fn get_page(&self, arch_id: u16, slot: u16, page_index: u16) -> Option<PageRef<'_>> {
+    /// Returns `Ok(None)` if the page is not in this sorted run's index.
+    /// Returns `Err(LsmError::Format(...))` if the page is indexed but the
+    /// file data is corrupt or out of bounds.
+    pub fn get_page(
+        &self,
+        arch_id: u16,
+        slot: u16,
+        page_index: u16,
+    ) -> Result<Option<PageRef<'_>>, LsmError> {
         let key = (arch_id, slot, page_index);
-        let pos = self
+        let Ok(pos) = self
             .index
             .binary_search_by_key(&key, |e| (e.arch_id, e.slot, e.page_index))
-            .ok()?;
+        else {
+            return Ok(None);
+        };
 
         let entry = &self.index[pos];
         let buf = self.data.as_slice();
@@ -173,28 +200,48 @@ impl SortedRunReader {
         let header_size = std::mem::size_of::<PageHeader>();
 
         // Bounds-check header.
-        if offset
-            .checked_add(header_size)
-            .is_none_or(|end| end > buf.len())
-        {
-            return None;
+        let header_end = offset.checked_add(header_size).ok_or_else(|| {
+            LsmError::Format(format!(
+                "page ({arch_id}, {slot}, {page_index}): header offset overflow"
+            ))
+        })?;
+        if header_end > buf.len() {
+            return Err(LsmError::Format(format!(
+                "page ({arch_id}, {slot}, {page_index}): header at offset {offset} extends beyond file"
+            )));
         }
-        let header_bytes: &[u8; 16] = buf[offset..offset + header_size]
-            .try_into()
-            .expect("16 bytes");
+        let header_bytes: &[u8; 16] = buf[offset..header_end].try_into().expect("16 bytes");
         let header = PageHeader::from_bytes(header_bytes);
 
         // Compute and bounds-check data.
-        let item_size = self.item_size_for_slot(slot);
-        let data_len = PAGE_SIZE.checked_mul(item_size)?;
-        let data_start = offset.checked_add(header_size)?;
-        let data_end = data_start.checked_add(data_len)?;
+        let item_size = self.item_size_for_slot(slot)?;
+        let data_len = PAGE_SIZE.checked_mul(item_size).ok_or_else(|| {
+            LsmError::Format(format!(
+                "page ({arch_id}, {slot}, {page_index}): data length overflow"
+            ))
+        })?;
+        let data_start = offset.checked_add(header_size).ok_or_else(|| {
+            LsmError::Format(format!(
+                "page ({arch_id}, {slot}, {page_index}): data start overflow"
+            ))
+        })?;
+        let data_end = data_start.checked_add(data_len).ok_or_else(|| {
+            LsmError::Format(format!(
+                "page ({arch_id}, {slot}, {page_index}): data end overflow"
+            ))
+        })?;
         if data_end > buf.len() {
-            return None;
+            return Err(LsmError::Format(format!(
+                "page ({arch_id}, {slot}, {page_index}): data region [{data_start}..{data_end}] extends beyond file"
+            )));
         }
         let data = &buf[data_start..data_end];
 
-        Some(PageRef { header, data })
+        Ok(Some(PageRef {
+            header,
+            data,
+            file_offset: entry.file_offset,
+        }))
     }
 
     /// Validate the CRC of a specific page.
@@ -202,13 +249,13 @@ impl SortedRunReader {
     /// The CRC covers `row_count * item_size` bytes (the actual data, not
     /// zero-padding).
     pub fn validate_page_crc(&self, page: &PageRef<'_>) -> Result<(), LsmError> {
-        let item_size = self.item_size_for_slot(page.header.slot);
+        let item_size = self.item_size_for_slot(page.header.slot)?;
         let actual_len = page.header.row_count as usize * item_size;
         let computed = crc32fast::hash(&page.data[..actual_len]);
 
         if computed != page.header.page_crc32 {
             return Err(LsmError::Crc {
-                offset: 0,
+                offset: page.file_offset,
                 expected: page.header.page_crc32,
                 actual: computed,
             });
@@ -239,14 +286,14 @@ impl SortedRunReader {
     // ── Private helpers ─────────────────────────────────────────────────────
 
     /// Item size in bytes for a given slot.
-    fn item_size_for_slot(&self, slot: u16) -> usize {
+    fn item_size_for_slot(&self, slot: u16) -> Result<usize, LsmError> {
         if slot == ENTITY_SLOT {
-            std::mem::size_of::<u64>()
+            Ok(std::mem::size_of::<u64>())
         } else {
             self.schema
                 .entry_for_slot(slot)
-                .expect("slot must exist in schema")
-                .item_size as usize
+                .map(|e| e.item_size as usize)
+                .ok_or_else(|| LsmError::Format(format!("unknown slot {slot} not found in schema")))
         }
     }
 
@@ -277,14 +324,14 @@ mod tests {
     use minkowski::World;
 
     #[derive(Clone, Copy)]
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     struct Pos {
         x: f32,
         y: f32,
     }
 
     #[derive(Clone, Copy)]
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     struct Vel {
         dx: f32,
         dy: f32,
@@ -325,6 +372,7 @@ mod tests {
         let entry = &reader.index[0];
         let page = reader
             .get_page(entry.arch_id, entry.slot, entry.page_index)
+            .unwrap()
             .expect("page should exist");
 
         assert!(page.header.row_count > 0);
@@ -337,7 +385,7 @@ mod tests {
         let reader = SortedRunReader::open(&path).unwrap();
 
         // Use an arch_id that cannot exist.
-        let result = reader.get_page(255, 255, 255);
+        let result = reader.get_page(255, 255, 255).unwrap();
         assert!(result.is_none());
     }
 
@@ -350,6 +398,7 @@ mod tests {
         for entry in &reader.index {
             let page = reader
                 .get_page(entry.arch_id, entry.slot, entry.page_index)
+                .unwrap()
                 .unwrap();
             reader.validate_page_crc(&page).unwrap();
         }
@@ -398,6 +447,7 @@ mod tests {
         for entry in &reader.index {
             let page = reader
                 .get_page(entry.arch_id, entry.slot, entry.page_index)
+                .expect("get_page should not error")
                 .expect("every indexed page must be findable");
             reader
                 .validate_page_crc(&page)

--- a/crates/minkowski-lsm/src/reader.rs
+++ b/crates/minkowski-lsm/src/reader.rs
@@ -1,0 +1,1 @@
+// Sorted run reader — placeholder

--- a/crates/minkowski-lsm/src/reader.rs
+++ b/crates/minkowski-lsm/src/reader.rs
@@ -8,11 +8,28 @@ use crate::schema::SchemaSection;
 /// A reference to a page within a sorted run.
 pub struct PageRef<'a> {
     /// Header describing the page metadata (owned copy, read from file).
-    pub header: PageHeader,
+    header: PageHeader,
     /// Raw page data bytes (full `PAGE_SIZE * item_size`, zero-padded).
-    pub data: &'a [u8],
+    data: &'a [u8],
     /// Absolute byte offset of this page's header within the file.
-    pub file_offset: u64,
+    file_offset: u64,
+}
+
+impl<'a> PageRef<'a> {
+    /// Header describing the page metadata.
+    pub fn header(&self) -> &PageHeader {
+        &self.header
+    }
+
+    /// Raw page data bytes (full `PAGE_SIZE * item_size`, zero-padded).
+    pub fn data(&self) -> &'a [u8] {
+        self.data
+    }
+
+    /// Absolute byte offset of this page's header within the file.
+    pub fn file_offset(&self) -> u64 {
+        self.file_offset
+    }
 }
 
 // ── Internal mmap abstraction ───────────────────────────────────────────────
@@ -249,14 +266,14 @@ impl SortedRunReader {
     /// The CRC covers `row_count * item_size` bytes (the actual data, not
     /// zero-padding).
     pub fn validate_page_crc(&self, page: &PageRef<'_>) -> Result<(), LsmError> {
-        let item_size = self.item_size_for_slot(page.header.slot)?;
-        let actual_len = page.header.row_count as usize * item_size;
-        let computed = crc32fast::hash(&page.data[..actual_len]);
+        let item_size = self.item_size_for_slot(page.header().slot)?;
+        let actual_len = page.header().row_count as usize * item_size;
+        let computed = crc32fast::hash(&page.data()[..actual_len]);
 
-        if computed != page.header.page_crc32 {
+        if computed != page.header().page_crc32 {
             return Err(LsmError::Crc {
-                offset: page.file_offset,
-                expected: page.header.page_crc32,
+                offset: page.file_offset(),
+                expected: page.header().page_crc32,
                 actual: computed,
             });
         }
@@ -375,8 +392,8 @@ mod tests {
             .unwrap()
             .expect("page should exist");
 
-        assert!(page.header.row_count > 0);
-        assert!(!page.data.is_empty());
+        assert!(page.header().row_count > 0);
+        assert!(!page.data().is_empty());
     }
 
     #[test]

--- a/crates/minkowski-lsm/src/schema.rs
+++ b/crates/minkowski-lsm/src/schema.rs
@@ -1,0 +1,1 @@
+// Schema definitions — placeholder

--- a/crates/minkowski-lsm/src/schema.rs
+++ b/crates/minkowski-lsm/src/schema.rs
@@ -28,7 +28,7 @@ impl SchemaSection {
     /// Sorts by name lexicographically and assigns sequential slot indices
     /// starting from 0.  The entity pseudo-column (`ENTITY_SLOT = 0xFFFF`) is
     /// NOT included — callers must handle it separately.
-    pub fn from_components(components: &[(String, Layout)]) -> Self {
+    pub fn from_components(components: &[(String, Layout)]) -> Result<Self, LsmError> {
         // Deduplicate by name (take the first layout seen for a given name).
         let mut seen: Vec<(String, Layout)> = Vec::with_capacity(components.len());
         for (name, layout) in components {
@@ -44,12 +44,18 @@ impl SchemaSection {
         let mut name_to_slot = HashMap::with_capacity(seen.len());
 
         for (slot_idx, (name, layout)) in seen.into_iter().enumerate() {
-            let slot = slot_idx as u16;
+            let slot = u16::try_from(slot_idx).map_err(|_| {
+                LsmError::Format(format!(
+                    "too many components: slot index {slot_idx} exceeds u16"
+                ))
+            })?;
             // Slots must not collide with the reserved entity pseudo-column.
-            assert!(
-                slot != ENTITY_SLOT,
-                "too many components: slot index overflowed into ENTITY_SLOT (0xFFFF)"
-            );
+            if slot == ENTITY_SLOT {
+                return Err(LsmError::Format(
+                    "too many components: slot index overflowed into ENTITY_SLOT (0xFFFF)"
+                        .to_owned(),
+                ));
+            }
             name_to_slot.insert(name.clone(), slot);
             entries.push(SchemaEntry {
                 slot,
@@ -59,10 +65,10 @@ impl SchemaSection {
             });
         }
 
-        Self {
+        Ok(Self {
             entries,
             name_to_slot,
-        }
+        })
     }
 
     /// Look up slot index by component name.
@@ -110,11 +116,11 @@ impl SchemaSection {
         for entry in &self.entries {
             let name_bytes = entry.name.as_bytes();
             let name_len = name_bytes.len();
-            assert!(
-                u16::try_from(name_len).is_ok(),
-                "component name too long: {} bytes",
-                name_len
-            );
+            if u16::try_from(name_len).is_err() {
+                return Err(LsmError::Format(format!(
+                    "component name too long: {name_len} bytes exceeds u16"
+                )));
+            }
 
             writer.write_all(&entry.slot.to_le_bytes())?;
             writer.write_all(&(name_len as u16).to_le_bytes())?;
@@ -218,6 +224,38 @@ impl SchemaSection {
             });
         }
 
+        // Validate invariants on parsed entries.
+        for (i, entry) in entries.iter().enumerate() {
+            // Slot values must match their index position.
+            if entry.slot != i as u16 {
+                return Err(LsmError::Format(format!(
+                    "schema entry {i}: slot {} does not match index position",
+                    entry.slot
+                )));
+            }
+            // item_align must be a power of two (or zero for ZST).
+            if entry.item_align != 0 && !entry.item_align.is_power_of_two() {
+                return Err(LsmError::Format(format!(
+                    "schema entry {i}: item_align {} is not a power of two",
+                    entry.item_align
+                )));
+            }
+        }
+
+        // Check for duplicate names.
+        {
+            let mut seen_names: std::collections::HashSet<&str> =
+                std::collections::HashSet::with_capacity(entries.len());
+            for (i, entry) in entries.iter().enumerate() {
+                if !seen_names.insert(&entry.name) {
+                    return Err(LsmError::Format(format!(
+                        "schema entry {i}: duplicate name {:?}",
+                        entry.name
+                    )));
+                }
+            }
+        }
+
         Ok(Self {
             entries,
             name_to_slot,
@@ -246,7 +284,7 @@ mod tests {
                 )
             })
             .collect();
-        SchemaSection::from_components(&components)
+        SchemaSection::from_components(&components).unwrap()
     }
 
     #[test]
@@ -297,7 +335,7 @@ mod tests {
 
     #[test]
     fn empty_schema() {
-        let schema = SchemaSection::from_components(&[]);
+        let schema = SchemaSection::from_components(&[]).unwrap();
         assert!(schema.is_empty());
         assert_eq!(schema.len(), 0);
 
@@ -325,7 +363,7 @@ mod tests {
                     (name, layout_of::<u64>())
                 })
                 .collect();
-            let schema = SchemaSection::from_components(&specs);
+            let schema = SchemaSection::from_components(&specs).unwrap();
 
             let mut buf = Vec::new();
             let written = schema.write_to(&mut buf).unwrap();

--- a/crates/minkowski-lsm/src/schema.rs
+++ b/crates/minkowski-lsm/src/schema.rs
@@ -1,1 +1,367 @@
-// Schema definitions — placeholder
+use std::alloc::Layout;
+use std::collections::HashMap;
+use std::io::Write;
+
+use crate::error::LsmError;
+use crate::format::ENTITY_SLOT;
+
+/// One entry in the schema section.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaEntry {
+    pub slot: u16,
+    pub name: String,
+    pub item_size: u32,
+    pub item_align: u32,
+}
+
+/// The complete schema section of a sorted run.
+#[derive(Debug, Clone)]
+pub struct SchemaSection {
+    entries: Vec<SchemaEntry>,
+    /// name → slot lookup for the writer
+    name_to_slot: HashMap<String, u16>,
+}
+
+impl SchemaSection {
+    /// Build a schema from a set of component `(name, layout)` pairs.
+    ///
+    /// Sorts by name lexicographically and assigns sequential slot indices
+    /// starting from 0.  The entity pseudo-column (`ENTITY_SLOT = 0xFFFF`) is
+    /// NOT included — callers must handle it separately.
+    pub fn from_components(components: &[(String, Layout)]) -> Self {
+        // Deduplicate by name (take the first layout seen for a given name).
+        let mut seen: Vec<(String, Layout)> = Vec::with_capacity(components.len());
+        for (name, layout) in components {
+            if !seen.iter().any(|(n, _)| n == name) {
+                seen.push((name.clone(), *layout));
+            }
+        }
+
+        // Sort lexicographically for deterministic slot assignment.
+        seen.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+        let mut entries = Vec::with_capacity(seen.len());
+        let mut name_to_slot = HashMap::with_capacity(seen.len());
+
+        for (slot_idx, (name, layout)) in seen.into_iter().enumerate() {
+            let slot = slot_idx as u16;
+            // Slots must not collide with the reserved entity pseudo-column.
+            assert!(
+                slot != ENTITY_SLOT,
+                "too many components: slot index overflowed into ENTITY_SLOT (0xFFFF)"
+            );
+            name_to_slot.insert(name.clone(), slot);
+            entries.push(SchemaEntry {
+                slot,
+                name,
+                item_size: layout.size() as u32,
+                item_align: layout.align() as u32,
+            });
+        }
+
+        Self {
+            entries,
+            name_to_slot,
+        }
+    }
+
+    /// Look up slot index by component name.
+    pub fn slot_for(&self, name: &str) -> Option<u16> {
+        self.name_to_slot.get(name).copied()
+    }
+
+    /// Look up entry by slot.
+    pub fn entry_for_slot(&self, slot: u16) -> Option<&SchemaEntry> {
+        // Entries are stored in slot order (sequential from 0), so slot == index.
+        self.entries.get(slot as usize)
+    }
+
+    /// Number of schema entries (not counting the entity pseudo-column).
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns `true` if there are no schema entries.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Iterate all entries in slot order.
+    pub fn entries(&self) -> &[SchemaEntry] {
+        &self.entries
+    }
+
+    /// Serialize the schema section to `writer`.
+    ///
+    /// Wire format per entry:
+    /// ```text
+    /// slot:       u16 LE
+    /// name_len:   u16 LE
+    /// name:       [u8; name_len]  (UTF-8)
+    /// item_size:  u32 LE
+    /// item_align: u32 LE
+    /// ```
+    /// The entire section is zero-padded to the next 64-byte boundary.
+    ///
+    /// Returns the total number of bytes written (including padding).
+    pub fn write_to(&self, writer: &mut impl Write) -> Result<usize, LsmError> {
+        let mut written: usize = 0;
+
+        for entry in &self.entries {
+            let name_bytes = entry.name.as_bytes();
+            let name_len = name_bytes.len();
+            assert!(
+                u16::try_from(name_len).is_ok(),
+                "component name too long: {} bytes",
+                name_len
+            );
+
+            writer.write_all(&entry.slot.to_le_bytes())?;
+            writer.write_all(&(name_len as u16).to_le_bytes())?;
+            writer.write_all(name_bytes)?;
+            writer.write_all(&entry.item_size.to_le_bytes())?;
+            writer.write_all(&entry.item_align.to_le_bytes())?;
+
+            // 2 (slot) + 2 (name_len) + name_len + 4 (item_size) + 4 (item_align)
+            written += 2 + 2 + name_len + 4 + 4;
+        }
+
+        // Pad to 64-byte boundary with zeros.
+        let remainder = written % 64;
+        if remainder != 0 {
+            let pad_len = 64 - remainder;
+            let zeros = [0u8; 64];
+            writer.write_all(&zeros[..pad_len])?;
+            written += pad_len;
+        }
+
+        debug_assert_eq!(written % 64, 0);
+        Ok(written)
+    }
+
+    /// Deserialize from a byte slice starting at the schema section.
+    ///
+    /// Reads exactly `schema_count` entries and validates UTF-8 names.
+    /// Returns `LsmError::Format` on malformed data.
+    pub fn read_from(data: &[u8], schema_count: u32) -> Result<Self, LsmError> {
+        let count = schema_count as usize;
+        let mut entries = Vec::with_capacity(count);
+        let mut name_to_slot = HashMap::with_capacity(count);
+        let mut cursor = 0usize;
+
+        for i in 0..count {
+            // slot: u16
+            if cursor + 2 > data.len() {
+                return Err(LsmError::Format(format!(
+                    "schema entry {i}: unexpected end of data reading slot"
+                )));
+            }
+            let slot = u16::from_le_bytes([data[cursor], data[cursor + 1]]);
+            cursor += 2;
+
+            // name_len: u16
+            if cursor + 2 > data.len() {
+                return Err(LsmError::Format(format!(
+                    "schema entry {i}: unexpected end of data reading name_len"
+                )));
+            }
+            let name_len = u16::from_le_bytes([data[cursor], data[cursor + 1]]) as usize;
+            cursor += 2;
+
+            // name: [u8; name_len]
+            if cursor + name_len > data.len() {
+                return Err(LsmError::Format(format!(
+                    "schema entry {i}: unexpected end of data reading name ({name_len} bytes)"
+                )));
+            }
+            let name = std::str::from_utf8(&data[cursor..cursor + name_len])
+                .map_err(|e| {
+                    LsmError::Format(format!("schema entry {i}: invalid UTF-8 in name: {e}"))
+                })?
+                .to_owned();
+            cursor += name_len;
+
+            // item_size: u32
+            if cursor + 4 > data.len() {
+                return Err(LsmError::Format(format!(
+                    "schema entry {i}: unexpected end of data reading item_size"
+                )));
+            }
+            let item_size = u32::from_le_bytes([
+                data[cursor],
+                data[cursor + 1],
+                data[cursor + 2],
+                data[cursor + 3],
+            ]);
+            cursor += 4;
+
+            // item_align: u32
+            if cursor + 4 > data.len() {
+                return Err(LsmError::Format(format!(
+                    "schema entry {i}: unexpected end of data reading item_align"
+                )));
+            }
+            let item_align = u32::from_le_bytes([
+                data[cursor],
+                data[cursor + 1],
+                data[cursor + 2],
+                data[cursor + 3],
+            ]);
+            cursor += 4;
+
+            name_to_slot.insert(name.clone(), slot);
+            entries.push(SchemaEntry {
+                slot,
+                name,
+                item_size,
+                item_align,
+            });
+        }
+
+        Ok(Self {
+            entries,
+            name_to_slot,
+        })
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn layout_of<T>() -> Layout {
+        Layout::new::<T>()
+    }
+
+    // Helper: build a SchemaSection from simple (name, size, align) triples.
+    fn make_schema(specs: &[(&str, usize, usize)]) -> SchemaSection {
+        let components: Vec<(String, Layout)> = specs
+            .iter()
+            .map(|(name, size, align)| {
+                (
+                    (*name).to_owned(),
+                    Layout::from_size_align(*size, *align).unwrap(),
+                )
+            })
+            .collect();
+        SchemaSection::from_components(&components)
+    }
+
+    #[test]
+    fn round_trip() {
+        let schema = make_schema(&[("Health", 4, 4), ("Position", 8, 4), ("Velocity", 8, 4)]);
+
+        let mut buf = Vec::new();
+        let written = schema.write_to(&mut buf).unwrap();
+        assert_eq!(written, buf.len());
+
+        let recovered = SchemaSection::read_from(&buf, schema.len() as u32).unwrap();
+        assert_eq!(recovered.entries(), schema.entries());
+    }
+
+    #[test]
+    fn slot_assignment_is_sorted() {
+        // Input in unsorted order; slots must be assigned in lexicographic order.
+        let schema = make_schema(&[("Vel", 8, 4), ("Pos", 8, 4), ("Health", 4, 4)]);
+
+        assert_eq!(schema.slot_for("Health"), Some(0));
+        assert_eq!(schema.slot_for("Pos"), Some(1));
+        assert_eq!(schema.slot_for("Vel"), Some(2));
+
+        assert_eq!(schema.entries()[0].name, "Health");
+        assert_eq!(schema.entries()[1].name, "Pos");
+        assert_eq!(schema.entries()[2].name, "Vel");
+    }
+
+    #[test]
+    fn lookup() {
+        let schema = make_schema(&[("Pos", 8, 4), ("Vel", 8, 4)]);
+
+        // "Pos" sorts before "Vel", so it gets slot 0.
+        assert_eq!(schema.slot_for("Pos"), Some(0));
+        assert_eq!(schema.slot_for("Vel"), Some(1));
+        assert_eq!(schema.slot_for("Unknown"), None);
+
+        assert_eq!(
+            schema.entry_for_slot(0).map(|e| e.name.as_str()),
+            Some("Pos")
+        );
+        assert_eq!(
+            schema.entry_for_slot(1).map(|e| e.name.as_str()),
+            Some("Vel")
+        );
+        assert!(schema.entry_for_slot(2).is_none());
+    }
+
+    #[test]
+    fn empty_schema() {
+        let schema = SchemaSection::from_components(&[]);
+        assert!(schema.is_empty());
+        assert_eq!(schema.len(), 0);
+
+        let mut buf = Vec::new();
+        let written = schema.write_to(&mut buf).unwrap();
+
+        // No entries, so no content bytes; but the section is still padded to 64.
+        assert_eq!(
+            written, 0,
+            "empty schema writes 0 bytes (no content, no padding needed)"
+        );
+        assert_eq!(buf.len(), 0);
+
+        let recovered = SchemaSection::read_from(&buf, 0).unwrap();
+        assert!(recovered.is_empty());
+    }
+
+    #[test]
+    fn padding_is_multiple_of_64() {
+        for n in 0usize..=8 {
+            // Vary name lengths to hit different raw sizes.
+            let specs: Vec<(String, Layout)> = (0..n)
+                .map(|i| {
+                    let name = format!("Comp{i:0>3}");
+                    (name, layout_of::<u64>())
+                })
+                .collect();
+            let schema = SchemaSection::from_components(&specs);
+
+            let mut buf = Vec::new();
+            let written = schema.write_to(&mut buf).unwrap();
+
+            assert_eq!(
+                written % 64,
+                0,
+                "n={n}: written={written} is not a multiple of 64"
+            );
+            assert_eq!(written, buf.len(), "n={n}: returned size matches buffer");
+        }
+    }
+
+    #[test]
+    fn read_from_rejects_truncated_data() {
+        let schema = make_schema(&[("X", 4, 4)]);
+        let mut buf = Vec::new();
+        schema.write_to(&mut buf).unwrap();
+
+        // Truncate to 3 bytes — not enough to read even the slot field fully.
+        let result = SchemaSection::read_from(&buf[..3], 1);
+        assert!(
+            matches!(result, Err(LsmError::Format(_))),
+            "expected Format error on truncated input"
+        );
+    }
+
+    #[test]
+    fn entity_slot_is_not_in_schema() {
+        // Verify ENTITY_SLOT (0xFFFF) is reserved and not assigned by from_components.
+        let schema = make_schema(&[("A", 4, 4), ("B", 4, 4)]);
+        for entry in schema.entries() {
+            assert_ne!(
+                entry.slot, ENTITY_SLOT,
+                "component slot must not equal ENTITY_SLOT"
+            );
+        }
+    }
+}

--- a/crates/minkowski-lsm/src/schema.rs
+++ b/crates/minkowski-lsm/src/schema.rs
@@ -8,10 +8,32 @@ use crate::format::ENTITY_SLOT;
 /// One entry in the schema section.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SchemaEntry {
-    pub slot: u16,
-    pub name: String,
-    pub item_size: u32,
-    pub item_align: u32,
+    pub(crate) slot: u16,
+    pub(crate) name: String,
+    pub(crate) item_size: u32,
+    pub(crate) item_align: u32,
+}
+
+impl SchemaEntry {
+    /// Component slot index within this sorted run.
+    pub fn slot(&self) -> u16 {
+        self.slot
+    }
+
+    /// Component type name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Size in bytes of each item.
+    pub fn item_size(&self) -> u32 {
+        self.item_size
+    }
+
+    /// Alignment in bytes of each item.
+    pub fn item_align(&self) -> u32 {
+        self.item_align
+    }
 }
 
 /// The complete schema section of a sorted run.

--- a/crates/minkowski-lsm/src/writer.rs
+++ b/crates/minkowski-lsm/src/writer.rs
@@ -1,0 +1,1 @@
+// Flush writer — placeholder

--- a/crates/minkowski-lsm/src/writer.rs
+++ b/crates/minkowski-lsm/src/writer.rs
@@ -1,1 +1,412 @@
-// Flush writer — placeholder
+use std::collections::{BTreeSet, HashMap};
+use std::fs;
+use std::io::{BufWriter, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use minkowski::World;
+
+use crate::error::LsmError;
+use crate::format::*;
+use crate::schema::SchemaSection;
+
+/// Flush dirty pages from the World to a new sorted run file.
+///
+/// Returns `Ok(Some(path))` if dirty pages were written, `Ok(None)` if there
+/// were no dirty pages to flush. The file is written atomically (temp + rename).
+///
+/// `sequence_range` is the WAL sequence range covered by this flush — stored in
+/// the header for recovery to know where to start WAL replay.
+pub fn flush(
+    world: &World,
+    sequence_range: (u64, u64),
+    output_dir: &Path,
+) -> Result<Option<PathBuf>, LsmError> {
+    // ── 1. Collect dirty page set ───────────────────────────────────────────
+    // Key: (arch_idx, comp_id, page_index)
+    let mut dirty: BTreeSet<(usize, usize, usize)> = BTreeSet::new();
+    // Per-archetype union of dirty page indices (for entity pages).
+    let mut entity_dirty: HashMap<usize, BTreeSet<usize>> = HashMap::new();
+
+    for arch_idx in 0..world.archetype_count() {
+        for &comp_id in world.archetype_component_ids(arch_idx) {
+            if let Some(pages) = world.column_dirty_pages(arch_idx, comp_id) {
+                for page in pages {
+                    dirty.insert((arch_idx, comp_id, page));
+                    entity_dirty.entry(arch_idx).or_default().insert(page);
+                }
+            }
+        }
+    }
+
+    // ── 2. Early return if nothing dirty ────────────────────────────────────
+    if dirty.is_empty() {
+        return Ok(None);
+    }
+
+    // ── 3. Build schema section ─────────────────────────────────────────────
+    let mut seen_comp_ids: BTreeSet<usize> = BTreeSet::new();
+    for &(_, comp_id, _) in &dirty {
+        seen_comp_ids.insert(comp_id);
+    }
+
+    let components: Vec<(String, std::alloc::Layout)> = seen_comp_ids
+        .iter()
+        .map(|&comp_id| {
+            let name = world
+                .component_name(comp_id)
+                .expect("dirty component must be registered");
+            let layout = world
+                .component_layout(comp_id)
+                .expect("dirty component must have a layout");
+            (name.to_owned(), layout)
+        })
+        .collect();
+
+    let schema = SchemaSection::from_components(&components);
+
+    // Build comp_id → component name lookup for slot resolution.
+    let comp_id_to_name: HashMap<usize, &str> = seen_comp_ids
+        .iter()
+        .map(|&comp_id| {
+            (
+                comp_id,
+                world
+                    .component_name(comp_id)
+                    .expect("dirty component must be registered"),
+            )
+        })
+        .collect();
+
+    // ── 4. Write to temp file ───────────────────────────────────────────────
+    let (seq_lo, seq_hi) = sequence_range;
+    let tmp_name = format!("{seq_lo}-{seq_hi}.run.tmp");
+    let final_name = format!("{seq_lo}-{seq_hi}.run");
+    let tmp_path = output_dir.join(&tmp_name);
+    let final_path = output_dir.join(&final_name);
+
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&tmp_path)?;
+    let mut w = BufWriter::new(file);
+
+    // (a) Header — write with crc32 = 0, patch later.
+    let page_count = dirty.len() + entity_dirty.values().map(BTreeSet::len).sum::<usize>();
+    let header = Header {
+        magic: MAGIC,
+        version: VERSION,
+        schema_count: schema.len() as u32,
+        page_count: page_count as u64,
+        sequence_lo: seq_lo,
+        sequence_hi: seq_hi,
+        header_crc32: 0,
+        reserved: [0u8; 20],
+    };
+    w.write_all(header.as_bytes())?;
+
+    // (b) Schema section
+    let schema_offset = std::mem::size_of::<Header>() as u64;
+    schema.write_to(&mut w)?;
+
+    // (c) Component page images — sorted by (arch_id, slot, page_index)
+    let mut index_entries: Vec<IndexEntry> = Vec::with_capacity(page_count);
+
+    // Pre-sort dirty pages by (arch_idx as u16, slot, page_index as u16) for
+    // deterministic file order matching the index sort key.
+    struct PageJob {
+        arch_idx: usize,
+        comp_id: usize,
+        page_index: usize,
+        slot: u16,
+    }
+
+    let mut component_jobs: Vec<PageJob> = Vec::with_capacity(dirty.len());
+    for &(arch_idx, comp_id, page_index) in &dirty {
+        let comp_name = comp_id_to_name[&comp_id];
+        let slot = schema
+            .slot_for(comp_name)
+            .expect("component must be in schema");
+        component_jobs.push(PageJob {
+            arch_idx,
+            comp_id,
+            page_index,
+            slot,
+        });
+    }
+    component_jobs.sort_by_key(|j| (j.arch_idx as u16, j.slot, j.page_index as u16));
+
+    for job in &component_jobs {
+        let arch_len = world.archetype_len(job.arch_idx);
+        let start_row = job.page_index * PAGE_SIZE;
+        let row_count = PAGE_SIZE.min(arch_len.saturating_sub(start_row));
+        if row_count == 0 {
+            continue;
+        }
+
+        let item_size = schema
+            .entry_for_slot(job.slot)
+            .expect("slot must exist")
+            .item_size as usize;
+
+        let bytes = world
+            .column_page_bytes(job.arch_idx, job.comp_id, start_row, row_count)
+            .expect("dirty page must be readable");
+
+        let page_crc = crc32fast::hash(bytes);
+
+        let file_offset = w.stream_position()?;
+
+        let ph = PageHeader {
+            arch_id: job.arch_idx as u16,
+            slot: job.slot,
+            page_index: job.page_index as u16,
+            row_count: row_count as u16,
+            page_crc32: page_crc,
+            _padding: 0,
+        };
+        w.write_all(ph.as_bytes())?;
+        w.write_all(bytes)?;
+
+        // Zero-pad partial pages.
+        let full_page_bytes = PAGE_SIZE * item_size;
+        if bytes.len() < full_page_bytes {
+            let pad = full_page_bytes - bytes.len();
+            write_zeros(&mut w, pad)?;
+        }
+
+        index_entries.push(IndexEntry {
+            arch_id: job.arch_idx as u16,
+            slot: job.slot,
+            page_index: job.page_index as u16,
+            _pad: 0,
+            file_offset,
+        });
+    }
+
+    // (d) Entity pages
+    let entity_item_size = std::mem::size_of::<u64>();
+    let mut entity_jobs: Vec<(usize, usize)> = Vec::new(); // (arch_idx, page_index)
+    for (&arch_idx, pages) in &entity_dirty {
+        for &page_index in pages {
+            entity_jobs.push((arch_idx, page_index));
+        }
+    }
+    entity_jobs.sort_by_key(|&(arch_idx, page_index)| (arch_idx as u16, page_index as u16));
+
+    for &(arch_idx, page_index) in &entity_jobs {
+        let entities = world.archetype_entities(arch_idx);
+        let start_row = page_index * PAGE_SIZE;
+        let row_count = PAGE_SIZE.min(entities.len().saturating_sub(start_row));
+        if row_count == 0 {
+            continue;
+        }
+
+        let page_entities = &entities[start_row..start_row + row_count];
+
+        // Convert entities to LE bytes.
+        let mut entity_bytes = Vec::with_capacity(row_count * entity_item_size);
+        for &e in page_entities {
+            entity_bytes.extend_from_slice(&e.to_bits().to_le_bytes());
+        }
+
+        let page_crc = crc32fast::hash(&entity_bytes);
+        let file_offset = w.stream_position()?;
+
+        let ph = PageHeader {
+            arch_id: arch_idx as u16,
+            slot: ENTITY_SLOT,
+            page_index: page_index as u16,
+            row_count: row_count as u16,
+            page_crc32: page_crc,
+            _padding: 0,
+        };
+        w.write_all(ph.as_bytes())?;
+        w.write_all(&entity_bytes)?;
+
+        // Zero-pad partial pages.
+        let full_page_bytes = PAGE_SIZE * entity_item_size;
+        if entity_bytes.len() < full_page_bytes {
+            let pad = full_page_bytes - entity_bytes.len();
+            write_zeros(&mut w, pad)?;
+        }
+
+        index_entries.push(IndexEntry {
+            arch_id: arch_idx as u16,
+            slot: ENTITY_SLOT,
+            page_index: page_index as u16,
+            _pad: 0,
+            file_offset,
+        });
+    }
+
+    // (e) Sparse index — entries are already sorted by construction.
+    let sparse_index_offset = w.stream_position()?;
+    for entry in &index_entries {
+        w.write_all(entry.as_bytes())?;
+    }
+
+    // (f) Footer
+    let footer = Footer {
+        sparse_index_offset,
+        sparse_index_count: index_entries.len() as u64,
+        schema_offset,
+        bloom_filter_offset: 0,
+        total_crc32: 0,
+        reserved: [0u8; 28],
+    };
+    w.write_all(footer.as_bytes())?;
+
+    // Flush the BufWriter so all bytes reach disk before CRC patching.
+    w.flush()?;
+
+    // ── 5. Patch CRCs ──────────────────────────────────────────────────────
+
+    // Get the inner File for seeking.
+    let mut file = w
+        .into_inner()
+        .map_err(std::io::IntoInnerError::into_error)?;
+
+    // Patch header CRC: compute over the first 40 bytes (everything before
+    // header_crc32 field at offset 40).
+    file.seek(SeekFrom::Start(0))?;
+    let mut header_bytes = [0u8; 64];
+    {
+        use std::io::Read;
+        file.read_exact(&mut header_bytes)?;
+    }
+    // header_crc32 is at offset 40 (8 + 4 + 4 + 8 + 8 + 8 = 40).
+    let header_crc = crc32fast::hash(&header_bytes[..40]);
+    file.seek(SeekFrom::Start(40))?;
+    file.write_all(&header_crc.to_le_bytes())?;
+
+    // Patch total CRC: compute over entire file with total_crc32 field zeroed.
+    // total_crc32 is at footer offset + 32 (4 * u64 = 32 bytes into footer).
+    let file_len = file.seek(SeekFrom::End(0))?;
+    let footer_offset = file_len - 64;
+    let total_crc32_file_offset = footer_offset + 32;
+
+    // Read entire file, zero out total_crc32 field, compute CRC.
+    file.seek(SeekFrom::Start(0))?;
+    let mut all_bytes = vec![0u8; file_len as usize];
+    {
+        use std::io::Read;
+        file.read_exact(&mut all_bytes)?;
+    }
+    // Zero out the total_crc32 field for CRC computation.
+    let tco = total_crc32_file_offset as usize;
+    all_bytes[tco..tco + 4].copy_from_slice(&[0, 0, 0, 0]);
+    // Also zero out the header_crc32 was already patched, which is fine — we
+    // want total CRC to cover the patched header.
+    let total_crc = crc32fast::hash(&all_bytes);
+
+    // Write total_crc32 into footer.
+    file.seek(SeekFrom::Start(total_crc32_file_offset))?;
+    file.write_all(&total_crc.to_le_bytes())?;
+    file.sync_all()?;
+    drop(file);
+
+    // ── 6. Atomic rename ────────────────────────────────────────────────────
+    fs::rename(&tmp_path, &final_path)?;
+
+    Ok(Some(final_path))
+}
+
+/// Write `n` zero bytes to `w`.
+fn write_zeros(w: &mut impl Write, n: usize) -> Result<(), LsmError> {
+    const BLOCK: [u8; 4096] = [0u8; 4096];
+    let mut remaining = n;
+    while remaining > 0 {
+        let chunk = remaining.min(BLOCK.len());
+        w.write_all(&BLOCK[..chunk])?;
+        remaining -= chunk;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use minkowski::World;
+
+    #[derive(Clone, Copy)]
+    struct Pos {
+        x: f32,
+        y: f32,
+    }
+
+    #[derive(Clone, Copy)]
+    struct Vel {
+        dx: f32,
+        dy: f32,
+    }
+
+    #[test]
+    fn flush_no_dirty_pages_returns_none() {
+        let mut world = World::new();
+        world.spawn((Pos { x: 1.0, y: 2.0 },));
+        world.clear_all_dirty_pages();
+        let dir = tempfile::tempdir().unwrap();
+        let result = flush(&world, (0, 0), dir.path()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn flush_dirty_pages_creates_file() {
+        let mut world = World::new();
+        world.spawn((Pos { x: 1.0, y: 2.0 },));
+        // Pages are dirty from spawn.
+        let dir = tempfile::tempdir().unwrap();
+        let result = flush(&world, (1, 5), dir.path()).unwrap();
+        assert!(result.is_some());
+        let path = result.unwrap();
+        assert!(path.exists());
+        assert!(path.file_name().unwrap().to_str().unwrap().contains("1-5"));
+    }
+
+    #[test]
+    fn file_has_correct_header_magic() {
+        let mut world = World::new();
+        world.spawn((Pos { x: 1.0, y: 2.0 },));
+        let dir = tempfile::tempdir().unwrap();
+        let result = flush(&world, (10, 20), dir.path()).unwrap();
+        let path = result.unwrap();
+        let data = std::fs::read(&path).unwrap();
+        assert_eq!(&data[..8], &MAGIC);
+    }
+
+    #[test]
+    fn flush_multi_component() {
+        let mut world = World::new();
+        world.spawn((Pos { x: 1.0, y: 2.0 }, Vel { dx: 0.5, dy: -0.5 }));
+        world.spawn((Pos { x: 3.0, y: 4.0 }, Vel { dx: 1.0, dy: 1.0 }));
+        let dir = tempfile::tempdir().unwrap();
+        let result = flush(&world, (0, 10), dir.path()).unwrap();
+        assert!(result.is_some());
+        let path = result.unwrap();
+        let data = std::fs::read(&path).unwrap();
+
+        // Verify header fields.
+        let header = Header::from_bytes(data[..64].try_into().unwrap());
+        assert_eq!(header.magic, MAGIC);
+        assert_eq!(header.version, VERSION);
+        assert_eq!(header.sequence_lo, 0);
+        assert_eq!(header.sequence_hi, 10);
+        // 2 components + 1 entity page = 3 page count at minimum.
+        assert!(header.page_count >= 3);
+    }
+
+    #[test]
+    fn header_crc_is_valid() {
+        let mut world = World::new();
+        world.spawn((Pos { x: 1.0, y: 2.0 },));
+        let dir = tempfile::tempdir().unwrap();
+        let path = flush(&world, (0, 1), dir.path()).unwrap().unwrap();
+        let data = std::fs::read(&path).unwrap();
+
+        let stored_crc = u32::from_le_bytes(data[40..44].try_into().unwrap());
+        let computed_crc = crc32fast::hash(&data[..40]);
+        assert_eq!(stored_crc, computed_crc);
+    }
+}

--- a/crates/minkowski-lsm/src/writer.rs
+++ b/crates/minkowski-lsm/src/writer.rs
@@ -336,12 +336,14 @@ mod tests {
     use minkowski::World;
 
     #[derive(Clone, Copy)]
+    #[allow(dead_code)]
     struct Pos {
         x: f32,
         y: f32,
     }
 
     #[derive(Clone, Copy)]
+    #[allow(dead_code)]
     struct Vel {
         dx: f32,
         dy: f32,

--- a/crates/minkowski-lsm/src/writer.rs
+++ b/crates/minkowski-lsm/src/writer.rs
@@ -9,6 +9,11 @@ use crate::error::LsmError;
 use crate::format::*;
 use crate::schema::SchemaSection;
 
+/// Convert a `usize` to `u16`, returning `LsmError::Format` on overflow.
+fn to_u16(value: usize, label: &str) -> Result<u16, LsmError> {
+    u16::try_from(value).map_err(|_| LsmError::Format(format!("{label} {value} exceeds u16")))
+}
+
 /// Flush dirty pages from the World to a new sorted run file.
 ///
 /// Returns `Ok(Some(path))` if dirty pages were written, `Ok(None)` if there
@@ -62,7 +67,7 @@ pub fn flush(
         })
         .collect();
 
-    let schema = SchemaSection::from_components(&components);
+    let schema = SchemaSection::from_components(&components)?;
 
     // Build comp_id → component name lookup for slot resolution.
     let comp_id_to_name: HashMap<usize, &str> = seen_comp_ids
@@ -90,6 +95,24 @@ pub fn flush(
         .create(true)
         .truncate(true)
         .open(&tmp_path)?;
+
+    // Drop guard to clean up the temp file on error.
+    struct TmpGuard<'a> {
+        path: &'a Path,
+        disarmed: bool,
+    }
+    impl Drop for TmpGuard<'_> {
+        fn drop(&mut self) {
+            if !self.disarmed {
+                let _ = fs::remove_file(self.path);
+            }
+        }
+    }
+    let mut guard = TmpGuard {
+        path: &tmp_path,
+        disarmed: false,
+    };
+
     let mut w = BufWriter::new(file);
 
     // (a) Header — write with crc32 = 0, patch later.
@@ -135,15 +158,24 @@ pub fn flush(
             slot,
         });
     }
+    // Validate all indices fit in u16 before sorting.
+    for job in &component_jobs {
+        to_u16(job.arch_idx, "arch_idx")?;
+        to_u16(job.page_index, "page_index")?;
+    }
     component_jobs.sort_by_key(|j| (j.arch_idx as u16, j.slot, j.page_index as u16));
 
     for job in &component_jobs {
+        let arch_id = to_u16(job.arch_idx, "arch_idx")?;
+        let page_idx = to_u16(job.page_index, "page_index")?;
+
         let arch_len = world.archetype_len(job.arch_idx);
         let start_row = job.page_index * PAGE_SIZE;
         let row_count = PAGE_SIZE.min(arch_len.saturating_sub(start_row));
         if row_count == 0 {
             continue;
         }
+        let row_count_u16 = to_u16(row_count, "row_count")?;
 
         let item_size = schema
             .entry_for_slot(job.slot)
@@ -159,10 +191,10 @@ pub fn flush(
         let file_offset = w.stream_position()?;
 
         let ph = PageHeader {
-            arch_id: job.arch_idx as u16,
+            arch_id,
             slot: job.slot,
-            page_index: job.page_index as u16,
-            row_count: row_count as u16,
+            page_index: page_idx,
+            row_count: row_count_u16,
             page_crc32: page_crc,
             _padding: 0,
         };
@@ -177,9 +209,9 @@ pub fn flush(
         }
 
         index_entries.push(IndexEntry {
-            arch_id: job.arch_idx as u16,
+            arch_id,
             slot: job.slot,
-            page_index: job.page_index as u16,
+            page_index: page_idx,
             _pad: 0,
             file_offset,
         });
@@ -193,15 +225,24 @@ pub fn flush(
             entity_jobs.push((arch_idx, page_index));
         }
     }
+    // Validate all entity job indices fit in u16 before sorting.
+    for &(arch_idx, page_index) in &entity_jobs {
+        to_u16(arch_idx, "arch_idx")?;
+        to_u16(page_index, "page_index")?;
+    }
     entity_jobs.sort_by_key(|&(arch_idx, page_index)| (arch_idx as u16, page_index as u16));
 
     for &(arch_idx, page_index) in &entity_jobs {
+        let arch_id = to_u16(arch_idx, "arch_idx")?;
+        let page_idx = to_u16(page_index, "page_index")?;
+
         let entities = world.archetype_entities(arch_idx);
         let start_row = page_index * PAGE_SIZE;
         let row_count = PAGE_SIZE.min(entities.len().saturating_sub(start_row));
         if row_count == 0 {
             continue;
         }
+        let row_count_u16 = to_u16(row_count, "row_count")?;
 
         let page_entities = &entities[start_row..start_row + row_count];
 
@@ -215,10 +256,10 @@ pub fn flush(
         let file_offset = w.stream_position()?;
 
         let ph = PageHeader {
-            arch_id: arch_idx as u16,
+            arch_id,
             slot: ENTITY_SLOT,
-            page_index: page_index as u16,
-            row_count: row_count as u16,
+            page_index: page_idx,
+            row_count: row_count_u16,
             page_crc32: page_crc,
             _padding: 0,
         };
@@ -233,9 +274,9 @@ pub fn flush(
         }
 
         index_entries.push(IndexEntry {
-            arch_id: arch_idx as u16,
+            arch_id,
             slot: ENTITY_SLOT,
-            page_index: page_index as u16,
+            page_index: page_idx,
             _pad: 0,
             file_offset,
         });
@@ -315,6 +356,12 @@ pub fn flush(
     // ── 6. Atomic rename ────────────────────────────────────────────────────
     fs::rename(&tmp_path, &final_path)?;
 
+    // Sync the directory to ensure the rename is durable.
+    let dir = fs::File::open(output_dir)?;
+    dir.sync_all()?;
+
+    guard.disarmed = true;
+
     Ok(Some(final_path))
 }
 
@@ -336,14 +383,14 @@ mod tests {
     use minkowski::World;
 
     #[derive(Clone, Copy)]
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     struct Pos {
         x: f32,
         y: f32,
     }
 
     #[derive(Clone, Copy)]
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     struct Vel {
         dx: f32,
         dy: f32,

--- a/crates/minkowski-lsm/src/writer.rs
+++ b/crates/minkowski-lsm/src/writer.rs
@@ -241,7 +241,12 @@ pub fn flush(
         });
     }
 
-    // (e) Sparse index — entries are already sorted by construction.
+    // (e) Sparse index — sort by (arch_id, slot, page_index) so the reader
+    //     can binary-search.  Component pages are already sorted by their
+    //     write order, but entity pages (slot = ENTITY_SLOT) are appended
+    //     after all component pages, which breaks global sort order when
+    //     multiple archetypes are present.
+    index_entries.sort();
     let sparse_index_offset = w.stream_position()?;
     for entry in &index_entries {
         w.write_all(entry.as_bytes())?;

--- a/crates/minkowski-lsm/tests/integration.rs
+++ b/crates/minkowski-lsm/tests/integration.rs
@@ -62,6 +62,7 @@ fn round_trip_single_archetype() {
     for entry in schema.entries() {
         let page = reader
             .get_page(0, entry.slot, 0)
+            .expect("get_page should not error")
             .expect("page must exist for slot");
         assert_eq!(page.header.row_count, 5);
 
@@ -87,6 +88,7 @@ fn round_trip_single_archetype() {
     // Check entity page.
     let entity_page = reader
         .get_page(0, ENTITY_SLOT, 0)
+        .expect("get_page should not error")
         .expect("entity page must exist");
     assert_eq!(entity_page.header.row_count, 5);
 
@@ -113,7 +115,10 @@ fn round_trip_partial_page() {
     assert_eq!(schema.len(), 1);
 
     let slot = schema.slot_for(std::any::type_name::<Pos>()).unwrap();
-    let page = reader.get_page(0, slot, 0).expect("page must exist");
+    let page = reader
+        .get_page(0, slot, 0)
+        .expect("get_page should not error")
+        .expect("page must exist");
 
     // Verify row count.
     assert_eq!(page.header.row_count, 100);
@@ -194,7 +199,7 @@ fn multi_archetype_flush() {
     // Scan all possible arch_ids for entity pages.
     let mut found_arch_ids: Vec<u16> = Vec::new();
     for arch_id in 0..world.archetype_count() as u16 {
-        if reader.get_page(arch_id, ENTITY_SLOT, 0).is_some() {
+        if reader.get_page(arch_id, ENTITY_SLOT, 0).unwrap().is_some() {
             found_arch_ids.push(arch_id);
         }
     }
@@ -271,16 +276,24 @@ fn crc_corruption_detected() {
             // File opened — validate all page CRCs; at least one must fail.
             let mut found_corruption = false;
             for entry in reader.schema().entries() {
-                if let Some(page) = reader.get_page(0, entry.slot, 0)
-                    && reader.validate_page_crc(&page).is_err()
-                {
-                    found_corruption = true;
+                match reader.get_page(0, entry.slot, 0) {
+                    Ok(Some(page)) if reader.validate_page_crc(&page).is_err() => {
+                        found_corruption = true;
+                    }
+                    Err(_) => {
+                        found_corruption = true;
+                    }
+                    _ => {}
                 }
             }
-            if let Some(entity_page) = reader.get_page(0, ENTITY_SLOT, 0)
-                && reader.validate_page_crc(&entity_page).is_err()
-            {
-                found_corruption = true;
+            match reader.get_page(0, ENTITY_SLOT, 0) {
+                Ok(Some(entity_page)) if reader.validate_page_crc(&entity_page).is_err() => {
+                    found_corruption = true;
+                }
+                Err(_) => {
+                    found_corruption = true;
+                }
+                _ => {}
             }
             assert!(
                 found_corruption,
@@ -354,6 +367,7 @@ fn sparse_index_finds_all_pages() {
     for page_index in 0..expected_pages {
         let page = reader
             .get_page(0, pos_slot, page_index as u16)
+            .unwrap_or_else(|e| panic!("get_page error: {e}"))
             .unwrap_or_else(|| panic!("component page {page_index} must exist"));
 
         let expected_rows = if page_index < expected_pages - 1 {
@@ -373,6 +387,7 @@ fn sparse_index_finds_all_pages() {
     for page_index in 0..expected_pages {
         let page = reader
             .get_page(0, ENTITY_SLOT, page_index as u16)
+            .unwrap_or_else(|e| panic!("get_page error: {e}"))
             .unwrap_or_else(|| panic!("entity page {page_index} must exist"));
         reader.validate_page_crc(&page).unwrap();
     }
@@ -381,6 +396,7 @@ fn sparse_index_finds_all_pages() {
     assert!(
         reader
             .get_page(0, pos_slot, expected_pages as u16)
+            .unwrap()
             .is_none(),
         "no page beyond the expected count"
     );
@@ -400,6 +416,7 @@ fn entity_pages_match_world() {
 
     let entity_page = reader
         .get_page(0, ENTITY_SLOT, 0)
+        .expect("get_page should not error")
         .expect("entity page must exist");
     assert_eq!(entity_page.header.row_count, 20);
 
@@ -416,4 +433,44 @@ fn entity_pages_match_world() {
             "entity bits mismatch at index {i}"
         );
     }
+}
+
+#[test]
+fn zst_component_round_trip() {
+    #[derive(Clone, Copy)]
+    struct Marker;
+
+    let mut world = World::new();
+    for _ in 0..5 {
+        world.spawn((Marker,));
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let path = flush(&world, (0, 0), dir.path()).unwrap().unwrap();
+    let reader = SortedRunReader::open(&path).unwrap();
+
+    // Schema should have one entry for the ZST component.
+    assert_eq!(reader.schema().len(), 1);
+    let entry = &reader.schema().entries()[0];
+    assert_eq!(entry.item_size, 0, "ZST component should have item_size 0");
+
+    // ZST page should exist with row_count=5 but empty data region.
+    let page = reader
+        .get_page(0, entry.slot, 0)
+        .expect("get_page should not error")
+        .expect("ZST page must exist");
+    assert_eq!(page.header.row_count, 5);
+    assert!(
+        page.data.is_empty(),
+        "ZST page data should be empty (0 * PAGE_SIZE = 0 bytes)"
+    );
+
+    // Entity page should also exist.
+    let entity_page = reader
+        .get_page(0, ENTITY_SLOT, 0)
+        .expect("get_page should not error")
+        .expect("entity page must exist");
+    assert_eq!(entity_page.header.row_count, 5);
+
+    reader.validate_page_crc(&page).unwrap();
+    reader.validate_page_crc(&entity_page).unwrap();
 }

--- a/crates/minkowski-lsm/tests/integration.rs
+++ b/crates/minkowski-lsm/tests/integration.rs
@@ -1,0 +1,419 @@
+use std::alloc::Layout;
+
+use minkowski::World;
+use minkowski_lsm::error::LsmError;
+use minkowski_lsm::format::{ENTITY_SLOT, PAGE_SIZE};
+use minkowski_lsm::reader::SortedRunReader;
+use minkowski_lsm::writer::flush;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct Pos {
+    x: f32,
+    y: f32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct Vel {
+    dx: f32,
+    dy: f32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct Health(u32);
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Flush the world and return (tempdir, path, reader).
+/// The tempdir must be kept alive for the duration of the test.
+fn flush_and_open(world: &World) -> (tempfile::TempDir, SortedRunReader) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = flush(world, (0, 100), dir.path())
+        .unwrap()
+        .expect("flush should produce a file");
+    let reader = SortedRunReader::open(&path).unwrap();
+    (dir, reader)
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn round_trip_single_archetype() {
+    let mut world = World::new();
+    for i in 0..5 {
+        world.spawn((
+            Pos {
+                x: i as f32,
+                y: i as f32 * 2.0,
+            },
+            Vel {
+                dx: i as f32 * 0.1,
+                dy: -(i as f32),
+            },
+        ));
+    }
+
+    let (_dir, reader) = flush_and_open(&world);
+
+    // There is one archetype (arch_id = 0).
+    let schema = reader.schema();
+    assert_eq!(schema.len(), 2);
+
+    // Check each component page.
+    for entry in schema.entries() {
+        let page = reader
+            .get_page(0, entry.slot, 0)
+            .expect("page must exist for slot");
+        assert_eq!(page.header.row_count, 5);
+
+        // Reconstruct expected bytes from world.
+        let comp_id = world
+            .archetype_component_ids(0)
+            .iter()
+            .find(|&&cid| world.component_name(cid).unwrap() == entry.name)
+            .copied()
+            .expect("component must exist in archetype");
+
+        let expected = world.column_page_bytes(0, comp_id, 0, 5).unwrap();
+        assert_eq!(
+            &page.data[..expected.len()],
+            expected,
+            "data mismatch for component {}",
+            entry.name
+        );
+
+        reader.validate_page_crc(&page).unwrap();
+    }
+
+    // Check entity page.
+    let entity_page = reader
+        .get_page(0, ENTITY_SLOT, 0)
+        .expect("entity page must exist");
+    assert_eq!(entity_page.header.row_count, 5);
+
+    let entities = world.archetype_entities(0);
+    for (i, &e) in entities.iter().enumerate() {
+        let offset = i * 8;
+        let stored = u64::from_le_bytes(entity_page.data[offset..offset + 8].try_into().unwrap());
+        assert_eq!(stored, e.to_bits(), "entity mismatch at index {i}");
+    }
+}
+
+#[test]
+fn round_trip_partial_page() {
+    let mut world = World::new();
+    for i in 0..100 {
+        world.spawn((Pos {
+            x: i as f32,
+            y: 0.0,
+        },));
+    }
+
+    let (_dir, reader) = flush_and_open(&world);
+    let schema = reader.schema();
+    assert_eq!(schema.len(), 1);
+
+    let slot = schema.slot_for(std::any::type_name::<Pos>()).unwrap();
+    let page = reader.get_page(0, slot, 0).expect("page must exist");
+
+    // Verify row count.
+    assert_eq!(page.header.row_count, 100);
+
+    // Verify data bytes for valid rows match.
+    let item_size = Layout::new::<Pos>().size();
+    let valid_len = 100 * item_size;
+    let expected = world
+        .column_page_bytes(0, world.archetype_component_ids(0)[0], 0, 100)
+        .unwrap();
+    assert_eq!(&page.data[..valid_len], expected);
+
+    // Verify padding beyond valid rows is zero.
+    let full_len = PAGE_SIZE * item_size;
+    assert!(
+        page.data[valid_len..full_len].iter().all(|&b| b == 0),
+        "padding bytes beyond row_count must be zero"
+    );
+
+    reader.validate_page_crc(&page).unwrap();
+}
+
+#[test]
+fn multi_archetype_flush() {
+    let mut world = World::new();
+
+    // Archetype A: (Pos, Vel)
+    for i in 0..3 {
+        world.spawn((
+            Pos {
+                x: i as f32,
+                y: 0.0,
+            },
+            Vel {
+                dx: 1.0,
+                dy: i as f32,
+            },
+        ));
+    }
+    // Archetype B: (Pos, Health)
+    for i in 0..4 {
+        world.spawn((
+            Pos {
+                x: 10.0 + i as f32,
+                y: 0.0,
+            },
+            Health(100 + i),
+        ));
+    }
+
+    assert!(
+        world.archetype_count() >= 2,
+        "should have at least 2 archetypes"
+    );
+
+    let (_dir, reader) = flush_and_open(&world);
+    let schema = reader.schema();
+
+    // Schema must contain all three component types.
+    let pos_name = std::any::type_name::<Pos>();
+    let vel_name = std::any::type_name::<Vel>();
+    let health_name = std::any::type_name::<Health>();
+
+    assert!(
+        schema.slot_for(pos_name).is_some(),
+        "schema must contain Pos"
+    );
+    assert!(
+        schema.slot_for(vel_name).is_some(),
+        "schema must contain Vel"
+    );
+    assert!(
+        schema.slot_for(health_name).is_some(),
+        "schema must contain Health"
+    );
+
+    // Verify pages exist for both archetypes.
+    // Scan all possible arch_ids for entity pages.
+    let mut found_arch_ids: Vec<u16> = Vec::new();
+    for arch_id in 0..world.archetype_count() as u16 {
+        if reader.get_page(arch_id, ENTITY_SLOT, 0).is_some() {
+            found_arch_ids.push(arch_id);
+        }
+    }
+    assert_eq!(
+        found_arch_ids.len(),
+        2,
+        "must have entity pages for exactly 2 archetypes, found: {found_arch_ids:?}"
+    );
+}
+
+#[test]
+fn no_dirty_pages_no_file() {
+    let mut world = World::new();
+    world.spawn((Pos { x: 1.0, y: 2.0 },));
+    world.clear_all_dirty_pages();
+
+    let dir = tempfile::tempdir().unwrap();
+    let result = flush(&world, (0, 0), dir.path()).unwrap();
+    assert!(
+        result.is_none(),
+        "flush should return None when no dirty pages"
+    );
+
+    // Verify no .run file was created.
+    let entries: Vec<_> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|e| {
+            e.path()
+                .extension()
+                .is_some_and(|ext| ext == "run" || ext == "tmp")
+        })
+        .collect();
+    assert!(entries.is_empty(), "no run files should exist in temp dir");
+}
+
+#[test]
+fn crc_corruption_detected() {
+    let mut world = World::new();
+    for i in 0..10 {
+        world.spawn((Pos {
+            x: i as f32,
+            y: 0.0,
+        },));
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = flush(&world, (0, 50), dir.path()).unwrap().unwrap();
+
+    // Read file, corrupt a byte in the middle of page data, write back.
+    let mut data = std::fs::read(&path).unwrap();
+
+    // Page data starts after the file header (64 bytes) + schema section.
+    // Find the first page header — it's after the schema. The schema offset
+    // is at header byte 64, but we can just look for the first page by
+    // scanning past the schema. A simpler approach: corrupt a byte well into
+    // the file (past header + schema + page header = somewhere in page data).
+    // File is large enough that byte 200 is within page data.
+    let corrupt_offset = 200;
+    assert!(
+        corrupt_offset < data.len(),
+        "file must be large enough to corrupt"
+    );
+    data[corrupt_offset] ^= 0xFF; // flip all bits
+    std::fs::write(&path, &data).unwrap();
+
+    // Open should succeed (header CRC may still be valid).
+    // But page CRC validation should fail.
+    // Note: if flipping byte 200 corrupted the header CRC region, open will
+    // fail with a CRC or Format error, which is also a valid corruption
+    // detection. We accept either page-level or header-level detection.
+    match SortedRunReader::open(&path) {
+        Ok(reader) => {
+            // File opened — validate all page CRCs; at least one must fail.
+            let mut found_corruption = false;
+            for entry in reader.schema().entries() {
+                if let Some(page) = reader.get_page(0, entry.slot, 0)
+                    && reader.validate_page_crc(&page).is_err()
+                {
+                    found_corruption = true;
+                }
+            }
+            if let Some(entity_page) = reader.get_page(0, ENTITY_SLOT, 0)
+                && reader.validate_page_crc(&entity_page).is_err()
+            {
+                found_corruption = true;
+            }
+            assert!(
+                found_corruption,
+                "at least one page CRC should fail after corruption"
+            );
+        }
+        Err(LsmError::Crc { .. } | LsmError::Format(_)) => {
+            // Header or format-level corruption detected — also acceptable.
+        }
+        Err(e) => panic!("unexpected error type: {e}"),
+    }
+}
+
+#[test]
+fn schema_contains_correct_entries() {
+    let mut world = World::new();
+    world.spawn((Pos { x: 1.0, y: 2.0 }, Vel { dx: 0.5, dy: -0.5 }));
+
+    let (_dir, reader) = flush_and_open(&world);
+    let schema = reader.schema();
+
+    assert_eq!(schema.len(), 2, "schema should have exactly 2 entries");
+
+    let pos_name = std::any::type_name::<Pos>();
+    let vel_name = std::any::type_name::<Vel>();
+
+    let names: Vec<&str> = schema.entries().iter().map(|e| e.name.as_str()).collect();
+    assert!(names.contains(&pos_name), "schema must contain Pos name");
+    assert!(names.contains(&vel_name), "schema must contain Vel name");
+
+    // Verify item sizes.
+    let pos_entry = schema
+        .entries()
+        .iter()
+        .find(|e| e.name == pos_name)
+        .unwrap();
+    let vel_entry = schema
+        .entries()
+        .iter()
+        .find(|e| e.name == vel_name)
+        .unwrap();
+
+    assert_eq!(pos_entry.item_size as usize, Layout::new::<Pos>().size());
+    assert_eq!(vel_entry.item_size as usize, Layout::new::<Vel>().size());
+}
+
+#[test]
+fn sparse_index_finds_all_pages() {
+    let mut world = World::new();
+    // Spawn > 256 entities to fill 2+ pages.
+    let count = PAGE_SIZE + 50; // 306 entities
+    for i in 0..count {
+        world.spawn((Pos {
+            x: i as f32,
+            y: 0.0,
+        },));
+    }
+
+    let (_dir, reader) = flush_and_open(&world);
+
+    let schema = reader.schema();
+    let pos_slot = schema
+        .slot_for(std::any::type_name::<Pos>())
+        .expect("Pos must be in schema");
+
+    // With 306 entities and PAGE_SIZE=256, we expect 2 pages (page 0 and page 1).
+    let expected_pages = count.div_ceil(PAGE_SIZE);
+    assert_eq!(expected_pages, 2);
+
+    // Verify component pages.
+    for page_index in 0..expected_pages {
+        let page = reader
+            .get_page(0, pos_slot, page_index as u16)
+            .unwrap_or_else(|| panic!("component page {page_index} must exist"));
+
+        let expected_rows = if page_index < expected_pages - 1 {
+            PAGE_SIZE
+        } else {
+            count - page_index * PAGE_SIZE
+        };
+        assert_eq!(
+            page.header.row_count, expected_rows as u16,
+            "page {page_index} row count mismatch"
+        );
+
+        reader.validate_page_crc(&page).unwrap();
+    }
+
+    // Verify entity pages.
+    for page_index in 0..expected_pages {
+        let page = reader
+            .get_page(0, ENTITY_SLOT, page_index as u16)
+            .unwrap_or_else(|| panic!("entity page {page_index} must exist"));
+        reader.validate_page_crc(&page).unwrap();
+    }
+
+    // Verify no extra pages beyond expected.
+    assert!(
+        reader
+            .get_page(0, pos_slot, expected_pages as u16)
+            .is_none(),
+        "no page beyond the expected count"
+    );
+}
+
+#[test]
+fn entity_pages_match_world() {
+    let mut world = World::new();
+    for i in 0..20 {
+        world.spawn((Pos {
+            x: i as f32,
+            y: 0.0,
+        },));
+    }
+
+    let (_dir, reader) = flush_and_open(&world);
+
+    let entity_page = reader
+        .get_page(0, ENTITY_SLOT, 0)
+        .expect("entity page must exist");
+    assert_eq!(entity_page.header.row_count, 20);
+
+    let entities = world.archetype_entities(0);
+    assert_eq!(entities.len(), 20);
+
+    for (i, &e) in entities.iter().enumerate() {
+        let offset = i * 8;
+        let stored_bits =
+            u64::from_le_bytes(entity_page.data[offset..offset + 8].try_into().unwrap());
+        assert_eq!(
+            stored_bits,
+            e.to_bits(),
+            "entity bits mismatch at index {i}"
+        );
+    }
+}

--- a/crates/minkowski-lsm/tests/integration.rs
+++ b/crates/minkowski-lsm/tests/integration.rs
@@ -4,6 +4,7 @@ use minkowski::World;
 use minkowski_lsm::error::LsmError;
 use minkowski_lsm::format::{ENTITY_SLOT, PAGE_SIZE};
 use minkowski_lsm::reader::SortedRunReader;
+use minkowski_lsm::schema::SchemaEntry;
 use minkowski_lsm::writer::flush;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -61,25 +62,25 @@ fn round_trip_single_archetype() {
     // Check each component page.
     for entry in schema.entries() {
         let page = reader
-            .get_page(0, entry.slot, 0)
+            .get_page(0, entry.slot(), 0)
             .expect("get_page should not error")
             .expect("page must exist for slot");
-        assert_eq!(page.header.row_count, 5);
+        assert_eq!(page.header().row_count, 5);
 
         // Reconstruct expected bytes from world.
         let comp_id = world
             .archetype_component_ids(0)
             .iter()
-            .find(|&&cid| world.component_name(cid).unwrap() == entry.name)
+            .find(|&&cid| world.component_name(cid).unwrap() == entry.name())
             .copied()
             .expect("component must exist in archetype");
 
         let expected = world.column_page_bytes(0, comp_id, 0, 5).unwrap();
         assert_eq!(
-            &page.data[..expected.len()],
+            &page.data()[..expected.len()],
             expected,
             "data mismatch for component {}",
-            entry.name
+            entry.name()
         );
 
         reader.validate_page_crc(&page).unwrap();
@@ -90,12 +91,12 @@ fn round_trip_single_archetype() {
         .get_page(0, ENTITY_SLOT, 0)
         .expect("get_page should not error")
         .expect("entity page must exist");
-    assert_eq!(entity_page.header.row_count, 5);
+    assert_eq!(entity_page.header().row_count, 5);
 
     let entities = world.archetype_entities(0);
     for (i, &e) in entities.iter().enumerate() {
         let offset = i * 8;
-        let stored = u64::from_le_bytes(entity_page.data[offset..offset + 8].try_into().unwrap());
+        let stored = u64::from_le_bytes(entity_page.data()[offset..offset + 8].try_into().unwrap());
         assert_eq!(stored, e.to_bits(), "entity mismatch at index {i}");
     }
 }
@@ -121,7 +122,7 @@ fn round_trip_partial_page() {
         .expect("page must exist");
 
     // Verify row count.
-    assert_eq!(page.header.row_count, 100);
+    assert_eq!(page.header().row_count, 100);
 
     // Verify data bytes for valid rows match.
     let item_size = Layout::new::<Pos>().size();
@@ -129,12 +130,12 @@ fn round_trip_partial_page() {
     let expected = world
         .column_page_bytes(0, world.archetype_component_ids(0)[0], 0, 100)
         .unwrap();
-    assert_eq!(&page.data[..valid_len], expected);
+    assert_eq!(&page.data()[..valid_len], expected);
 
     // Verify padding beyond valid rows is zero.
     let full_len = PAGE_SIZE * item_size;
     assert!(
-        page.data[valid_len..full_len].iter().all(|&b| b == 0),
+        page.data()[valid_len..full_len].iter().all(|&b| b == 0),
         "padding bytes beyond row_count must be zero"
     );
 
@@ -249,34 +250,29 @@ fn crc_corruption_detected() {
     let dir = tempfile::tempdir().unwrap();
     let path = flush(&world, (0, 50), dir.path()).unwrap().unwrap();
 
-    // Read file, corrupt a byte in the middle of page data, write back.
-    let mut data = std::fs::read(&path).unwrap();
+    // Open the reader first to find a valid page's file_offset, then corrupt a
+    // byte well inside that page's data region.  We use offset 256, which is
+    // past the 64-byte file header, past any realistic schema section, and past
+    // the 16-byte page header — i.e. guaranteed to be inside page data for
+    // files with 10 entities.
+    let corrupt_offset: usize = 256;
 
-    // Page data starts after the file header (64 bytes) + schema section.
-    // Find the first page header — it's after the schema. The schema offset
-    // is at header byte 64, but we can just look for the first page by
-    // scanning past the schema. A simpler approach: corrupt a byte well into
-    // the file (past header + schema + page header = somewhere in page data).
-    // File is large enough that byte 200 is within page data.
-    let corrupt_offset = 200;
+    let mut data = std::fs::read(&path).unwrap();
     assert!(
         corrupt_offset < data.len(),
-        "file must be large enough to corrupt"
+        "file must be large enough to have page data at offset {corrupt_offset}"
     );
     data[corrupt_offset] ^= 0xFF; // flip all bits
     std::fs::write(&path, &data).unwrap();
 
-    // Open should succeed (header CRC may still be valid).
-    // But page CRC validation should fail.
-    // Note: if flipping byte 200 corrupted the header CRC region, open will
-    // fail with a CRC or Format error, which is also a valid corruption
-    // detection. We accept either page-level or header-level detection.
+    // Open may succeed (header CRC region ends at byte 40) or fail with a
+    // CRC/Format error if the corruption propagated to a covered region.
     match SortedRunReader::open(&path) {
         Ok(reader) => {
             // File opened — validate all page CRCs; at least one must fail.
             let mut found_corruption = false;
             for entry in reader.schema().entries() {
-                match reader.get_page(0, entry.slot, 0) {
+                match reader.get_page(0, entry.slot(), 0) {
                     Ok(Some(page)) if reader.validate_page_crc(&page).is_err() => {
                         found_corruption = true;
                     }
@@ -301,10 +297,68 @@ fn crc_corruption_detected() {
             );
         }
         Err(LsmError::Crc { .. } | LsmError::Format(_)) => {
-            // Header or format-level corruption detected — also acceptable.
+            // Header or total-file CRC corruption detected at open — acceptable.
         }
         Err(e) => panic!("unexpected error type: {e}"),
     }
+}
+
+#[test]
+fn header_crc_corruption_detected() {
+    let mut world = World::new();
+    for i in 0..5 {
+        world.spawn((Pos {
+            x: i as f32,
+            y: 0.0,
+        },));
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = flush(&world, (0, 10), dir.path()).unwrap().unwrap();
+
+    // Corrupt byte 20, which falls in the `page_count` field of the file
+    // header (bytes 8-11: version, 12-15: schema_count, 16-23: page_count).
+    // This is within the 40-byte CRC-protected region but after the magic
+    // bytes (0-7), so the magic check passes but the header CRC fails.
+    let mut data = std::fs::read(&path).unwrap();
+    data[20] ^= 0xFF;
+    std::fs::write(&path, &data).unwrap();
+
+    let result = SortedRunReader::open(&path);
+    assert!(
+        matches!(result, Err(LsmError::Crc { .. })),
+        "expected CRC error for header byte corruption, got: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn empty_file_returns_format_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("empty.run");
+    std::fs::write(&path, b"").unwrap();
+
+    let result = SortedRunReader::open(&path);
+    assert!(
+        matches!(result, Err(LsmError::Format(_))),
+        "expected Format error for empty file, got: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn truncated_file_returns_format_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("short.run");
+    // 64 bytes — enough for a header but not the minimum 128 (header + footer).
+    std::fs::write(&path, [0u8; 64]).unwrap();
+
+    let result = SortedRunReader::open(&path);
+    assert!(
+        matches!(result, Err(LsmError::Format(_))),
+        "expected Format error for truncated file, got: {:?}",
+        result.err()
+    );
 }
 
 #[test]
@@ -320,7 +374,7 @@ fn schema_contains_correct_entries() {
     let pos_name = std::any::type_name::<Pos>();
     let vel_name = std::any::type_name::<Vel>();
 
-    let names: Vec<&str> = schema.entries().iter().map(|e| e.name.as_str()).collect();
+    let names: Vec<&str> = schema.entries().iter().map(SchemaEntry::name).collect();
     assert!(names.contains(&pos_name), "schema must contain Pos name");
     assert!(names.contains(&vel_name), "schema must contain Vel name");
 
@@ -328,16 +382,16 @@ fn schema_contains_correct_entries() {
     let pos_entry = schema
         .entries()
         .iter()
-        .find(|e| e.name == pos_name)
+        .find(|e| e.name() == pos_name)
         .unwrap();
     let vel_entry = schema
         .entries()
         .iter()
-        .find(|e| e.name == vel_name)
+        .find(|e| e.name() == vel_name)
         .unwrap();
 
-    assert_eq!(pos_entry.item_size as usize, Layout::new::<Pos>().size());
-    assert_eq!(vel_entry.item_size as usize, Layout::new::<Vel>().size());
+    assert_eq!(pos_entry.item_size() as usize, Layout::new::<Pos>().size());
+    assert_eq!(vel_entry.item_size() as usize, Layout::new::<Vel>().size());
 }
 
 #[test]
@@ -376,7 +430,8 @@ fn sparse_index_finds_all_pages() {
             count - page_index * PAGE_SIZE
         };
         assert_eq!(
-            page.header.row_count, expected_rows as u16,
+            page.header().row_count,
+            expected_rows as u16,
             "page {page_index} row count mismatch"
         );
 
@@ -418,7 +473,7 @@ fn entity_pages_match_world() {
         .get_page(0, ENTITY_SLOT, 0)
         .expect("get_page should not error")
         .expect("entity page must exist");
-    assert_eq!(entity_page.header.row_count, 20);
+    assert_eq!(entity_page.header().row_count, 20);
 
     let entities = world.archetype_entities(0);
     assert_eq!(entities.len(), 20);
@@ -426,7 +481,7 @@ fn entity_pages_match_world() {
     for (i, &e) in entities.iter().enumerate() {
         let offset = i * 8;
         let stored_bits =
-            u64::from_le_bytes(entity_page.data[offset..offset + 8].try_into().unwrap());
+            u64::from_le_bytes(entity_page.data()[offset..offset + 8].try_into().unwrap());
         assert_eq!(
             stored_bits,
             e.to_bits(),
@@ -451,16 +506,20 @@ fn zst_component_round_trip() {
     // Schema should have one entry for the ZST component.
     assert_eq!(reader.schema().len(), 1);
     let entry = &reader.schema().entries()[0];
-    assert_eq!(entry.item_size, 0, "ZST component should have item_size 0");
+    assert_eq!(
+        entry.item_size(),
+        0,
+        "ZST component should have item_size 0"
+    );
 
     // ZST page should exist with row_count=5 but empty data region.
     let page = reader
-        .get_page(0, entry.slot, 0)
+        .get_page(0, entry.slot(), 0)
         .expect("get_page should not error")
         .expect("ZST page must exist");
-    assert_eq!(page.header.row_count, 5);
+    assert_eq!(page.header().row_count, 5);
     assert!(
-        page.data.is_empty(),
+        page.data().is_empty(),
         "ZST page data should be empty (0 * PAGE_SIZE = 0 bytes)"
     );
 
@@ -469,7 +528,7 @@ fn zst_component_round_trip() {
         .get_page(0, ENTITY_SLOT, 0)
         .expect("get_page should not error")
         .expect("entity page must exist");
-    assert_eq!(entity_page.header.row_count, 5);
+    assert_eq!(entity_page.header().row_count, 5);
 
     reader.validate_page_crc(&page).unwrap();
     reader.validate_page_crc(&entity_page).unwrap();

--- a/crates/minkowski/src/storage/blob_vec.rs
+++ b/crates/minkowski/src/storage/blob_vec.rs
@@ -98,6 +98,15 @@ impl BlobVec {
         self.capacity
     }
 
+    /// Returns a raw pointer to the first byte of the allocation.
+    ///
+    /// For zero-sized components, returns a dangling pointer — callers must
+    /// guard on `item_layout.size() == 0` before performing pointer arithmetic.
+    #[inline]
+    pub(crate) fn data_ptr(&self) -> *const u8 {
+        self.data.as_ptr()
+    }
+
     /// Ensures the column has capacity for at least `additional` more elements.
     /// If the column already has enough spare capacity, this is a no-op.
     pub(crate) fn reserve(&mut self, additional: usize) {

--- a/crates/minkowski/src/world.rs
+++ b/crates/minkowski/src/world.rs
@@ -1949,15 +1949,16 @@ impl World {
         let arch = &self.archetypes.archetypes[arch_idx];
         let col_idx = arch.column_index(comp_id)?;
         let col = &arch.columns[col_idx];
-        if start_row + row_count > col.len() {
+        let end_row = start_row.checked_add(row_count)?;
+        if end_row > col.len() {
             return None;
         }
         let item_size = col.item_layout.size();
         if item_size == 0 {
             return Some(&[]);
         }
-        let offset = start_row * item_size;
-        let len = row_count * item_size;
+        let offset = start_row.checked_mul(item_size)?;
+        let len = row_count.checked_mul(item_size)?;
         // Safety: `col.data_ptr()` is valid for `col.len() * item_size` bytes.
         // The range check above guarantees `offset + len <= col.len() * item_size`.
         // The lifetime of the returned slice is tied to `&self`.

--- a/crates/minkowski/src/world.rs
+++ b/crates/minkowski/src/world.rs
@@ -1933,6 +1933,37 @@ impl World {
         self.archetypes.archetypes[arch_idx].clear_dirty_pages();
     }
 
+    /// Returns a raw byte slice covering rows `[start_row, start_row + row_count)` in the
+    /// column for `comp_id` within archetype `arch_idx`.
+    ///
+    /// Returns `None` if the component is not present in the archetype or if
+    /// the row range exceeds the column length.
+    /// Zero-sized components return an empty slice.
+    pub fn column_page_bytes(
+        &self,
+        arch_idx: usize,
+        comp_id: ComponentId,
+        start_row: usize,
+        row_count: usize,
+    ) -> Option<&[u8]> {
+        let arch = &self.archetypes.archetypes[arch_idx];
+        let col_idx = arch.column_index(comp_id)?;
+        let col = &arch.columns[col_idx];
+        if start_row + row_count > col.len() {
+            return None;
+        }
+        let item_size = col.item_layout.size();
+        if item_size == 0 {
+            return Some(&[]);
+        }
+        let offset = start_row * item_size;
+        let len = row_count * item_size;
+        // Safety: `col.data_ptr()` is valid for `col.len() * item_size` bytes.
+        // The range check above guarantees `offset + len <= col.len() * item_size`.
+        // The lifetime of the returned slice is tied to `&self`.
+        Some(unsafe { std::slice::from_raw_parts(col.data_ptr().add(offset), len) })
+    }
+
     /// Component name (from `std::any::type_name`). Returns None if unregistered.
     pub fn component_name(&self, id: ComponentId) -> Option<&'static str> {
         if id < self.components.len() {
@@ -3962,6 +3993,53 @@ mod tests {
         let _e = world.spawn((Pos { x: 1.0, y: 2.0 },));
         let vel_id = world.register_component::<Vel>();
         assert!(world.column_dirty_pages(0, vel_id).is_none());
+    }
+
+    #[test]
+    fn column_page_bytes_returns_correct_data() {
+        let mut world = World::new();
+        world.spawn((Pos { x: 1.0, y: 2.0 },));
+        world.spawn((Pos { x: 3.0, y: 4.0 },));
+        let pos_id = world.component_id::<Pos>().unwrap();
+        let bytes = world.column_page_bytes(0, pos_id, 0, 2).unwrap();
+        assert_eq!(bytes.len(), 2 * std::mem::size_of::<Pos>());
+        // Verify actual data
+        let pos0: Pos = unsafe { std::ptr::read(bytes.as_ptr() as *const Pos) };
+        assert_eq!(pos0.x, 1.0);
+        assert_eq!(pos0.y, 2.0);
+    }
+
+    #[test]
+    fn column_page_bytes_out_of_range_returns_none() {
+        let mut world = World::new();
+        world.spawn((Pos { x: 1.0, y: 2.0 },));
+        let pos_id = world.component_id::<Pos>().unwrap();
+        assert!(world.column_page_bytes(0, pos_id, 0, 2).is_none()); // only 1 row
+    }
+
+    #[test]
+    fn column_page_bytes_missing_component_returns_none() {
+        let mut world = World::new();
+        world.spawn((Pos { x: 1.0, y: 2.0 },));
+        let vel_id = world.register_component::<Vel>();
+        assert!(world.column_page_bytes(0, vel_id, 0, 1).is_none());
+    }
+
+    #[test]
+    fn column_page_bytes_partial_range() {
+        let mut world = World::new();
+        for i in 0..10 {
+            world.spawn((Pos {
+                x: i as f32,
+                y: 0.0,
+            },));
+        }
+        let pos_id = world.component_id::<Pos>().unwrap();
+        // Read rows 3..6
+        let bytes = world.column_page_bytes(0, pos_id, 3, 3).unwrap();
+        assert_eq!(bytes.len(), 3 * std::mem::size_of::<Pos>());
+        let pos3: Pos = unsafe { std::ptr::read(bytes.as_ptr() as *const Pos) };
+        assert_eq!(pos3.x, 3.0);
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 1 of LSM tree storage (Stage 3 scaling roadmap). Introduces the `minkowski-lsm` crate with:

- **SortedRun file format**: 64-byte header, schema section (slot-based column identification), page images sorted by `(arch_id, slot, page_index)`, sparse index (binary-searchable), 64-byte footer. Per-page CRC32 integrity.
- **FlushWriter**: collects dirty pages from World via `DirtyPageTracker`, writes atomic sorted run files (temp + rename). Entity pages flushed as pseudo-column (slot 0xFFFF) for the union of all dirty page indices.
- **SortedRunReader**: mmap-backed reader (`Vec<u8>` fallback for Miri) with O(log n) page lookup via binary search on sparse index. Header/page CRC validation.
- **World::column_page_bytes()**: new public API for raw column byte access, following existing accessor patterns.

31 tests (23 unit + 8 integration). Integration tests caught a sparse index sort-order bug (entity pages breaking binary search with multiple archetypes).

~2,050 LOC across 11 files.

## Key design decisions

- **Slot-based column identification**: per-file slot indices assigned from sorted stable names, not runtime `ComponentId` (which varies across runs)
- **Partial pages zero-padded**: `row_count` in PageHeader records valid rows; data always `PAGE_SIZE * item_size` bytes on disk
- **No dependency on `minkowski-persist`**: self-contained format, Phase 5 will integrate with `Durable<S>`
- **Entity mapping as pseudo-column**: entities lack their own `DirtyPageTracker`, so entity pages are flushed for the union of all component dirty pages per archetype

## Test plan

- [x] `cargo test -p minkowski-lsm` — 31 tests passing
- [x] `cargo test -p minkowski --lib` — core tests pass with new `column_page_bytes` API
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] CI pipeline (fmt, clippy, test, tsan, loom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)