### PR TITLE
Claude/atomic manifest updates oi f5 j

### DIFF
--- a/crates/minkowski-lsm/src/manifest.rs
+++ b/crates/minkowski-lsm/src/manifest.rs
@@ -78,13 +78,14 @@ impl LsmManifest {
         to_level: u8,
         path: &Path,
     ) -> Result<(), LsmError> {
-        let meta = self.remove_run(from_level, path).ok_or_else(|| {
+        let mut meta = self.remove_run(from_level, path).ok_or_else(|| {
             LsmError::Format(format!(
                 "run {} not found at level {}",
                 path.display(),
                 from_level
             ))
         })?;
+        meta.level = to_level;
         self.add_run(to_level, meta);
         Ok(())
     }
@@ -174,10 +175,12 @@ mod tests {
     fn promote_run_moves_between_levels() {
         let mut m = LsmManifest::new();
         let meta = test_meta("run_x.sst", 0);
-        m.add_run(0, meta.clone());
+        m.add_run(0, meta);
         m.promote_run(0, 1, Path::new("run_x.sst")).unwrap();
         assert!(m.runs_at_level(0).is_empty());
-        assert_eq!(m.runs_at_level(1), &[meta]);
+        let promoted = &m.runs_at_level(1)[0];
+        assert_eq!(promoted.path(), Path::new("run_x.sst"));
+        assert_eq!(promoted.level(), 1);
     }
 
     #[test]

--- a/crates/minkowski-lsm/src/manifest_log.rs
+++ b/crates/minkowski-lsm/src/manifest_log.rs
@@ -32,6 +32,15 @@ pub enum ManifestEntry {
     SetSequence {
         next_sequence: u64,
     },
+    /// Atomic combination of `AddRun` + `SetSequence`.
+    ///
+    /// A single frame ensures that a crash can never leave the manifest with a
+    /// new run recorded but the sequence pointer still at its old value.
+    AddRunAndSequence {
+        level: u8,
+        meta: SortedRunMeta,
+        next_sequence: u64,
+    },
 }
 
 // ── Frame codec ─────────────────────────────────────────────────────────────
@@ -92,6 +101,7 @@ const TAG_ADD_RUN: u8 = 0x01;
 const TAG_REMOVE_RUN: u8 = 0x02;
 const TAG_PROMOTE_RUN: u8 = 0x03;
 const TAG_SET_SEQUENCE: u8 = 0x04;
+const TAG_ADD_RUN_AND_SEQUENCE: u8 = 0x05;
 
 fn encode_path(buf: &mut Vec<u8>, path: &Path) -> Result<(), LsmError> {
     let s = path
@@ -172,6 +182,25 @@ fn encode_entry(entry: &ManifestEntry) -> Result<Vec<u8>, LsmError> {
             buf.push(TAG_SET_SEQUENCE);
             buf.extend_from_slice(&next_sequence.to_le_bytes());
         }
+        ManifestEntry::AddRunAndSequence {
+            level,
+            meta,
+            next_sequence,
+        } => {
+            buf.push(TAG_ADD_RUN_AND_SEQUENCE);
+            buf.push(*level);
+            encode_path(&mut buf, &meta.path)?;
+            buf.extend_from_slice(&meta.sequence_range.0.to_le_bytes());
+            buf.extend_from_slice(&meta.sequence_range.1.to_le_bytes());
+            let count = meta.archetype_coverage.len() as u16;
+            buf.extend_from_slice(&count.to_le_bytes());
+            for &arch_id in &meta.archetype_coverage {
+                buf.extend_from_slice(&arch_id.to_le_bytes());
+            }
+            buf.extend_from_slice(&meta.page_count.to_le_bytes());
+            buf.extend_from_slice(&meta.size_bytes.to_le_bytes());
+            buf.extend_from_slice(&next_sequence.to_le_bytes());
+        }
     }
     Ok(buf)
 }
@@ -244,6 +273,40 @@ fn decode_entry(data: &[u8]) -> Result<ManifestEntry, LsmError> {
             let next_sequence = read_u64_le(data, &mut offset)?;
             Ok(ManifestEntry::SetSequence { next_sequence })
         }
+        TAG_ADD_RUN_AND_SEQUENCE => {
+            if offset >= data.len() {
+                return Err(LsmError::Format("truncated AddRunAndSequence".to_owned()));
+            }
+            let level = data[offset];
+            offset += 1;
+            let path = decode_path(data, &mut offset)?;
+            let seq_lo = read_u64_le(data, &mut offset)?;
+            let seq_hi = read_u64_le(data, &mut offset)?;
+            let count = read_u16_le(data, &mut offset)? as usize;
+            if offset + count * 2 > data.len() {
+                return Err(LsmError::Format("truncated coverage data".to_owned()));
+            }
+            let mut coverage = Vec::with_capacity(count);
+            for _ in 0..count {
+                coverage.push(read_u16_le(data, &mut offset)?);
+            }
+            let page_count = read_u64_le(data, &mut offset)?;
+            let size_bytes = read_u64_le(data, &mut offset)?;
+            let next_sequence = read_u64_le(data, &mut offset)?;
+
+            Ok(ManifestEntry::AddRunAndSequence {
+                level,
+                meta: SortedRunMeta {
+                    path,
+                    level,
+                    sequence_range: (seq_lo, seq_hi),
+                    archetype_coverage: coverage,
+                    page_count,
+                    size_bytes,
+                },
+                next_sequence,
+            })
+        }
         _ => Err(LsmError::Format(format!("unknown entry tag: {tag:#04x}"))),
     }
 }
@@ -264,6 +327,14 @@ fn apply_entry(manifest: &mut LsmManifest, entry: &ManifestEntry) {
             let _ = manifest.promote_run(*from_level, *to_level, path);
         }
         ManifestEntry::SetSequence { next_sequence } => {
+            manifest.set_next_sequence(*next_sequence);
+        }
+        ManifestEntry::AddRunAndSequence {
+            level,
+            meta,
+            next_sequence,
+        } => {
+            manifest.add_run(*level, meta.clone());
             manifest.set_next_sequence(*next_sequence);
         }
     }
@@ -425,6 +496,39 @@ mod tests {
         let payload = encode_entry(&entry).unwrap();
         let decoded = decode_entry(&payload).unwrap();
         assert_eq!(entry, decoded);
+    }
+
+    #[test]
+    fn encode_decode_add_run_and_sequence() {
+        let mut meta = test_meta("atomic.run");
+        meta.level = 0;
+        let entry = ManifestEntry::AddRunAndSequence {
+            level: 0,
+            meta,
+            next_sequence: 99,
+        };
+        let payload = encode_entry(&entry).unwrap();
+        let decoded = decode_entry(&payload).unwrap();
+        assert_eq!(entry, decoded);
+    }
+
+    #[test]
+    fn replay_add_run_and_sequence() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("manifest.log");
+
+        let mut log = ManifestLog::create(&path).unwrap();
+        log.append(&ManifestEntry::AddRunAndSequence {
+            level: 0,
+            meta: test_meta("atomic.run"),
+            next_sequence: 42,
+        })
+        .unwrap();
+
+        let manifest = ManifestLog::replay(&path).unwrap();
+        assert_eq!(manifest.total_runs(), 1);
+        assert_eq!(manifest.next_sequence(), 42);
+        assert_eq!(manifest.runs_at_level(0)[0].path(), Path::new("atomic.run"));
     }
 
     #[test]

--- a/crates/minkowski-lsm/src/manifest_ops.rs
+++ b/crates/minkowski-lsm/src/manifest_ops.rs
@@ -41,11 +41,11 @@ pub fn flush_and_record(
     };
 
     // Persist to log first, then update in-memory state.
-    log.append(&ManifestEntry::AddRun {
+    // A single atomic entry ensures a crash can never leave the manifest with
+    // a new run recorded but the sequence pointer still at its old value.
+    log.append(&ManifestEntry::AddRunAndSequence {
         level: 0,
         meta: meta.clone(),
-    })?;
-    log.append(&ManifestEntry::SetSequence {
         next_sequence: sequence_range.1,
     })?;
 

--- a/crates/minkowski-lsm/tests/manifest_integration.rs
+++ b/crates/minkowski-lsm/tests/manifest_integration.rs
@@ -112,7 +112,7 @@ fn corrupt_tail_partial_recovery() {
         f.write_all(&[0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x42]).unwrap();
     }
 
-    // Replay should recover the 2 good entries (each flush writes AddRun + SetSequence = 4 log entries).
+    // Replay should recover the 2 good entries (each flush writes one atomic AddRunAndSequence entry).
     let recovered = ManifestLog::replay(&log_path).unwrap();
     assert_eq!(recovered.total_runs(), 2);
     assert_eq!(recovered.next_sequence(), 20);


### PR DESCRIPTION
This pull request introduces an atomic log entry to ensure that adding a new run and updating the sequence pointer happen together, preventing inconsistencies if a crash occurs between these operations. It updates the log encoding/decoding, manifest application logic, and associated tests to support this new atomic entry. Additionally, the `promote_run` logic is improved to update run metadata correctly.

**Atomic Manifest Log Entry Improvements:**

* Added a new `ManifestEntry::AddRunAndSequence` variant that atomically records both adding a run and updating the sequence pointer, along with its encoding and decoding logic (`manifest_log.rs`). [[1]](diffhunk://#diff-09ff6d8ef88e7f0d134d818c7bce17715a90ca9f40c488e2664b3ee3b6c7a055R35-R43) [[2]](diffhunk://#diff-09ff6d8ef88e7f0d134d818c7bce17715a90ca9f40c488e2664b3ee3b6c7a055R104) [[3]](diffhunk://#diff-09ff6d8ef88e7f0d134d818c7bce17715a90ca9f40c488e2664b3ee3b6c7a055R185-R203) [[4]](diffhunk://#diff-09ff6d8ef88e7f0d134d818c7bce17715a90ca9f40c488e2664b3ee3b6c7a055R276-R309)
* Updated the manifest log application logic to handle the new atomic entry, ensuring both the run and sequence are updated together (`manifest_log.rs`).
* Modified `flush_and_record` to use the new atomic entry instead of separate `AddRun` and `SetSequence` entries (`manifest_ops.rs`).

**Testing and Validation:**

* Added and updated tests to verify encoding/decoding and replay of the new atomic entry, and adjusted integration tests to reflect the new atomic logging behavior (`manifest_log.rs`, `manifest_integration.rs`). [[1]](diffhunk://#diff-09ff6d8ef88e7f0d134d818c7bce17715a90ca9f40c488e2664b3ee3b6c7a055R501-R533) [[2]](diffhunk://#diff-18c74ae8c0e3acb199a59257a5f056c03d892b05dcefa26165f496e5c16a8fbaL115-R115)

**Manifest Promotion Logic:**

* Fixed `promote_run` to update the run's level in its metadata before adding it to the new level (`manifest.rs`). [[1]](diffhunk://#diff-c303dd0c140602c6006036f43672d654a2c4ba1f7c13a5c12a1ba127b07a0837L81-R88) [[2]](diffhunk://#diff-c303dd0c140602c6006036f43672d654a2c4ba1f7c13a5c12a1ba127b07a0837L177-R183)