### PR TITLE
feat(lsm): manifest type-safety refactor (PR A)

### DIFF
--- a/crates/minkowski-lsm/src/lib.rs
+++ b/crates/minkowski-lsm/src/lib.rs
@@ -5,4 +5,5 @@ pub mod manifest_log;
 pub mod manifest_ops;
 pub mod reader;
 pub mod schema;
+pub mod types;
 pub mod writer;

--- a/crates/minkowski-lsm/src/manifest.rs
+++ b/crates/minkowski-lsm/src/manifest.rs
@@ -49,7 +49,7 @@ impl SortedRunMeta {
     /// - `archetype_coverage` is strictly sorted ascending (sorted + deduped).
     /// - `page_count` is non-zero.
     ///
-    /// `seq_range` is already validated by `SeqRange::new`. `size_bytes` is
+    /// `sequence_range` is already validated by `SeqRange::new`. `size_bytes` is
     /// not validated (redundant with `page_count`; a valid run file always
     /// has a non-empty header).
     pub fn new(
@@ -117,14 +117,17 @@ impl LsmManifest {
         Ok(())
     }
 
+    /// Record the next sequence number to assign on flush.
     pub fn set_next_sequence(&mut self, seq: SeqNo) {
         self.next_sequence = seq.0;
     }
 
+    /// The next sequence number to assign on the next flush.
     pub fn next_sequence(&self) -> SeqNo {
         SeqNo(self.next_sequence)
     }
 
+    /// All sorted runs currently tracked at the given level.
     pub fn runs_at_level(&self, level: Level) -> &[SortedRunMeta] {
         &self.levels[level.as_index()]
     }

--- a/crates/minkowski-lsm/src/manifest.rs
+++ b/crates/minkowski-lsm/src/manifest.rs
@@ -16,7 +16,6 @@ pub struct LsmManifest {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SortedRunMeta {
     path: PathBuf,
-    pub(crate) level: u8, // stays pub(crate); promote_run mutates it directly — Task 5 removes it
     sequence_range: SeqRange,
     archetype_coverage: Vec<u16>,
     page_count: u64,
@@ -26,10 +25,6 @@ pub struct SortedRunMeta {
 impl SortedRunMeta {
     pub fn path(&self) -> &Path {
         &self.path
-    }
-
-    pub fn level(&self) -> u8 {
-        self.level
     }
 
     pub fn sequence_range(&self) -> SeqRange {
@@ -59,7 +54,6 @@ impl SortedRunMeta {
     /// has a non-empty header).
     pub fn new(
         path: PathBuf,
-        level: u8,
         sequence_range: SeqRange,
         archetype_coverage: Vec<u16>,
         page_count: u64,
@@ -75,7 +69,6 @@ impl SortedRunMeta {
         }
         Ok(Self {
             path,
-            level,
             sequence_range,
             archetype_coverage,
             page_count,
@@ -114,14 +107,13 @@ impl LsmManifest {
         to_level: u8,
         path: &Path,
     ) -> Result<(), LsmError> {
-        let mut meta = self.remove_run(from_level, path).ok_or_else(|| {
+        let meta = self.remove_run(from_level, path).ok_or_else(|| {
             LsmError::Format(format!(
                 "run {} not found at level {}",
                 path.display(),
                 from_level
             ))
         })?;
-        meta.level = to_level;
         self.add_run(to_level, meta);
         Ok(())
     }
@@ -162,10 +154,9 @@ mod tests {
     use super::*;
     use crate::types::{SeqNo, SeqRange};
 
-    fn test_meta(name: &str, level: u8) -> SortedRunMeta {
+    fn test_meta(name: &str) -> SortedRunMeta {
         SortedRunMeta::new(
             PathBuf::from(name),
-            level,
             SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
             vec![0],
             1,
@@ -187,7 +178,7 @@ mod tests {
     #[test]
     fn add_run_places_at_correct_level() {
         let mut m = LsmManifest::new();
-        let meta = test_meta("run_l1.sst", 1);
+        let meta = test_meta("run_l1.sst");
         m.add_run(1, meta.clone());
         assert_eq!(m.runs_at_level(1), &[meta]);
         assert!(m.runs_at_level(0).is_empty());
@@ -196,7 +187,7 @@ mod tests {
     #[test]
     fn remove_run_by_path() {
         let mut m = LsmManifest::new();
-        let meta = test_meta("run_a.sst", 0);
+        let meta = test_meta("run_a.sst");
         m.add_run(0, meta.clone());
         let removed = m.remove_run(0, Path::new("run_a.sst"));
         assert_eq!(removed, Some(meta));
@@ -212,13 +203,12 @@ mod tests {
     #[test]
     fn promote_run_moves_between_levels() {
         let mut m = LsmManifest::new();
-        let meta = test_meta("run_x.sst", 0);
+        let meta = test_meta("run_x.sst");
         m.add_run(0, meta);
         m.promote_run(0, 1, Path::new("run_x.sst")).unwrap();
         assert!(m.runs_at_level(0).is_empty());
-        let promoted = &m.runs_at_level(1)[0];
-        assert_eq!(promoted.path(), Path::new("run_x.sst"));
-        assert_eq!(promoted.level(), 1);
+        assert_eq!(m.runs_at_level(1).len(), 1);
+        assert_eq!(m.runs_at_level(1)[0].path(), Path::new("run_x.sst"));
     }
 
     #[test]
@@ -231,8 +221,8 @@ mod tests {
     #[test]
     fn all_run_paths_collects_all_levels() {
         let mut m = LsmManifest::new();
-        m.add_run(0, test_meta("l0.sst", 0));
-        m.add_run(2, test_meta("l2.sst", 2));
+        m.add_run(0, test_meta("l0.sst"));
+        m.add_run(2, test_meta("l2.sst"));
         let paths = m.all_run_paths();
         assert_eq!(paths.len(), 2);
         assert!(paths.contains(&Path::new("l0.sst")));
@@ -242,9 +232,9 @@ mod tests {
     #[test]
     fn total_runs_counts_correctly() {
         let mut m = LsmManifest::new();
-        m.add_run(0, test_meta("a.sst", 0));
-        m.add_run(0, test_meta("b.sst", 0));
-        m.add_run(2, test_meta("c.sst", 2));
+        m.add_run(0, test_meta("a.sst"));
+        m.add_run(0, test_meta("b.sst"));
+        m.add_run(2, test_meta("c.sst"));
         assert_eq!(m.total_runs(), 3);
     }
 
@@ -259,7 +249,6 @@ mod tests {
     fn sorted_run_meta_new_accepts_valid_input() {
         let meta = SortedRunMeta::new(
             PathBuf::from("0-10.run"),
-            0,
             SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
             vec![0, 3, 7],
             1,
@@ -274,7 +263,6 @@ mod tests {
     fn sorted_run_meta_new_rejects_unsorted_coverage() {
         let result = SortedRunMeta::new(
             PathBuf::from("x.run"),
-            0,
             SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
             vec![3, 1, 2],
             1,
@@ -287,7 +275,6 @@ mod tests {
     fn sorted_run_meta_new_rejects_duplicated_coverage() {
         let result = SortedRunMeta::new(
             PathBuf::from("x.run"),
-            0,
             SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
             vec![1, 2, 2, 3],
             1,
@@ -300,7 +287,6 @@ mod tests {
     fn sorted_run_meta_new_accepts_empty_coverage() {
         let meta = SortedRunMeta::new(
             PathBuf::from("x.run"),
-            0,
             SeqRange::new(SeqNo(0), SeqNo(0)).unwrap(),
             vec![],
             1,
@@ -314,7 +300,6 @@ mod tests {
     fn sorted_run_meta_new_rejects_zero_page_count() {
         let result = SortedRunMeta::new(
             PathBuf::from("x.run"),
-            0,
             SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
             vec![0],
             0,

--- a/crates/minkowski-lsm/src/manifest.rs
+++ b/crates/minkowski-lsm/src/manifest.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::error::LsmError;
-use crate::types::SeqRange;
+use crate::types::{Level, SeqNo, SeqRange};
 
 /// Number of LSM levels (L0 through L3).
 pub const NUM_LEVELS: usize = 4;
@@ -87,24 +87,23 @@ impl LsmManifest {
     }
 
     /// Add a sorted run to a level.
-    pub fn add_run(&mut self, level: u8, meta: SortedRunMeta) {
-        assert!((level as usize) < NUM_LEVELS, "level out of range");
-        self.levels[level as usize].push(meta);
+    pub fn add_run(&mut self, level: Level, meta: SortedRunMeta) {
+        self.levels[level.as_index()].push(meta);
     }
 
     /// Remove a sorted run by path from a level. Returns the removed entry.
-    pub fn remove_run(&mut self, level: u8, path: &Path) -> Option<SortedRunMeta> {
-        let runs = &mut self.levels[level as usize];
+    pub fn remove_run(&mut self, level: Level, path: &Path) -> Option<SortedRunMeta> {
+        let runs = &mut self.levels[level.as_index()];
         runs.iter()
-            .position(|r| r.path == path)
+            .position(|r| r.path() == path)
             .map(|pos| runs.remove(pos))
     }
 
     /// Move a run from one level to another.
     pub fn promote_run(
         &mut self,
-        from_level: u8,
-        to_level: u8,
+        from_level: Level,
+        to_level: Level,
         path: &Path,
     ) -> Result<(), LsmError> {
         let meta = self.remove_run(from_level, path).ok_or_else(|| {
@@ -118,23 +117,23 @@ impl LsmManifest {
         Ok(())
     }
 
-    pub fn set_next_sequence(&mut self, seq: u64) {
-        self.next_sequence = seq;
+    pub fn set_next_sequence(&mut self, seq: SeqNo) {
+        self.next_sequence = seq.0;
     }
 
-    pub fn next_sequence(&self) -> u64 {
-        self.next_sequence
+    pub fn next_sequence(&self) -> SeqNo {
+        SeqNo(self.next_sequence)
     }
 
-    pub fn runs_at_level(&self, level: u8) -> &[SortedRunMeta] {
-        &self.levels[level as usize]
+    pub fn runs_at_level(&self, level: Level) -> &[SortedRunMeta] {
+        &self.levels[level.as_index()]
     }
 
     /// All tracked run file paths across all levels.
     pub fn all_run_paths(&self) -> Vec<&Path> {
         self.levels
             .iter()
-            .flat_map(|runs| runs.iter().map(|r| r.path.as_path()))
+            .flat_map(|runs| runs.iter().map(SortedRunMeta::path))
             .collect()
     }
 
@@ -152,7 +151,7 @@ impl Default for LsmManifest {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{SeqNo, SeqRange};
+    use crate::types::{Level, SeqNo, SeqRange};
 
     fn test_meta(name: &str) -> SortedRunMeta {
         SortedRunMeta::new(
@@ -168,10 +167,10 @@ mod tests {
     #[test]
     fn new_manifest_is_empty() {
         let m = LsmManifest::new();
-        for lvl in 0..NUM_LEVELS as u8 {
-            assert!(m.runs_at_level(lvl).is_empty());
+        for lvl in 0..NUM_LEVELS {
+            assert!(m.runs_at_level(Level::new(lvl as u8).unwrap()).is_empty());
         }
-        assert_eq!(m.next_sequence(), 0);
+        assert_eq!(m.next_sequence(), SeqNo(0));
         assert_eq!(m.total_runs(), 0);
     }
 
@@ -179,50 +178,54 @@ mod tests {
     fn add_run_places_at_correct_level() {
         let mut m = LsmManifest::new();
         let meta = test_meta("run_l1.sst");
-        m.add_run(1, meta.clone());
-        assert_eq!(m.runs_at_level(1), &[meta]);
-        assert!(m.runs_at_level(0).is_empty());
+        m.add_run(Level::L1, meta.clone());
+        assert_eq!(m.runs_at_level(Level::L1), &[meta]);
+        assert!(m.runs_at_level(Level::L0).is_empty());
     }
 
     #[test]
     fn remove_run_by_path() {
         let mut m = LsmManifest::new();
         let meta = test_meta("run_a.sst");
-        m.add_run(0, meta.clone());
-        let removed = m.remove_run(0, Path::new("run_a.sst"));
+        m.add_run(Level::L0, meta.clone());
+        let removed = m.remove_run(Level::L0, Path::new("run_a.sst"));
         assert_eq!(removed, Some(meta));
-        assert!(m.runs_at_level(0).is_empty());
+        assert!(m.runs_at_level(Level::L0).is_empty());
     }
 
     #[test]
     fn remove_run_missing_returns_none() {
         let mut m = LsmManifest::new();
-        assert!(m.remove_run(0, Path::new("nonexistent.sst")).is_none());
+        assert!(
+            m.remove_run(Level::L0, Path::new("nonexistent.sst"))
+                .is_none()
+        );
     }
 
     #[test]
     fn promote_run_moves_between_levels() {
         let mut m = LsmManifest::new();
         let meta = test_meta("run_x.sst");
-        m.add_run(0, meta);
-        m.promote_run(0, 1, Path::new("run_x.sst")).unwrap();
-        assert!(m.runs_at_level(0).is_empty());
-        assert_eq!(m.runs_at_level(1).len(), 1);
-        assert_eq!(m.runs_at_level(1)[0].path(), Path::new("run_x.sst"));
+        m.add_run(Level::L0, meta);
+        m.promote_run(Level::L0, Level::L1, Path::new("run_x.sst"))
+            .unwrap();
+        assert!(m.runs_at_level(Level::L0).is_empty());
+        assert_eq!(m.runs_at_level(Level::L1).len(), 1);
+        assert_eq!(m.runs_at_level(Level::L1)[0].path(), Path::new("run_x.sst"));
     }
 
     #[test]
     fn promote_run_missing_returns_error() {
         let mut m = LsmManifest::new();
-        let result = m.promote_run(0, 1, Path::new("missing.sst"));
+        let result = m.promote_run(Level::L0, Level::L1, Path::new("missing.sst"));
         assert!(matches!(result, Err(LsmError::Format(_))));
     }
 
     #[test]
     fn all_run_paths_collects_all_levels() {
         let mut m = LsmManifest::new();
-        m.add_run(0, test_meta("l0.sst"));
-        m.add_run(2, test_meta("l2.sst"));
+        m.add_run(Level::L0, test_meta("l0.sst"));
+        m.add_run(Level::L2, test_meta("l2.sst"));
         let paths = m.all_run_paths();
         assert_eq!(paths.len(), 2);
         assert!(paths.contains(&Path::new("l0.sst")));
@@ -232,17 +235,17 @@ mod tests {
     #[test]
     fn total_runs_counts_correctly() {
         let mut m = LsmManifest::new();
-        m.add_run(0, test_meta("a.sst"));
-        m.add_run(0, test_meta("b.sst"));
-        m.add_run(2, test_meta("c.sst"));
+        m.add_run(Level::L0, test_meta("a.sst"));
+        m.add_run(Level::L0, test_meta("b.sst"));
+        m.add_run(Level::L2, test_meta("c.sst"));
         assert_eq!(m.total_runs(), 3);
     }
 
     #[test]
     fn set_and_get_next_sequence() {
         let mut m = LsmManifest::new();
-        m.set_next_sequence(42);
-        assert_eq!(m.next_sequence(), 42);
+        m.set_next_sequence(SeqNo(42));
+        assert_eq!(m.next_sequence(), SeqNo(42));
     }
 
     #[test]

--- a/crates/minkowski-lsm/src/manifest.rs
+++ b/crates/minkowski-lsm/src/manifest.rs
@@ -15,12 +15,12 @@ pub struct LsmManifest {
 /// Metadata for a single sorted run file.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SortedRunMeta {
-    pub(crate) path: PathBuf,
-    pub(crate) level: u8,
-    pub(crate) sequence_range: SeqRange,
-    pub(crate) archetype_coverage: Vec<u16>,
-    pub(crate) page_count: u64,
-    pub(crate) size_bytes: u64,
+    path: PathBuf,
+    pub(crate) level: u8, // stays pub(crate); promote_run mutates it directly — Task 5 removes it
+    sequence_range: SeqRange,
+    archetype_coverage: Vec<u16>,
+    page_count: u64,
+    size_bytes: u64,
 }
 
 impl SortedRunMeta {

--- a/crates/minkowski-lsm/src/manifest.rs
+++ b/crates/minkowski-lsm/src/manifest.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::error::LsmError;
+use crate::types::SeqRange;
 
 /// Number of LSM levels (L0 through L3).
 pub const NUM_LEVELS: usize = 4;
@@ -16,7 +17,7 @@ pub struct LsmManifest {
 pub struct SortedRunMeta {
     pub(crate) path: PathBuf,
     pub(crate) level: u8,
-    pub(crate) sequence_range: (u64, u64),
+    pub(crate) sequence_range: SeqRange,
     pub(crate) archetype_coverage: Vec<u16>,
     pub(crate) page_count: u64,
     pub(crate) size_bytes: u64,
@@ -31,7 +32,7 @@ impl SortedRunMeta {
         self.level
     }
 
-    pub fn sequence_range(&self) -> (u64, u64) {
+    pub fn sequence_range(&self) -> SeqRange {
         self.sequence_range
     }
 
@@ -45,6 +46,41 @@ impl SortedRunMeta {
 
     pub fn size_bytes(&self) -> u64 {
         self.size_bytes
+    }
+
+    /// Build a `SortedRunMeta` with enforced invariants.
+    ///
+    /// Validates:
+    /// - `archetype_coverage` is strictly sorted ascending (sorted + deduped).
+    /// - `page_count` is non-zero.
+    ///
+    /// `seq_range` is already validated by `SeqRange::new`. `size_bytes` is
+    /// not validated (redundant with `page_count`; a valid run file always
+    /// has a non-empty header).
+    pub fn new(
+        path: PathBuf,
+        level: u8,
+        sequence_range: SeqRange,
+        archetype_coverage: Vec<u16>,
+        page_count: u64,
+        size_bytes: u64,
+    ) -> Result<Self, LsmError> {
+        if archetype_coverage.windows(2).any(|w| w[0] >= w[1]) {
+            return Err(LsmError::Format(
+                "archetype_coverage is not strictly sorted".to_owned(),
+            ));
+        }
+        if page_count == 0 {
+            return Err(LsmError::Format("page_count must be non-zero".to_owned()));
+        }
+        Ok(Self {
+            path,
+            level,
+            sequence_range,
+            archetype_coverage,
+            page_count,
+            size_bytes,
+        })
     }
 }
 
@@ -124,16 +160,18 @@ impl Default for LsmManifest {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::{SeqNo, SeqRange};
 
     fn test_meta(name: &str, level: u8) -> SortedRunMeta {
-        SortedRunMeta {
-            path: PathBuf::from(name),
+        SortedRunMeta::new(
+            PathBuf::from(name),
             level,
-            sequence_range: (0, 10),
-            archetype_coverage: vec![0],
-            page_count: 1,
-            size_bytes: 1024,
-        }
+            SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+            vec![0],
+            1,
+            1024,
+        )
+        .unwrap()
     }
 
     #[test]
@@ -215,5 +253,72 @@ mod tests {
         let mut m = LsmManifest::new();
         m.set_next_sequence(42);
         assert_eq!(m.next_sequence(), 42);
+    }
+
+    #[test]
+    fn sorted_run_meta_new_accepts_valid_input() {
+        let meta = SortedRunMeta::new(
+            PathBuf::from("0-10.run"),
+            0,
+            SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+            vec![0, 3, 7],
+            1,
+            1024,
+        )
+        .unwrap();
+        assert_eq!(meta.sequence_range().lo, SeqNo(0));
+        assert_eq!(meta.page_count(), 1);
+    }
+
+    #[test]
+    fn sorted_run_meta_new_rejects_unsorted_coverage() {
+        let result = SortedRunMeta::new(
+            PathBuf::from("x.run"),
+            0,
+            SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+            vec![3, 1, 2],
+            1,
+            1024,
+        );
+        assert!(matches!(result, Err(LsmError::Format(_))));
+    }
+
+    #[test]
+    fn sorted_run_meta_new_rejects_duplicated_coverage() {
+        let result = SortedRunMeta::new(
+            PathBuf::from("x.run"),
+            0,
+            SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+            vec![1, 2, 2, 3],
+            1,
+            1024,
+        );
+        assert!(matches!(result, Err(LsmError::Format(_))));
+    }
+
+    #[test]
+    fn sorted_run_meta_new_accepts_empty_coverage() {
+        let meta = SortedRunMeta::new(
+            PathBuf::from("x.run"),
+            0,
+            SeqRange::new(SeqNo(0), SeqNo(0)).unwrap(),
+            vec![],
+            1,
+            1024,
+        );
+        assert!(meta.is_ok());
+    }
+
+    #[test]
+    fn sorted_run_meta_new_rejects_zero_page_count() {
+        let result = SortedRunMeta::new(
+            PathBuf::from("x.run"),
+            0,
+            SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+            vec![0],
+            0,
+            1024,
+        );
+        assert!(matches!(result, Err(LsmError::Format(_))));
     }
 }

--- a/crates/minkowski-lsm/src/manifest.rs
+++ b/crates/minkowski-lsm/src/manifest.rs
@@ -266,7 +266,7 @@ mod tests {
             1024,
         )
         .unwrap();
-        assert_eq!(meta.sequence_range().lo, SeqNo(0));
+        assert_eq!(meta.sequence_range().lo(), SeqNo(0));
         assert_eq!(meta.page_count(), 1);
     }
 
@@ -305,8 +305,9 @@ mod tests {
             vec![],
             1,
             1024,
-        );
-        assert!(meta.is_ok());
+        )
+        .unwrap();
+        assert_eq!(meta.archetype_coverage().len(), 0);
     }
 
     #[test]

--- a/crates/minkowski-lsm/src/manifest_log.rs
+++ b/crates/minkowski-lsm/src/manifest_log.rs
@@ -254,7 +254,6 @@ fn decode_entry(data: &[u8]) -> Result<ManifestEntry, LsmError> {
 
             let meta = SortedRunMeta::new(
                 path,
-                level,
                 SeqRange::new(SeqNo(seq_lo), SeqNo(seq_hi))?,
                 coverage,
                 page_count,
@@ -313,7 +312,6 @@ fn decode_entry(data: &[u8]) -> Result<ManifestEntry, LsmError> {
 
             let meta = SortedRunMeta::new(
                 path,
-                level,
                 SeqRange::new(SeqNo(seq_lo), SeqNo(seq_hi))?,
                 coverage,
                 page_count,
@@ -473,7 +471,6 @@ mod tests {
     fn test_meta(name: &str) -> SortedRunMeta {
         SortedRunMeta::new(
             PathBuf::from(name),
-            0,
             SeqRange::new(SeqNo(10), SeqNo(20)).unwrap(),
             vec![0, 3, 7],
             42,
@@ -484,8 +481,7 @@ mod tests {
 
     #[test]
     fn encode_decode_add_run() {
-        let mut meta = test_meta("10-20.run");
-        meta.level = 1;
+        let meta = test_meta("10-20.run");
         let entry = ManifestEntry::AddRun { level: 1, meta };
         let payload = encode_entry(&entry).unwrap();
         let decoded = decode_entry(&payload).unwrap();
@@ -527,8 +523,7 @@ mod tests {
 
     #[test]
     fn encode_decode_add_run_and_sequence() {
-        let mut meta = test_meta("atomic.run");
-        meta.level = 0;
+        let meta = test_meta("atomic.run");
         let entry = ManifestEntry::AddRunAndSequence {
             level: 0,
             meta,

--- a/crates/minkowski-lsm/src/manifest_log.rs
+++ b/crates/minkowski-lsm/src/manifest_log.rs
@@ -179,12 +179,12 @@ fn encode_entry(entry: &ManifestEntry) -> Result<Vec<u8>, LsmError> {
         ManifestEntry::AddRun { level, meta } => {
             buf.push(TAG_ADD_RUN);
             buf.push(*level);
-            encode_path(&mut buf, &meta.path)?;
-            buf.extend_from_slice(&meta.sequence_range.lo.0.to_le_bytes());
-            buf.extend_from_slice(&meta.sequence_range.hi.0.to_le_bytes());
-            encode_coverage(&mut buf, &meta.archetype_coverage)?;
-            buf.extend_from_slice(&meta.page_count.to_le_bytes());
-            buf.extend_from_slice(&meta.size_bytes.to_le_bytes());
+            encode_path(&mut buf, meta.path())?;
+            buf.extend_from_slice(&meta.sequence_range().lo().0.to_le_bytes());
+            buf.extend_from_slice(&meta.sequence_range().hi().0.to_le_bytes());
+            encode_coverage(&mut buf, meta.archetype_coverage())?;
+            buf.extend_from_slice(&meta.page_count().to_le_bytes());
+            buf.extend_from_slice(&meta.size_bytes().to_le_bytes());
         }
         ManifestEntry::RemoveRun { level, path } => {
             buf.push(TAG_REMOVE_RUN);
@@ -212,12 +212,12 @@ fn encode_entry(entry: &ManifestEntry) -> Result<Vec<u8>, LsmError> {
         } => {
             buf.push(TAG_ADD_RUN_AND_SEQUENCE);
             buf.push(*level);
-            encode_path(&mut buf, &meta.path)?;
-            buf.extend_from_slice(&meta.sequence_range.lo.0.to_le_bytes());
-            buf.extend_from_slice(&meta.sequence_range.hi.0.to_le_bytes());
-            encode_coverage(&mut buf, &meta.archetype_coverage)?;
-            buf.extend_from_slice(&meta.page_count.to_le_bytes());
-            buf.extend_from_slice(&meta.size_bytes.to_le_bytes());
+            encode_path(&mut buf, meta.path())?;
+            buf.extend_from_slice(&meta.sequence_range().lo().0.to_le_bytes());
+            buf.extend_from_slice(&meta.sequence_range().hi().0.to_le_bytes());
+            encode_coverage(&mut buf, meta.archetype_coverage())?;
+            buf.extend_from_slice(&meta.page_count().to_le_bytes());
+            buf.extend_from_slice(&meta.size_bytes().to_le_bytes());
             buf.extend_from_slice(&next_sequence.to_le_bytes());
         }
     }
@@ -653,7 +653,7 @@ mod tests {
         .unwrap();
         log.append(&ManifestEntry::RemoveRun {
             level: 0,
-            path: meta.path,
+            path: meta.path().to_path_buf(),
         })
         .unwrap();
 

--- a/crates/minkowski-lsm/src/manifest_log.rs
+++ b/crates/minkowski-lsm/src/manifest_log.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 
 use crate::error::LsmError;
 use crate::manifest::{LsmManifest, SortedRunMeta};
+use crate::types::{SeqNo, SeqRange};
 
 // ── Entry type ──────────────────────────────────────────────────────────────
 
@@ -179,8 +180,8 @@ fn encode_entry(entry: &ManifestEntry) -> Result<Vec<u8>, LsmError> {
             buf.push(TAG_ADD_RUN);
             buf.push(*level);
             encode_path(&mut buf, &meta.path)?;
-            buf.extend_from_slice(&meta.sequence_range.0.to_le_bytes());
-            buf.extend_from_slice(&meta.sequence_range.1.to_le_bytes());
+            buf.extend_from_slice(&meta.sequence_range.lo.0.to_le_bytes());
+            buf.extend_from_slice(&meta.sequence_range.hi.0.to_le_bytes());
             encode_coverage(&mut buf, &meta.archetype_coverage)?;
             buf.extend_from_slice(&meta.page_count.to_le_bytes());
             buf.extend_from_slice(&meta.size_bytes.to_le_bytes());
@@ -212,8 +213,8 @@ fn encode_entry(entry: &ManifestEntry) -> Result<Vec<u8>, LsmError> {
             buf.push(TAG_ADD_RUN_AND_SEQUENCE);
             buf.push(*level);
             encode_path(&mut buf, &meta.path)?;
-            buf.extend_from_slice(&meta.sequence_range.0.to_le_bytes());
-            buf.extend_from_slice(&meta.sequence_range.1.to_le_bytes());
+            buf.extend_from_slice(&meta.sequence_range.lo.0.to_le_bytes());
+            buf.extend_from_slice(&meta.sequence_range.hi.0.to_le_bytes());
             encode_coverage(&mut buf, &meta.archetype_coverage)?;
             buf.extend_from_slice(&meta.page_count.to_le_bytes());
             buf.extend_from_slice(&meta.size_bytes.to_le_bytes());
@@ -251,17 +252,15 @@ fn decode_entry(data: &[u8]) -> Result<ManifestEntry, LsmError> {
             let page_count = read_u64_le(data, &mut offset)?;
             let size_bytes = read_u64_le(data, &mut offset)?;
 
-            Ok(ManifestEntry::AddRun {
+            let meta = SortedRunMeta::new(
+                path,
                 level,
-                meta: SortedRunMeta {
-                    path,
-                    level,
-                    sequence_range: (seq_lo, seq_hi),
-                    archetype_coverage: coverage,
-                    page_count,
-                    size_bytes,
-                },
-            })
+                SeqRange::new(SeqNo(seq_lo), SeqNo(seq_hi))?,
+                coverage,
+                page_count,
+                size_bytes,
+            )?;
+            Ok(ManifestEntry::AddRun { level, meta })
         }
         TAG_REMOVE_RUN => {
             if offset >= data.len() {
@@ -312,16 +311,17 @@ fn decode_entry(data: &[u8]) -> Result<ManifestEntry, LsmError> {
             let size_bytes = read_u64_le(data, &mut offset)?;
             let next_sequence = read_u64_le(data, &mut offset)?;
 
+            let meta = SortedRunMeta::new(
+                path,
+                level,
+                SeqRange::new(SeqNo(seq_lo), SeqNo(seq_hi))?,
+                coverage,
+                page_count,
+                size_bytes,
+            )?;
             Ok(ManifestEntry::AddRunAndSequence {
                 level,
-                meta: SortedRunMeta {
-                    path,
-                    level,
-                    sequence_range: (seq_lo, seq_hi),
-                    archetype_coverage: coverage,
-                    page_count,
-                    size_bytes,
-                },
+                meta,
                 next_sequence,
             })
         }
@@ -471,14 +471,15 @@ mod tests {
     use super::*;
 
     fn test_meta(name: &str) -> SortedRunMeta {
-        SortedRunMeta {
-            path: PathBuf::from(name),
-            level: 0,
-            sequence_range: (10, 20),
-            archetype_coverage: vec![0, 3, 7],
-            page_count: 42,
-            size_bytes: 8192,
-        }
+        SortedRunMeta::new(
+            PathBuf::from(name),
+            0,
+            SeqRange::new(SeqNo(10), SeqNo(20)).unwrap(),
+            vec![0, 3, 7],
+            42,
+            8192,
+        )
+        .unwrap()
     }
 
     #[test]

--- a/crates/minkowski-lsm/src/manifest_log.rs
+++ b/crates/minkowski-lsm/src/manifest_log.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 
 use crate::error::LsmError;
 use crate::manifest::{LsmManifest, SortedRunMeta};
-use crate::types::{SeqNo, SeqRange};
+use crate::types::{Level, SeqNo, SeqRange};
 
 // ── Entry type ──────────────────────────────────────────────────────────────
 
@@ -18,29 +18,29 @@ use crate::types::{SeqNo, SeqRange};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ManifestEntry {
     AddRun {
-        level: u8,
+        level: Level,
         meta: SortedRunMeta,
     },
     RemoveRun {
-        level: u8,
+        level: Level,
         path: PathBuf,
     },
     PromoteRun {
-        from_level: u8,
-        to_level: u8,
+        from_level: Level,
+        to_level: Level,
         path: PathBuf,
     },
     SetSequence {
-        next_sequence: u64,
+        next_sequence: SeqNo,
     },
     /// Atomic combination of `AddRun` + `SetSequence`.
     ///
     /// A single frame ensures that a crash can never leave the manifest with a
     /// new run recorded but the sequence pointer still at its old value.
     AddRunAndSequence {
-        level: u8,
+        level: Level,
         meta: SortedRunMeta,
-        next_sequence: u64,
+        next_sequence: SeqNo,
     },
 }
 
@@ -178,7 +178,7 @@ fn encode_entry(entry: &ManifestEntry) -> Result<Vec<u8>, LsmError> {
     match entry {
         ManifestEntry::AddRun { level, meta } => {
             buf.push(TAG_ADD_RUN);
-            buf.push(*level);
+            buf.push(level.as_u8());
             encode_path(&mut buf, meta.path())?;
             buf.extend_from_slice(&meta.sequence_range().lo().0.to_le_bytes());
             buf.extend_from_slice(&meta.sequence_range().hi().0.to_le_bytes());
@@ -188,7 +188,7 @@ fn encode_entry(entry: &ManifestEntry) -> Result<Vec<u8>, LsmError> {
         }
         ManifestEntry::RemoveRun { level, path } => {
             buf.push(TAG_REMOVE_RUN);
-            buf.push(*level);
+            buf.push(level.as_u8());
             encode_path(&mut buf, path)?;
         }
         ManifestEntry::PromoteRun {
@@ -197,13 +197,13 @@ fn encode_entry(entry: &ManifestEntry) -> Result<Vec<u8>, LsmError> {
             path,
         } => {
             buf.push(TAG_PROMOTE_RUN);
-            buf.push(*from_level);
-            buf.push(*to_level);
+            buf.push(from_level.as_u8());
+            buf.push(to_level.as_u8());
             encode_path(&mut buf, path)?;
         }
         ManifestEntry::SetSequence { next_sequence } => {
             buf.push(TAG_SET_SEQUENCE);
-            buf.extend_from_slice(&next_sequence.to_le_bytes());
+            buf.extend_from_slice(&next_sequence.0.to_le_bytes());
         }
         ManifestEntry::AddRunAndSequence {
             level,
@@ -211,14 +211,14 @@ fn encode_entry(entry: &ManifestEntry) -> Result<Vec<u8>, LsmError> {
             next_sequence,
         } => {
             buf.push(TAG_ADD_RUN_AND_SEQUENCE);
-            buf.push(*level);
+            buf.push(level.as_u8());
             encode_path(&mut buf, meta.path())?;
             buf.extend_from_slice(&meta.sequence_range().lo().0.to_le_bytes());
             buf.extend_from_slice(&meta.sequence_range().hi().0.to_le_bytes());
             encode_coverage(&mut buf, meta.archetype_coverage())?;
             buf.extend_from_slice(&meta.page_count().to_le_bytes());
             buf.extend_from_slice(&meta.size_bytes().to_le_bytes());
-            buf.extend_from_slice(&next_sequence.to_le_bytes());
+            buf.extend_from_slice(&next_sequence.0.to_le_bytes());
         }
     }
     Ok(buf)
@@ -236,8 +236,10 @@ fn decode_entry(data: &[u8]) -> Result<ManifestEntry, LsmError> {
             if offset >= data.len() {
                 return Err(LsmError::Format("truncated AddRun".to_owned()));
             }
-            let level = data[offset];
+            let level_byte = data[offset];
             offset += 1;
+            let level = Level::new(level_byte)
+                .ok_or_else(|| LsmError::Format(format!("invalid level {level_byte}")))?;
             let path = decode_path(data, &mut offset)?;
             let seq_lo = read_u64_le(data, &mut offset)?;
             let seq_hi = read_u64_le(data, &mut offset)?;
@@ -265,8 +267,10 @@ fn decode_entry(data: &[u8]) -> Result<ManifestEntry, LsmError> {
             if offset >= data.len() {
                 return Err(LsmError::Format("truncated RemoveRun".to_owned()));
             }
-            let level = data[offset];
+            let level_byte = data[offset];
             offset += 1;
+            let level = Level::new(level_byte)
+                .ok_or_else(|| LsmError::Format(format!("invalid level {level_byte}")))?;
             let path = decode_path(data, &mut offset)?;
             Ok(ManifestEntry::RemoveRun { level, path })
         }
@@ -274,10 +278,14 @@ fn decode_entry(data: &[u8]) -> Result<ManifestEntry, LsmError> {
             if offset + 2 > data.len() {
                 return Err(LsmError::Format("truncated PromoteRun".to_owned()));
             }
-            let from_level = data[offset];
+            let from_byte = data[offset];
             offset += 1;
-            let to_level = data[offset];
+            let to_byte = data[offset];
             offset += 1;
+            let from_level = Level::new(from_byte)
+                .ok_or_else(|| LsmError::Format(format!("invalid level {from_byte}")))?;
+            let to_level = Level::new(to_byte)
+                .ok_or_else(|| LsmError::Format(format!("invalid level {to_byte}")))?;
             let path = decode_path(data, &mut offset)?;
             Ok(ManifestEntry::PromoteRun {
                 from_level,
@@ -286,15 +294,17 @@ fn decode_entry(data: &[u8]) -> Result<ManifestEntry, LsmError> {
             })
         }
         TAG_SET_SEQUENCE => {
-            let next_sequence = read_u64_le(data, &mut offset)?;
+            let next_sequence = SeqNo(read_u64_le(data, &mut offset)?);
             Ok(ManifestEntry::SetSequence { next_sequence })
         }
         TAG_ADD_RUN_AND_SEQUENCE => {
             if offset >= data.len() {
                 return Err(LsmError::Format("truncated AddRunAndSequence".to_owned()));
             }
-            let level = data[offset];
+            let level_byte = data[offset];
             offset += 1;
+            let level = Level::new(level_byte)
+                .ok_or_else(|| LsmError::Format(format!("invalid level {level_byte}")))?;
             let path = decode_path(data, &mut offset)?;
             let seq_lo = read_u64_le(data, &mut offset)?;
             let seq_hi = read_u64_le(data, &mut offset)?;
@@ -308,7 +318,7 @@ fn decode_entry(data: &[u8]) -> Result<ManifestEntry, LsmError> {
             }
             let page_count = read_u64_le(data, &mut offset)?;
             let size_bytes = read_u64_le(data, &mut offset)?;
-            let next_sequence = read_u64_le(data, &mut offset)?;
+            let next_sequence = SeqNo(read_u64_le(data, &mut offset)?);
 
             let meta = SortedRunMeta::new(
                 path,
@@ -467,6 +477,7 @@ mod tests {
     use std::fs;
 
     use super::*;
+    use crate::types::Level;
 
     fn test_meta(name: &str) -> SortedRunMeta {
         SortedRunMeta::new(
@@ -482,7 +493,10 @@ mod tests {
     #[test]
     fn encode_decode_add_run() {
         let meta = test_meta("10-20.run");
-        let entry = ManifestEntry::AddRun { level: 1, meta };
+        let entry = ManifestEntry::AddRun {
+            level: Level::L1,
+            meta,
+        };
         let payload = encode_entry(&entry).unwrap();
         let decoded = decode_entry(&payload).unwrap();
         assert_eq!(entry, decoded);
@@ -491,7 +505,7 @@ mod tests {
     #[test]
     fn encode_decode_remove_run() {
         let entry = ManifestEntry::RemoveRun {
-            level: 2,
+            level: Level::L2,
             path: PathBuf::from("old.run"),
         };
         let payload = encode_entry(&entry).unwrap();
@@ -502,8 +516,8 @@ mod tests {
     #[test]
     fn encode_decode_promote_run() {
         let entry = ManifestEntry::PromoteRun {
-            from_level: 0,
-            to_level: 1,
+            from_level: Level::L0,
+            to_level: Level::L1,
             path: PathBuf::from("promoted.run"),
         };
         let payload = encode_entry(&entry).unwrap();
@@ -514,7 +528,7 @@ mod tests {
     #[test]
     fn encode_decode_set_sequence() {
         let entry = ManifestEntry::SetSequence {
-            next_sequence: 12345,
+            next_sequence: SeqNo(12345),
         };
         let payload = encode_entry(&entry).unwrap();
         let decoded = decode_entry(&payload).unwrap();
@@ -525,9 +539,9 @@ mod tests {
     fn encode_decode_add_run_and_sequence() {
         let meta = test_meta("atomic.run");
         let entry = ManifestEntry::AddRunAndSequence {
-            level: 0,
+            level: Level::L0,
             meta,
-            next_sequence: 99,
+            next_sequence: SeqNo(99),
         };
         let payload = encode_entry(&entry).unwrap();
         let decoded = decode_entry(&payload).unwrap();
@@ -541,16 +555,19 @@ mod tests {
 
         let mut log = ManifestLog::create(&path).unwrap();
         log.append(&ManifestEntry::AddRunAndSequence {
-            level: 0,
+            level: Level::L0,
             meta: test_meta("atomic.run"),
-            next_sequence: 42,
+            next_sequence: SeqNo(42),
         })
         .unwrap();
 
         let manifest = ManifestLog::replay(&path).unwrap();
         assert_eq!(manifest.total_runs(), 1);
-        assert_eq!(manifest.next_sequence(), 42);
-        assert_eq!(manifest.runs_at_level(0)[0].path(), Path::new("atomic.run"));
+        assert_eq!(manifest.next_sequence(), SeqNo(42));
+        assert_eq!(
+            manifest.runs_at_level(Level::L0)[0].path(),
+            Path::new("atomic.run")
+        );
     }
 
     #[test]
@@ -614,7 +631,7 @@ mod tests {
         // File doesn't exist → empty manifest.
         let manifest = ManifestLog::replay(&path).unwrap();
         assert_eq!(manifest.total_runs(), 0);
-        assert_eq!(manifest.next_sequence(), 0);
+        assert_eq!(manifest.next_sequence(), SeqNo(0));
     }
 
     #[test]
@@ -625,13 +642,16 @@ mod tests {
         let mut log = ManifestLog::create(&path).unwrap();
         for i in 0..3 {
             let meta = test_meta(&format!("{i}.run"));
-            log.append(&ManifestEntry::AddRun { level: 0, meta })
-                .unwrap();
+            log.append(&ManifestEntry::AddRun {
+                level: Level::L0,
+                meta,
+            })
+            .unwrap();
         }
 
         let manifest = ManifestLog::replay(&path).unwrap();
         assert_eq!(manifest.total_runs(), 3);
-        assert_eq!(manifest.runs_at_level(0).len(), 3);
+        assert_eq!(manifest.runs_at_level(Level::L0).len(), 3);
     }
 
     #[test]
@@ -642,12 +662,12 @@ mod tests {
         let mut log = ManifestLog::create(&path).unwrap();
         let meta = test_meta("ephemeral.run");
         log.append(&ManifestEntry::AddRun {
-            level: 0,
+            level: Level::L0,
             meta: meta.clone(),
         })
         .unwrap();
         log.append(&ManifestEntry::RemoveRun {
-            level: 0,
+            level: Level::L0,
             path: meta.path().to_path_buf(),
         })
         .unwrap();
@@ -664,12 +684,12 @@ mod tests {
         // Write 2 good entries.
         let mut log = ManifestLog::create(&path).unwrap();
         log.append(&ManifestEntry::AddRun {
-            level: 0,
+            level: Level::L0,
             meta: test_meta("a.run"),
         })
         .unwrap();
         log.append(&ManifestEntry::AddRun {
-            level: 0,
+            level: Level::L0,
             meta: test_meta("b.run"),
         })
         .unwrap();
@@ -691,7 +711,7 @@ mod tests {
 
         // Should be able to append after recovery.
         log2.append(&ManifestEntry::AddRun {
-            level: 1,
+            level: Level::L1,
             meta: test_meta("c.run"),
         })
         .unwrap();

--- a/crates/minkowski-lsm/src/manifest_ops.rs
+++ b/crates/minkowski-lsm/src/manifest_ops.rs
@@ -33,7 +33,6 @@ pub fn flush_and_record(
 
     let meta = SortedRunMeta::new(
         path.clone(),
-        0,
         reader.sequence_range(),
         archetype_coverage,
         reader.page_count(),
@@ -162,7 +161,6 @@ mod tests {
             0,
             SortedRunMeta::new(
                 dir.path().join("0-10.run"),
-                0,
                 SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
                 vec![0],
                 1,

--- a/crates/minkowski-lsm/src/manifest_ops.rs
+++ b/crates/minkowski-lsm/src/manifest_ops.rs
@@ -10,6 +10,7 @@ use crate::error::LsmError;
 use crate::manifest::{LsmManifest, SortedRunMeta};
 use crate::manifest_log::{ManifestEntry, ManifestLog};
 use crate::reader::SortedRunReader;
+use crate::types::{Level, SeqNo};
 use crate::writer::flush;
 
 /// Flush dirty pages and record the new sorted run in the manifest.
@@ -43,13 +44,13 @@ pub fn flush_and_record(
     // A single atomic entry ensures a crash can never leave the manifest with
     // a new run recorded but the sequence pointer still at its old value.
     log.append(&ManifestEntry::AddRunAndSequence {
-        level: 0,
+        level: Level::L0,
         meta: meta.clone(),
-        next_sequence: sequence_range.1,
+        next_sequence: SeqNo(sequence_range.1),
     })?;
 
-    manifest.add_run(0, meta);
-    manifest.set_next_sequence(sequence_range.1);
+    manifest.add_run(Level::L0, meta);
+    manifest.set_next_sequence(SeqNo(sequence_range.1));
 
     Ok(Some(path))
 }
@@ -97,7 +98,7 @@ pub fn cleanup_orphans(dir: &Path, manifest: &LsmManifest) -> Result<usize, LsmE
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{SeqNo, SeqRange};
+    use crate::types::{Level, SeqNo, SeqRange};
 
     #[derive(Clone, Copy)]
     #[expect(dead_code)]
@@ -124,8 +125,8 @@ mod tests {
             flush_and_record(&world, (0, 10), &mut manifest, &mut log, dir.path()).unwrap();
         assert!(result.is_some());
         assert_eq!(manifest.total_runs(), 1);
-        assert_eq!(manifest.next_sequence(), 10);
-        assert_eq!(manifest.runs_at_level(0).len(), 1);
+        assert_eq!(manifest.next_sequence(), SeqNo(10));
+        assert_eq!(manifest.runs_at_level(Level::L0).len(), 1);
     }
 
     #[test]
@@ -158,7 +159,7 @@ mod tests {
         // Manifest only knows about 0-10.run.
         let mut manifest = LsmManifest::new();
         manifest.add_run(
-            0,
+            Level::L0,
             SortedRunMeta::new(
                 dir.path().join("0-10.run"),
                 SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),

--- a/crates/minkowski-lsm/src/manifest_ops.rs
+++ b/crates/minkowski-lsm/src/manifest_ops.rs
@@ -31,14 +31,14 @@ pub fn flush_and_record(
     let file_size = fs::metadata(&path)?.len();
     let archetype_coverage = reader.archetype_ids();
 
-    let meta = SortedRunMeta {
-        path: path.clone(),
-        level: 0,
-        sequence_range: reader.sequence_range(),
+    let meta = SortedRunMeta::new(
+        path.clone(),
+        0,
+        reader.sequence_range(),
         archetype_coverage,
-        page_count: reader.page_count(),
-        size_bytes: file_size,
-    };
+        reader.page_count(),
+        file_size,
+    )?;
 
     // Persist to log first, then update in-memory state.
     // A single atomic entry ensures a crash can never leave the manifest with
@@ -98,6 +98,7 @@ pub fn cleanup_orphans(dir: &Path, manifest: &LsmManifest) -> Result<usize, LsmE
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::{SeqNo, SeqRange};
 
     #[derive(Clone, Copy)]
     #[expect(dead_code)]
@@ -159,14 +160,15 @@ mod tests {
         let mut manifest = LsmManifest::new();
         manifest.add_run(
             0,
-            SortedRunMeta {
-                path: dir.path().join("0-10.run"),
-                level: 0,
-                sequence_range: (0, 10),
-                archetype_coverage: vec![0],
-                page_count: 1,
-                size_bytes: 4,
-            },
+            SortedRunMeta::new(
+                dir.path().join("0-10.run"),
+                0,
+                SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+                vec![0],
+                1,
+                4,
+            )
+            .unwrap(),
         );
 
         let deleted = cleanup_orphans(dir.path(), &manifest).unwrap();

--- a/crates/minkowski-lsm/src/reader.rs
+++ b/crates/minkowski-lsm/src/reader.rs
@@ -476,6 +476,52 @@ mod tests {
     }
 
     #[test]
+    fn open_rejects_header_with_lo_greater_than_hi() {
+        let (_dir, path, _world) = flush_world_with_pos(3);
+
+        // Corrupt sequence_lo / sequence_hi so that lo > hi, then fix up
+        // both CRCs so the file passes magic, version, and CRC checks but
+        // fails the SeqRange::new validation inside validate_and_parse.
+        //
+        // Header layout (all fields little-endian):
+        //   bytes  0..8  : magic
+        //   bytes  8..12 : version
+        //   bytes 12..16 : schema_count
+        //   bytes 16..24 : page_count
+        //   bytes 24..32 : sequence_lo  ← overwrite to 9999
+        //   bytes 32..40 : sequence_hi  ← overwrite to 1 (so lo > hi)
+        //   bytes 40..44 : header_crc32  (covers bytes 0..40)
+        //   bytes 44..64 : reserved
+        let mut data = std::fs::read(&path).unwrap();
+
+        // Write lo = 9999, hi = 1 — clearly lo > hi.
+        data[24..32].copy_from_slice(&9999u64.to_le_bytes());
+        data[32..40].copy_from_slice(&1u64.to_le_bytes());
+
+        // Recompute header CRC (covers bytes 0..40).
+        let new_header_crc = crc32fast::hash(&data[..40]);
+        data[40..44].copy_from_slice(&new_header_crc.to_le_bytes());
+
+        // Recompute total CRC (entire file with total_crc32 field zeroed).
+        // Footer is the last 64 bytes; total_crc32 is at footer_offset + 32.
+        let file_len = data.len();
+        let total_crc32_offset = (file_len - 64) + 32;
+        data[total_crc32_offset..total_crc32_offset + 4].copy_from_slice(&[0, 0, 0, 0]);
+        let new_total_crc = crc32fast::hash(&data);
+        data[total_crc32_offset..total_crc32_offset + 4]
+            .copy_from_slice(&new_total_crc.to_le_bytes());
+
+        std::fs::write(&path, &data).unwrap();
+
+        let result = SortedRunReader::open(&path);
+        assert!(
+            matches!(result, Err(LsmError::Format(_))),
+            "expected Format error for header with lo > hi, got: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
     fn multi_component_index_lookup() {
         let mut world = World::new();
         for i in 0..10 {

--- a/crates/minkowski-lsm/src/reader.rs
+++ b/crates/minkowski-lsm/src/reader.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use crate::error::LsmError;
 use crate::format::*;
 use crate::schema::SchemaSection;
+use crate::types::{SeqNo, SeqRange};
 
 /// A reference to a page within a sorted run.
 pub struct PageRef<'a> {
@@ -57,7 +58,7 @@ pub struct SortedRunReader {
     data: MappedData,
     schema: SchemaSection,
     index: Vec<IndexEntry>,
-    sequence_range: (u64, u64),
+    sequence_range: SeqRange,
     page_count: u64,
 }
 
@@ -68,7 +69,7 @@ const MIN_FILE_SIZE: usize = 128;
 struct ParsedMetadata {
     schema: SchemaSection,
     index: Vec<IndexEntry>,
-    sequence_range: (u64, u64),
+    sequence_range: SeqRange,
     page_count: u64,
 }
 
@@ -112,7 +113,13 @@ fn validate_and_parse(buf: &[u8]) -> Result<ParsedMetadata, LsmError> {
     }
 
     let schema_count = header.schema_count;
-    let sequence_range = (header.sequence_lo, header.sequence_hi);
+    let sequence_range = SeqRange::new(SeqNo(header.sequence_lo), SeqNo(header.sequence_hi))
+        .map_err(|_| {
+            LsmError::Format(format!(
+                "header sequence range invalid: lo={} > hi={}",
+                header.sequence_lo, header.sequence_hi
+            ))
+        })?;
     let page_count = header.page_count;
 
     // 5. Read footer (last 64 bytes).
@@ -286,7 +293,7 @@ impl SortedRunReader {
     }
 
     /// WAL sequence range covered by this sorted run.
-    pub fn sequence_range(&self) -> (u64, u64) {
+    pub fn sequence_range(&self) -> SeqRange {
         self.sequence_range
     }
 
@@ -381,7 +388,10 @@ mod tests {
         let (_dir, path, _world) = flush_world_with_pos(5);
         let reader = SortedRunReader::open(&path).unwrap();
 
-        assert_eq!(reader.sequence_range(), (10, 20));
+        assert_eq!(
+            reader.sequence_range(),
+            SeqRange::new(SeqNo(10), SeqNo(20)).unwrap()
+        );
         assert_eq!(reader.schema().len(), 1); // Pos only
         assert!(reader.page_count() > 0);
         assert!(reader.index_len() > 0);

--- a/crates/minkowski-lsm/src/types.rs
+++ b/crates/minkowski-lsm/src/types.rs
@@ -1,0 +1,151 @@
+//! Invariant-carrying newtype primitives shared across the manifest.
+
+use std::fmt;
+
+use crate::error::LsmError;
+use crate::manifest::NUM_LEVELS;
+
+/// A WAL sequence number.
+///
+/// Raw `u64` arithmetic on sequence numbers is disallowed by the type
+/// (no `Add`/`Sub` impls) because sequences are identities, not sizes.
+/// Callers that need "next seq" do so explicitly: `SeqNo(x.0 + 1)`.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default)]
+pub struct SeqNo(pub u64);
+
+impl From<u64> for SeqNo {
+    fn from(v: u64) -> Self {
+        Self(v)
+    }
+}
+
+impl From<SeqNo> for u64 {
+    fn from(s: SeqNo) -> Self {
+        s.0
+    }
+}
+
+impl fmt::Display for SeqNo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A half-open sequence range `[lo, hi)`.
+///
+/// Construction enforces `lo <= hi`. `hi == lo` represents an empty
+/// range (syntactically allowed, not currently produced by any code path).
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct SeqRange {
+    pub lo: SeqNo,
+    pub hi: SeqNo,
+}
+
+impl SeqRange {
+    pub fn new(lo: SeqNo, hi: SeqNo) -> Result<Self, LsmError> {
+        if lo > hi {
+            return Err(LsmError::Format(format!("SeqRange: lo ({lo}) > hi ({hi})")));
+        }
+        Ok(Self { lo, hi })
+    }
+}
+
+/// An LSM level index. Construction enforces `< NUM_LEVELS`.
+///
+/// The bounds check lives in exactly one place (`Level::new`); all
+/// other code sites trust the invariant once they hold a `Level`.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct Level(u8);
+
+impl Level {
+    pub const L0: Level = Level(0);
+    pub const L1: Level = Level(1);
+    pub const L2: Level = Level(2);
+    pub const L3: Level = Level(3);
+
+    pub fn new(level: u8) -> Option<Self> {
+        if (level as usize) < NUM_LEVELS {
+            Some(Self(level))
+        } else {
+            None
+        }
+    }
+
+    pub fn as_u8(self) -> u8 {
+        self.0
+    }
+
+    pub fn as_index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+impl fmt::Display for Level {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "L{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seqno_display_matches_inner_u64() {
+        assert_eq!(SeqNo(42).to_string(), "42");
+    }
+
+    #[test]
+    fn seqno_ordering_matches_u64() {
+        assert!(SeqNo(1) < SeqNo(2));
+        assert_eq!(SeqNo(5), SeqNo(5));
+    }
+
+    #[test]
+    fn seqrange_rejects_lo_greater_than_hi() {
+        let result = SeqRange::new(SeqNo(10), SeqNo(5));
+        assert!(matches!(result, Err(LsmError::Format(_))));
+    }
+
+    #[test]
+    fn seqrange_accepts_lo_equal_to_hi() {
+        let r = SeqRange::new(SeqNo(5), SeqNo(5)).unwrap();
+        assert_eq!(r.lo, SeqNo(5));
+        assert_eq!(r.hi, SeqNo(5));
+    }
+
+    #[test]
+    fn seqrange_accepts_lo_less_than_hi() {
+        let r = SeqRange::new(SeqNo(0), SeqNo(10)).unwrap();
+        assert_eq!(r.lo.0, 0);
+        assert_eq!(r.hi.0, 10);
+    }
+
+    #[test]
+    fn level_rejects_values_at_or_above_num_levels() {
+        assert!(Level::new(NUM_LEVELS as u8).is_none());
+        assert!(Level::new(255).is_none());
+    }
+
+    #[test]
+    fn level_accepts_values_below_num_levels() {
+        for i in 0..NUM_LEVELS {
+            assert!(Level::new(i as u8).is_some());
+        }
+    }
+
+    #[test]
+    fn level_consts_match_new() {
+        assert_eq!(Level::L0, Level::new(0).unwrap());
+        assert_eq!(Level::L1, Level::new(1).unwrap());
+        assert_eq!(Level::L2, Level::new(2).unwrap());
+        assert_eq!(Level::L3, Level::new(3).unwrap());
+    }
+
+    #[test]
+    fn level_as_u8_and_as_index_agree() {
+        let l = Level::L2;
+        assert_eq!(l.as_u8(), 2);
+        assert_eq!(l.as_index(), 2);
+    }
+}

--- a/crates/minkowski-lsm/src/types.rs
+++ b/crates/minkowski-lsm/src/types.rs
@@ -33,15 +33,15 @@ impl fmt::Display for SeqNo {
 
 /// A half-open sequence range `[lo, hi)`.
 ///
-/// Construction enforces `lo <= hi`. `hi == lo` represents an empty
-/// range (syntactically allowed, not currently produced by any code path).
+/// Construction enforces `lo <= hi`. `hi == lo` represents an empty range.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct SeqRange {
-    pub(crate) lo: SeqNo,
-    pub(crate) hi: SeqNo,
+    lo: SeqNo,
+    hi: SeqNo,
 }
 
 impl SeqRange {
+    /// Build a half-open range. Returns `Err(LsmError::Format)` if `lo > hi`.
     pub fn new(lo: SeqNo, hi: SeqNo) -> Result<Self, LsmError> {
         if lo > hi {
             return Err(LsmError::Format(format!("SeqRange: lo ({lo}) > hi ({hi})")));
@@ -73,6 +73,7 @@ impl Level {
     pub const L2: Level = Level(2);
     pub const L3: Level = Level(3);
 
+    /// Construct a level index. Returns `None` if `level >= NUM_LEVELS`.
     pub fn new(level: u8) -> Option<Self> {
         if (level as usize) < NUM_LEVELS {
             Some(Self(level))
@@ -81,10 +82,12 @@ impl Level {
         }
     }
 
+    /// The underlying level byte (always `< NUM_LEVELS`).
     pub fn as_u8(self) -> u8 {
         self.0
     }
 
+    /// Convert to a `usize` for indexing `[T; NUM_LEVELS]` arrays.
     pub fn as_index(self) -> usize {
         self.0 as usize
     }
@@ -120,15 +123,15 @@ mod tests {
     #[test]
     fn seqrange_accepts_lo_equal_to_hi() {
         let r = SeqRange::new(SeqNo(5), SeqNo(5)).unwrap();
-        assert_eq!(r.lo, SeqNo(5));
-        assert_eq!(r.hi, SeqNo(5));
+        assert_eq!(r.lo(), SeqNo(5));
+        assert_eq!(r.hi(), SeqNo(5));
     }
 
     #[test]
     fn seqrange_accepts_lo_less_than_hi() {
         let r = SeqRange::new(SeqNo(0), SeqNo(10)).unwrap();
-        assert_eq!(r.lo, SeqNo(0));
-        assert_eq!(r.hi, SeqNo(10));
+        assert_eq!(r.lo(), SeqNo(0));
+        assert_eq!(r.hi(), SeqNo(10));
     }
 
     #[test]

--- a/crates/minkowski-lsm/src/types.rs
+++ b/crates/minkowski-lsm/src/types.rs
@@ -37,8 +37,8 @@ impl fmt::Display for SeqNo {
 /// range (syntactically allowed, not currently produced by any code path).
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct SeqRange {
-    pub lo: SeqNo,
-    pub hi: SeqNo,
+    pub(crate) lo: SeqNo,
+    pub(crate) hi: SeqNo,
 }
 
 impl SeqRange {
@@ -117,8 +117,8 @@ mod tests {
     #[test]
     fn seqrange_accepts_lo_less_than_hi() {
         let r = SeqRange::new(SeqNo(0), SeqNo(10)).unwrap();
-        assert_eq!(r.lo.0, 0);
-        assert_eq!(r.hi.0, 10);
+        assert_eq!(r.lo, SeqNo(0));
+        assert_eq!(r.hi, SeqNo(10));
     }
 
     #[test]

--- a/crates/minkowski-lsm/src/types.rs
+++ b/crates/minkowski-lsm/src/types.rs
@@ -48,6 +48,16 @@ impl SeqRange {
         }
         Ok(Self { lo, hi })
     }
+
+    /// Lower bound of the range (inclusive).
+    pub fn lo(self) -> SeqNo {
+        self.lo
+    }
+
+    /// Upper bound of the range (exclusive).
+    pub fn hi(self) -> SeqNo {
+        self.hi
+    }
 }
 
 /// An LSM level index. Construction enforces `< NUM_LEVELS`.

--- a/crates/minkowski-lsm/tests/manifest_integration.rs
+++ b/crates/minkowski-lsm/tests/manifest_integration.rs
@@ -189,8 +189,7 @@ fn replay_converges_at_every_truncation_prefix() {
 }
 
 /// Replay must truncate the log when `apply_entry` fails, not silently skip
-/// the bad entry. Previously `let _ = promote_run(...)` ate the error; the
-/// fix makes replay treat the rest of the log as tail garbage.
+/// the bad entry.
 #[test]
 fn replay_truncates_log_on_promote_of_missing_run() {
     let dir = tempfile::tempdir().unwrap();
@@ -372,6 +371,69 @@ fn replay_truncates_log_on_invalid_level_byte() {
     assert_eq!(
         len_after_replay, len_after_first_frame,
         "replay truncated the invalid-level frame"
+    );
+}
+
+/// Regression: a frame whose `SeqRange::new` call fails (seq_lo > seq_hi)
+/// must be treated as tail garbage, not propagated as a fatal error.
+/// Completes the three-error regression symmetry alongside
+/// `replay_truncates_log_on_unsorted_coverage` and
+/// `replay_truncates_log_on_invalid_level_byte`.
+#[test]
+fn replay_truncates_log_on_inverted_seq_range() {
+    let dir = tempfile::tempdir().unwrap();
+    let log_path = dir.path().join("manifest.log");
+    let mut manifest = LsmManifest::new();
+    let mut log = ManifestLog::create(&log_path).unwrap();
+
+    let mut world = World::new();
+    world.spawn((Pos { x: 1.0, y: 0.0 },));
+    // One real flush, produces a valid AddRunAndSequence frame.
+    flush_and_record(&world, (0, 10), &mut manifest, &mut log, dir.path()).unwrap();
+
+    let len_after_first_frame = fs::metadata(&log_path).unwrap().len();
+
+    // Manually craft an AddRun frame with seq_lo=20 > seq_hi=10, which
+    // makes SeqRange::new fail inside decode_entry → LsmError::Format.
+    // Bypass SortedRunMeta::new by encoding the bytes directly.
+    let mut payload = Vec::new();
+    // TAG_ADD_RUN = 0x01
+    payload.push(0x01);
+    payload.push(0); // level (L0)
+    // path: "bad.run"
+    let path_bytes = b"bad.run";
+    payload.extend_from_slice(&(path_bytes.len() as u16).to_le_bytes());
+    payload.extend_from_slice(path_bytes);
+    payload.extend_from_slice(&20u64.to_le_bytes()); // seq_lo  (intentionally > seq_hi)
+    payload.extend_from_slice(&10u64.to_le_bytes()); // seq_hi
+    // archetype_coverage: [0] — valid (just one entry)
+    payload.extend_from_slice(&1u16.to_le_bytes()); // count
+    payload.extend_from_slice(&0u16.to_le_bytes()); // arch_id
+    payload.extend_from_slice(&1u64.to_le_bytes()); // page_count
+    payload.extend_from_slice(&1024u64.to_le_bytes()); // size_bytes
+
+    // Frame format: [len: u32 LE][crc32: u32 LE][payload]
+    let mut f = fs::OpenOptions::new().append(true).open(&log_path).unwrap();
+    let len = payload.len() as u32;
+    let crc = crc32fast::hash(&payload);
+    f.write_all(&len.to_le_bytes()).unwrap();
+    f.write_all(&crc.to_le_bytes()).unwrap();
+    f.write_all(&payload).unwrap();
+    f.sync_all().unwrap();
+    drop(f);
+
+    // Replay must truncate back to end of first valid frame.
+    let recovered = ManifestLog::replay(&log_path).unwrap();
+    assert_eq!(
+        recovered.total_runs(),
+        1,
+        "only the valid first flush survives"
+    );
+
+    let len_after_replay = fs::metadata(&log_path).unwrap().len();
+    assert_eq!(
+        len_after_replay, len_after_first_frame,
+        "replay truncated the bad frame"
     );
 }
 

--- a/crates/minkowski-lsm/tests/manifest_integration.rs
+++ b/crates/minkowski-lsm/tests/manifest_integration.rs
@@ -260,6 +260,119 @@ fn cleanup_removes_orphans_and_tmp() {
     assert!(run_path.exists());
 }
 
+// ── Decode validation → tail truncation ─────────────────────────────────────
+
+/// Regression: a frame whose decoded SortedRunMeta fails validation
+/// (unsorted archetype_coverage) must be treated as tail garbage, not
+/// propagated as a fatal error. Wires the new SortedRunMeta::new
+/// validation into the existing torn-tail recovery path.
+#[test]
+fn replay_truncates_log_on_unsorted_coverage() {
+    let dir = tempfile::tempdir().unwrap();
+    let log_path = dir.path().join("manifest.log");
+    let mut manifest = LsmManifest::new();
+    let mut log = ManifestLog::create(&log_path).unwrap();
+
+    let mut world = World::new();
+    world.spawn((Pos { x: 1.0, y: 0.0 },));
+    // One real flush, produces a valid AddRunAndSequence frame.
+    flush_and_record(&world, (0, 10), &mut manifest, &mut log, dir.path()).unwrap();
+
+    let len_after_first_frame = fs::metadata(&log_path).unwrap().len();
+
+    // Manually craft an AddRun frame with unsorted archetype_coverage.
+    // Bypass SortedRunMeta::new (can't call it — would error) by encoding
+    // the bytes directly. Wire layout per manifest_log.rs::encode_entry.
+    let mut payload = Vec::new();
+    payload.push(0x01); // TAG_ADD_RUN
+    payload.push(0); // level
+    // path: "x.run"
+    let path_bytes = b"x.run";
+    payload.extend_from_slice(&(path_bytes.len() as u16).to_le_bytes());
+    payload.extend_from_slice(path_bytes);
+    payload.extend_from_slice(&0u64.to_le_bytes()); // seq_lo
+    payload.extend_from_slice(&10u64.to_le_bytes()); // seq_hi
+    // archetype_coverage: [3, 1] — intentionally unsorted (rejects invariant)
+    payload.extend_from_slice(&2u16.to_le_bytes()); // count
+    payload.extend_from_slice(&3u16.to_le_bytes());
+    payload.extend_from_slice(&1u16.to_le_bytes());
+    payload.extend_from_slice(&1u64.to_le_bytes()); // page_count
+    payload.extend_from_slice(&1024u64.to_le_bytes()); // size_bytes
+
+    // Frame format: [len: u32 LE][crc32: u32 LE][payload]
+    let mut f = fs::OpenOptions::new().append(true).open(&log_path).unwrap();
+    let len = payload.len() as u32;
+    let crc = crc32fast::hash(&payload);
+    f.write_all(&len.to_le_bytes()).unwrap();
+    f.write_all(&crc.to_le_bytes()).unwrap();
+    f.write_all(&payload).unwrap();
+    f.sync_all().unwrap();
+    drop(f);
+
+    // Replay must truncate back to end of first valid frame.
+    let recovered = ManifestLog::replay(&log_path).unwrap();
+    assert_eq!(
+        recovered.total_runs(),
+        1,
+        "only the valid first flush survives"
+    );
+
+    let len_after_replay = fs::metadata(&log_path).unwrap().len();
+    assert_eq!(
+        len_after_replay, len_after_first_frame,
+        "replay truncated the bad frame"
+    );
+}
+
+/// Regression: a frame with a valid CRC but an invalid level byte
+/// (>= NUM_LEVELS) must be treated as tail garbage. Level::new returns
+/// None on invalid input, decode_entry surfaces LsmError::Format, and
+/// the replay loop must truncate.
+#[test]
+fn replay_truncates_log_on_invalid_level_byte() {
+    let dir = tempfile::tempdir().unwrap();
+    let log_path = dir.path().join("manifest.log");
+    let mut manifest = LsmManifest::new();
+    let mut log = ManifestLog::create(&log_path).unwrap();
+
+    let mut world = World::new();
+    world.spawn((Pos { x: 1.0, y: 0.0 },));
+    flush_and_record(&world, (0, 10), &mut manifest, &mut log, dir.path()).unwrap();
+
+    let len_after_first_frame = fs::metadata(&log_path).unwrap().len();
+
+    // Craft a REMOVE_RUN frame with level=255 (invalid; NUM_LEVELS is 4).
+    // REMOVE_RUN is the simplest level-bearing entry to fabricate.
+    let mut payload = Vec::new();
+    payload.push(0x02); // TAG_REMOVE_RUN
+    payload.push(255); // invalid level byte
+    let path_bytes = b"ghost.run";
+    payload.extend_from_slice(&(path_bytes.len() as u16).to_le_bytes());
+    payload.extend_from_slice(path_bytes);
+
+    let mut f = fs::OpenOptions::new().append(true).open(&log_path).unwrap();
+    let len = payload.len() as u32;
+    let crc = crc32fast::hash(&payload);
+    f.write_all(&len.to_le_bytes()).unwrap();
+    f.write_all(&crc.to_le_bytes()).unwrap();
+    f.write_all(&payload).unwrap();
+    f.sync_all().unwrap();
+    drop(f);
+
+    let recovered = ManifestLog::replay(&log_path).unwrap();
+    assert_eq!(
+        recovered.total_runs(),
+        1,
+        "only the valid first flush survives"
+    );
+
+    let len_after_replay = fs::metadata(&log_path).unwrap().len();
+    assert_eq!(
+        len_after_replay, len_after_first_frame,
+        "replay truncated the invalid-level frame"
+    );
+}
+
 // ── Clean world ─────────────────────────────────────────────────────────────
 
 #[test]

--- a/crates/minkowski-lsm/tests/manifest_integration.rs
+++ b/crates/minkowski-lsm/tests/manifest_integration.rs
@@ -264,8 +264,8 @@ fn cleanup_removes_orphans_and_tmp() {
 
 /// Regression: a frame whose decoded SortedRunMeta fails validation
 /// (unsorted archetype_coverage) must be treated as tail garbage, not
-/// propagated as a fatal error. Wires the new SortedRunMeta::new
-/// validation into the existing torn-tail recovery path.
+/// propagated as a fatal error. Wires the SortedRunMeta::new invariant
+/// check into the existing torn-tail recovery path.
 #[test]
 fn replay_truncates_log_on_unsorted_coverage() {
     let dir = tempfile::tempdir().unwrap();
@@ -284,7 +284,8 @@ fn replay_truncates_log_on_unsorted_coverage() {
     // Bypass SortedRunMeta::new (can't call it — would error) by encoding
     // the bytes directly. Wire layout per manifest_log.rs::encode_entry.
     let mut payload = Vec::new();
-    payload.push(0x01); // TAG_ADD_RUN
+    // TAG_ADD_RUN = 0x01 (see manifest_log.rs::encode_entry AddRun branch)
+    payload.push(0x01);
     payload.push(0); // level
     // path: "x.run"
     let path_bytes = b"x.run";
@@ -344,7 +345,8 @@ fn replay_truncates_log_on_invalid_level_byte() {
     // Craft a REMOVE_RUN frame with level=255 (invalid; NUM_LEVELS is 4).
     // REMOVE_RUN is the simplest level-bearing entry to fabricate.
     let mut payload = Vec::new();
-    payload.push(0x02); // TAG_REMOVE_RUN
+    // TAG_REMOVE_RUN = 0x02 (see manifest_log.rs::encode_entry RemoveRun branch)
+    payload.push(0x02);
     payload.push(255); // invalid level byte
     let path_bytes = b"ghost.run";
     payload.extend_from_slice(&(path_bytes.len() as u16).to_le_bytes());

--- a/crates/minkowski-lsm/tests/manifest_integration.rs
+++ b/crates/minkowski-lsm/tests/manifest_integration.rs
@@ -8,6 +8,7 @@ use minkowski::World;
 use minkowski_lsm::manifest::LsmManifest;
 use minkowski_lsm::manifest_log::{ManifestEntry, ManifestLog};
 use minkowski_lsm::manifest_ops::{cleanup_orphans, flush_and_record};
+use minkowski_lsm::types::{Level, SeqNo};
 
 #[derive(Clone, Copy)]
 #[expect(dead_code)]
@@ -65,7 +66,7 @@ fn three_flushes_then_replay() {
         .unwrap();
 
     assert_eq!(manifest.total_runs(), 3);
-    assert_eq!(manifest.next_sequence(), 30);
+    assert_eq!(manifest.next_sequence(), SeqNo(30));
     assert!(p1.exists());
     assert!(p2.exists());
     assert!(p3.exists());
@@ -73,14 +74,14 @@ fn three_flushes_then_replay() {
     // Replay the log from scratch — should reconstruct identical state.
     let replayed = ManifestLog::replay(&log_path).unwrap();
     assert_eq!(replayed.total_runs(), 3);
-    assert_eq!(replayed.next_sequence(), 30);
-    assert_eq!(replayed.runs_at_level(0).len(), 3);
+    assert_eq!(replayed.next_sequence(), SeqNo(30));
+    assert_eq!(replayed.runs_at_level(Level::L0).len(), 3);
 
     // Verify run metadata matches.
     for (original, recovered) in manifest
-        .runs_at_level(0)
+        .runs_at_level(Level::L0)
         .iter()
-        .zip(replayed.runs_at_level(0).iter())
+        .zip(replayed.runs_at_level(Level::L0).iter())
     {
         assert_eq!(original.path(), recovered.path());
         assert_eq!(original.sequence_range(), recovered.sequence_range());
@@ -116,7 +117,7 @@ fn corrupt_tail_partial_recovery() {
     // Replay should recover the 2 good entries (each flush writes one atomic AddRunAndSequence entry).
     let recovered = ManifestLog::replay(&log_path).unwrap();
     assert_eq!(recovered.total_runs(), 2);
-    assert_eq!(recovered.next_sequence(), 20);
+    assert_eq!(recovered.next_sequence(), SeqNo(20));
 }
 
 /// Truncate the log to every byte prefix 0..=file_len and replay each time.
@@ -149,7 +150,7 @@ fn replay_converges_at_every_truncation_prefix() {
     assert!(!full_bytes.is_empty(), "log must have content");
 
     let mut prev_total_runs = 0usize;
-    let mut prev_next_seq = 0u64;
+    let mut prev_next_seq = SeqNo(0);
 
     for truncate_len in 0..=full_bytes.len() {
         let truncated_path = dir.path().join(format!("truncated_{truncate_len:05}.log"));
@@ -180,7 +181,11 @@ fn replay_converges_at_every_truncation_prefix() {
     }
 
     assert_eq!(prev_total_runs, 3, "full replay must recover all 3 runs");
-    assert_eq!(prev_next_seq, 30, "full replay must recover final sequence");
+    assert_eq!(
+        prev_next_seq,
+        SeqNo(30),
+        "full replay must recover final sequence"
+    );
 }
 
 /// Replay must truncate the log when `apply_entry` fails, not silently skip
@@ -201,14 +206,16 @@ fn replay_truncates_log_on_promote_of_missing_run() {
     // Inject a PromoteRun that references a path the manifest doesn't know.
     // Models a corrupted log or an out-of-order mutation.
     log.append(&ManifestEntry::PromoteRun {
-        from_level: 0,
-        to_level: 1,
+        from_level: Level::L0,
+        to_level: Level::L1,
         path: PathBuf::from("ghost.run"),
     })
     .unwrap();
     // Anything after the bad entry must be discarded on replay.
-    log.append(&ManifestEntry::SetSequence { next_sequence: 999 })
-        .unwrap();
+    log.append(&ManifestEntry::SetSequence {
+        next_sequence: SeqNo(999),
+    })
+    .unwrap();
     drop(log);
 
     let recovered = ManifestLog::replay(&log_path).unwrap();
@@ -218,11 +225,11 @@ fn replay_truncates_log_on_promote_of_missing_run() {
         "only the first flush should survive replay"
     );
     assert!(
-        recovered.next_sequence() < 999,
+        recovered.next_sequence() < SeqNo(999),
         "SetSequence past the bad PromoteRun must not apply"
     );
     // The surviving AddRunAndSequence set next_sequence to 10.
-    assert_eq!(recovered.next_sequence(), 10);
+    assert_eq!(recovered.next_sequence(), SeqNo(10));
 }
 
 // ── Cleanup ─────────────────────────────────────────────────────────────────
@@ -249,7 +256,7 @@ fn cleanup_removes_orphans_and_tmp() {
 
     // The real run file should still exist.
     assert_eq!(manifest.total_runs(), 1);
-    let run_path = manifest.runs_at_level(0)[0].path();
+    let run_path = manifest.runs_at_level(Level::L0)[0].path();
     assert!(run_path.exists());
 }
 
@@ -269,7 +276,7 @@ fn flush_and_record_clean_world_no_change() {
     let result = flush_and_record(&world, (0, 10), &mut manifest, &mut log, dir.path()).unwrap();
     assert!(result.is_none());
     assert_eq!(manifest.total_runs(), 0);
-    assert_eq!(manifest.next_sequence(), 0);
+    assert_eq!(manifest.next_sequence(), SeqNo(0));
 
     // Log should be empty — replay produces empty manifest.
     let replayed = ManifestLog::replay(&log_path).unwrap();

--- a/docs/plans/2026-04-16-lsm-manifest-type-safety-design.md
+++ b/docs/plans/2026-04-16-lsm-manifest-type-safety-design.md
@@ -1,0 +1,254 @@
+# LSM Manifest Type Safety (PR A)
+
+*Parent document: [Stage 3: LSM Tree Storage](./2026-04-03-stage3-lsm-implementation-plan.md), follow-up to Phase 2.*
+*Status: Design. Prerequisites: PR #160 (LSM Phase 2) merged.*
+
+---
+
+## Summary
+
+This PR tightens the type design of the `minkowski-lsm` manifest subsystem by introducing newtype primitives (`SeqNo`, `SeqRange`, `Level`), dropping the redundant `SortedRunMeta::level` field, and adding a validated `SortedRunMeta::new` constructor. The work was identified during review of PR #160 and is the first half of a two-PR sequence; PR B (unified `recover` entry point, on-disk magic+version header, parent-dir fsync) is explicitly out of scope.
+
+The refactor is **internal-only in on-disk format terms** — no wire format change, no replay compat story, no migration of existing log files. Type changes are source-level only.
+
+## Motivation
+
+PR #160's review (via `type-design-analyzer`) rated the manifest types 3–5/10 on invariant enforcement. Specific holes:
+
+- `level: u8` fields scattered across `LsmManifest::{add,remove,promote,runs_at}_level` with runtime `assert!` at three call sites. One forgotten assertion produces a panic in the wrong place.
+- `sequence_range: (u64, u64)` expresses no invariant. `(5, 3)` is representable. The convention (half-open, `[lo, hi)`) lives in a code comment.
+- `SortedRunMeta` has `pub(crate)` fields and three construction sites (`flush_and_record`, `decode_entry`, tests) with no validation. A decoded frame with an unsorted `archetype_coverage` vector silently produces a manifest that breaks downstream binary-search-based lookups.
+- `SortedRunMeta::level` duplicates the Vec index it sits in. PR #160's fix kept the field in sync on promotion, but the structural problem — two sources of truth for one fact — remains.
+
+The principle driving this work: move invariants from convention-in-comments to enforced-at-construction. Keep the validation cheap so there's no performance pressure to bypass it.
+
+## Non-goals
+
+Explicitly deferred to **PR B (LSM Manifest Format Hardening)**:
+
+- `ManifestLog::recover(path) -> (LsmManifest, ManifestLog)` unified entry point.
+- Magic + version header at the start of the log file.
+- Parent-directory fsync after `truncate_at` in replay.
+
+These are deferred because they touch on-disk format and forward/backward compatibility, which are independent design axes from type invariants. Bundling them would double the review surface and couple type-shape decisions to format-version decisions.
+
+## Design
+
+### 1. New types — `crates/minkowski-lsm/src/types.rs` (new module)
+
+```rust
+/// A WAL sequence number. Half-open ranges (`[lo, hi)`) are encoded
+/// via `SeqRange`; raw `u64` arithmetic on seq numbers is disallowed
+/// by the type (no Add/Sub impls) because seqs are identities, not sizes.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct SeqNo(pub u64);
+
+impl From<u64> for SeqNo { /* ... */ }
+impl From<SeqNo> for u64 { /* ... */ }
+impl fmt::Display for SeqNo { /* ... */ }
+
+/// A half-open sequence range `[lo, hi)`. Construction enforces
+/// `lo <= hi`. `hi == lo` represents an empty range (not currently
+/// produced by any code path but syntactically allowed).
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct SeqRange { pub lo: SeqNo, pub hi: SeqNo }
+
+impl SeqRange {
+    pub fn new(lo: SeqNo, hi: SeqNo) -> Result<Self, LsmError> {
+        if lo > hi {
+            return Err(LsmError::Format(
+                format!("SeqRange: lo ({lo}) > hi ({hi})")
+            ));
+        }
+        Ok(Self { lo, hi })
+    }
+}
+
+/// An LSM level index, guaranteed `< NUM_LEVELS` at construction.
+/// Bounds check lives once, in `Level::new`.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct Level(u8);
+
+impl Level {
+    pub const L0: Level = Level(0);
+    pub const L1: Level = Level(1);
+    pub const L2: Level = Level(2);
+    pub const L3: Level = Level(3);
+
+    pub fn new(level: u8) -> Option<Self> {
+        if (level as usize) < NUM_LEVELS { Some(Self(level)) } else { None }
+    }
+
+    pub fn as_u8(self) -> u8 { self.0 }
+    pub fn as_index(self) -> usize { self.0 as usize }
+}
+```
+
+Design notes:
+
+- `SeqNo` is transparent (pub field) because the type's only job is nominal distinction. `Level` keeps its `u8` private because the bounds invariant is the whole point.
+- No arithmetic impls on `SeqNo` — seq numbers aren't scalar quantities. Callers that need "next seq" explicitly go through `SeqNo(x.0 + 1)` or via `SeqRange.hi`.
+- `Level` has associated consts `L0..L3` for code that knows the level at compile time, avoiding an `.unwrap()` on `Level::new(0)`.
+- `NUM_LEVELS` stays a constant. Bumping to 5 or 6 in the future is a one-line change; no `match Level` to update.
+
+### 2. `SortedRunMeta` refactor
+
+```rust
+pub struct SortedRunMeta {
+    // All fields private. The public surface is new() + accessors.
+    path: PathBuf,
+    sequence_range: SeqRange,
+    archetype_coverage: Vec<u16>,
+    page_count: u64,
+    size_bytes: u64,
+    // `level: u8` DROPPED. Was never stored on disk — decode_entry
+    // previously derived it from the outer AddRun.level byte and
+    // populated meta.level as a redundant copy. Array position in
+    // LsmManifest::levels[i] is the single source of truth.
+}
+
+impl SortedRunMeta {
+    pub fn new(
+        path: PathBuf,
+        sequence_range: SeqRange,
+        archetype_coverage: Vec<u16>,
+        page_count: u64,
+        size_bytes: u64,
+    ) -> Result<Self, LsmError> {
+        // Invariants enforced at construction:
+        if archetype_coverage.windows(2).any(|w| w[0] >= w[1]) {
+            return Err(LsmError::Format(
+                "archetype_coverage is not strictly sorted".to_owned()
+            ));
+        }
+        if page_count == 0 {
+            return Err(LsmError::Format(
+                "page_count must be non-zero".to_owned()
+            ));
+        }
+        // size_bytes > 0 is NOT validated — redundant with page_count
+        // given that every sorted run has a non-empty header.
+        // SeqRange lo<=hi is already enforced by SeqRange::new.
+        Ok(Self { path, sequence_range, archetype_coverage, page_count, size_bytes })
+    }
+
+    pub fn path(&self) -> &Path { &self.path }
+    pub fn sequence_range(&self) -> SeqRange { self.sequence_range }
+    pub fn archetype_coverage(&self) -> &[u16] { &self.archetype_coverage }
+    pub fn page_count(&self) -> u64 { self.page_count }
+    pub fn size_bytes(&self) -> u64 { self.size_bytes }
+
+    // pub fn level(&self) -> u8 — REMOVED.
+    // Callers always know the level from the context they obtained
+    // the meta in: `manifest.runs_at_level(l)` or explicit iteration
+    // over levels.
+}
+```
+
+The `windows(2).any(w[0] >= w[1])` check rejects both unsorted and duplicated entries in a single pass. `>=` catches equal adjacent values (dedup), `<` ordering guarantees strict monotonicity.
+
+### 3. `LsmManifest` API updates
+
+Signatures are mechanical — every `u8` level becomes `Level`, every `u64` seq becomes `SeqNo`.
+
+```rust
+pub fn add_run(&mut self, level: Level, meta: SortedRunMeta);
+pub fn remove_run(&mut self, level: Level, path: &Path) -> Option<SortedRunMeta>;
+pub fn promote_run(&mut self, from: Level, to: Level, path: &Path) -> Result<(), LsmError>;
+pub fn runs_at_level(&self, level: Level) -> &[SortedRunMeta];
+pub fn set_next_sequence(&mut self, seq: SeqNo);
+pub fn next_sequence(&self) -> SeqNo;
+// all_run_paths, total_runs unchanged.
+```
+
+Internal simplifications:
+
+- `add_run` loses its `assert!((level as usize) < NUM_LEVELS, ...)` — `Level::new` already guaranteed it. The array index becomes `level.as_index()`.
+- `remove_run` / `runs_at_level` same.
+- `promote_run` no longer needs `meta.level = to_level` — the field is gone.
+- `levels` array indexing replaces scattered bounds checks.
+
+### 4. Wire format — unchanged
+
+The existing encoding of `ManifestEntry::AddRun`, `AddRunAndSequence`, `RemoveRun`, `PromoteRun`, `SetSequence` is untouched. Per inspection of PR #160's codec:
+
+- `AddRun` and `AddRunAndSequence` already encode `level` exactly once per entry (at the outer position). The inner `meta.level` was never serialized — decode was populating it from the outer byte. Dropping the field changes only memory layout, not bytes.
+- `RemoveRun` and `PromoteRun` still encode `level: u8`, decoded via `Level::new(byte).ok_or(LsmError::Format(...))?`.
+- `SetSequence` still encodes `next_sequence: u64`, decoded via `SeqNo(u64)`.
+
+### 5. Decode path integration
+
+`decode_entry` gains two new failure modes, both surfaced as `LsmError::Format`:
+
+- Invalid `level` byte (>= `NUM_LEVELS`) → `Format("invalid level N")`.
+- `SortedRunMeta::new` rejects the payload (unsorted coverage, zero page_count) → forwards that error.
+
+These integrate automatically with the replay loop fixed in PR #160: decode-stage `LsmError::Format` is treated as tail corruption, triggering `truncate_at` and breaking the loop. No additional replay logic needed.
+
+`apply_entry` is already `Result`-returning from PR #160; promotion with a missing source still propagates via `?`. The validated-constructor errors are caught one layer earlier (decode) so they never reach `apply_entry`.
+
+### 6. Call-site migration inventory
+
+Known construction sites needing updating:
+
+- `crates/minkowski-lsm/src/manifest_ops.rs::flush_and_record` — one `SortedRunMeta` struct literal, becomes `SortedRunMeta::new(...)?`.
+- `crates/minkowski-lsm/src/manifest_log.rs::decode_entry` — two construction sites (AddRun and AddRunAndSequence variants), both become `SortedRunMeta::new(...)?`.
+- `crates/minkowski-lsm/src/manifest.rs` — `test_meta` helper in the test module, one construction.
+- `crates/minkowski-lsm/src/manifest_ops.rs::cleanup_orphans_removes_untracked` test — one struct literal.
+
+Signature-only updates (level as `u8` → `Level`, seq as `u64` → `SeqNo`):
+
+- Public accessors on `LsmManifest`.
+- `ManifestEntry` enum variants that carry `level` or `next_sequence`.
+- Tests throughout `manifest.rs`, `manifest_log.rs`, `manifest_integration.rs`.
+
+No external callers of `minkowski-lsm` outside the workspace exist today, so the breaking accessor-signature change is internal-only.
+
+### 7. Error-type reuse
+
+All new validation failures surface as existing `LsmError::Format(String)`. No new error variants. This matches the codec's existing convention: `Format` already covers "bytes on disk don't form a valid entry," and validation failures are semantically in the same category.
+
+## Testing strategy
+
+### Unit tests for new types (`types.rs` test module)
+
+- `SeqNo` ordering, equality, `Display` round-trip.
+- `SeqRange::new` rejects `lo > hi`, accepts `lo == hi`.
+- `Level::new` rejects 4, 5, 255; accepts 0, 1, 2, 3.
+- `Level::L0..L3` associated consts equal their `Level::new` counterparts.
+
+### Unit tests for `SortedRunMeta::new`
+
+Table-driven — one valid case, plus one case per rejected-invariant:
+
+- Valid: sorted coverage, non-zero page_count → `Ok`.
+- Unsorted coverage (`[3, 1, 2]`) → `Err(Format)`.
+- Duplicated coverage (`[1, 2, 2, 3]`) → `Err(Format)`.
+- Empty coverage → `Ok`. The constructor does not enforce a cross-field "coverage must be non-empty when page_count > 0" invariant; in practice `flush_and_record` never produces this state (a dirty page implies at least one archetype), but the type alone doesn't know that.
+- `page_count == 0` → `Err(Format)`.
+
+### Integration regression test
+
+One new test in `manifest_integration.rs`: inject a handcrafted `ManifestEntry::AddRun` with `archetype_coverage: vec![3, 1]` via `log.append`, then `ManifestLog::replay` and assert:
+
+- Replay returns `Ok` (no error propagated).
+- Manifest has only the entries *before* the bad one.
+- Log file is truncated to the offset immediately before the bad frame.
+
+This wires the new validation into the existing torn-tail recovery path and confirms the error classification reaches the truncate branch.
+
+### Existing tests
+
+All existing tests in `manifest.rs`, `manifest_log.rs`, `manifest_integration.rs` should continue to pass with mechanical migration. No coverage is lost.
+
+## Rollout
+
+Single PR, squash-merge per project convention. CI gates: fmt, clippy, test, tsan, loom (loom is irrelevant here — no new concurrency), Miri runs on nightly schedule.
+
+Following merge, update the `project_lsm_phase2_type_safety.md` memory entry to reflect PR A completion and adjust PR B scope (magic header + recover + dir fsync).
+
+## Risks
+
+- **Clippy lint drift**: PR #160's post-merge CI revealed three clippy 1.95 lints that my local (1.93) didn't trigger. Before pushing this PR, run `rustup update stable` locally and re-run `cargo clippy --workspace --all-targets -- -D warnings` to catch newer lints locally.
+- **Test migration churn**: every test helper that built `SortedRunMeta` via struct literal needs updating. This is mechanical and will be caught by the compiler, but expect ~30–50 lines of test-file edits.
+- **`ManifestEntry::RemoveRun` and `PromoteRun` carry `level: u8`** — these decode paths need the new `Level::new(...).ok_or(...)?` treatment. Easy to miss one in the migration; `cargo check` catches it because the variant field type changes.

--- a/docs/plans/2026-04-16-lsm-manifest-type-safety-design.md
+++ b/docs/plans/2026-04-16-lsm-manifest-type-safety-design.md
@@ -51,7 +51,7 @@ impl fmt::Display for SeqNo { /* ... */ }
 /// `lo <= hi`. `hi == lo` represents an empty range (not currently
 /// produced by any code path but syntactically allowed).
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct SeqRange { pub lo: SeqNo, pub hi: SeqNo }
+pub struct SeqRange { pub(crate) lo: SeqNo, pub(crate) hi: SeqNo }
 
 impl SeqRange {
     pub fn new(lo: SeqNo, hi: SeqNo) -> Result<Self, LsmError> {
@@ -86,7 +86,7 @@ impl Level {
 
 Design notes:
 
-- `SeqNo` is transparent (pub field) because the type's only job is nominal distinction. `Level` keeps its `u8` private because the bounds invariant is the whole point.
+- `SeqNo` is transparent (pub field) because the type's only job is nominal distinction. `SeqRange` fields are `pub(crate)` — the invariant (`lo <= hi`) must flow through `SeqRange::new`; downstream code still reads via field syntax within the crate. `Level` keeps its `u8` private because the bounds invariant is the whole point.
 - No arithmetic impls on `SeqNo` — seq numbers aren't scalar quantities. Callers that need "next seq" explicitly go through `SeqNo(x.0 + 1)` or via `SeqRange.hi`.
 - `Level` has associated consts `L0..L3` for code that knows the level at compile time, avoiding an `.unwrap()` on `Level::new(0)`.
 - `NUM_LEVELS` stays a constant. Bumping to 5 or 6 in the future is a one-line change; no `match Level` to update.

--- a/docs/plans/2026-04-16-lsm-manifest-type-safety-implementation-plan.md
+++ b/docs/plans/2026-04-16-lsm-manifest-type-safety-implementation-plan.md
@@ -1,0 +1,1396 @@
+# LSM Manifest Type Safety (PR A) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce `SeqNo` / `SeqRange` / `Level` newtypes, a validated `SortedRunMeta::new` constructor, and drop the redundant `SortedRunMeta::level` field across the `minkowski-lsm` crate.
+
+**Architecture:** Pure Rust type-level refactor. No wire format change, no cross-crate ripple. Adds ~150 lines to a new `types.rs` module; mechanical rewrites across the existing five files. TDD for new type logic; compiler-driven migration for signature changes. Each task ends with a green `cargo test -p minkowski-lsm` + `cargo clippy -p minkowski-lsm --all-targets -- -D warnings`.
+
+**Tech Stack:** Rust 2024 edition, `minkowski-lsm` workspace crate, existing `LsmError` error type, existing `tempfile` test harness.
+
+**Spec:** `docs/plans/2026-04-16-lsm-manifest-type-safety-design.md`
+
+---
+
+## Starting state
+
+- Branch: `docs/lsm-type-safety-design` (one commit ahead of `main` — the spec).
+- Continue on this branch. When implementation completes, the PR squash-merges both the spec doc and the implementation as one clean squash commit.
+
+## File structure
+
+**Create:**
+- `crates/minkowski-lsm/src/types.rs` — new module holding `SeqNo`, `SeqRange`, `Level`. One responsibility: shared invariant-carrying newtype primitives.
+
+**Modify:**
+- `crates/minkowski-lsm/src/lib.rs` — add `pub mod types;` and re-exports.
+- `crates/minkowski-lsm/src/manifest.rs` — `SortedRunMeta::new`, accessor return types, `LsmManifest` signatures, drop `meta.level`.
+- `crates/minkowski-lsm/src/manifest_log.rs` — `ManifestEntry` variant field types, encode/decode using new primitives, call `SortedRunMeta::new`.
+- `crates/minkowski-lsm/src/manifest_ops.rs` — `flush_and_record` uses `SortedRunMeta::new` + `SeqRange::new`.
+- `crates/minkowski-lsm/src/reader.rs` — `sequence_range()` accessor return type becomes `SeqRange` (the reader's internal storage stays `(u64, u64)` since that's what's on disk; only the public accessor changes, or it stays `(u64, u64)` and callers build a SeqRange — decide in Task 3).
+- `crates/minkowski-lsm/tests/manifest_integration.rs` — test harness migration, add one new regression test.
+
+---
+
+## Task 1: Types module — `SeqNo`, `SeqRange`, `Level`
+
+**Files:**
+- Create: `crates/minkowski-lsm/src/types.rs`
+- Modify: `crates/minkowski-lsm/src/lib.rs`
+
+- [ ] **Step 1: Write the types module with inline tests**
+
+Create `crates/minkowski-lsm/src/types.rs`:
+
+```rust
+//! Invariant-carrying newtype primitives shared across the manifest.
+
+use std::fmt;
+
+use crate::error::LsmError;
+use crate::manifest::NUM_LEVELS;
+
+/// A WAL sequence number.
+///
+/// Raw `u64` arithmetic on sequence numbers is disallowed by the type
+/// (no `Add`/`Sub` impls) because sequences are identities, not sizes.
+/// Callers that need "next seq" do so explicitly: `SeqNo(x.0 + 1)`.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default)]
+pub struct SeqNo(pub u64);
+
+impl From<u64> for SeqNo {
+    fn from(v: u64) -> Self {
+        Self(v)
+    }
+}
+
+impl From<SeqNo> for u64 {
+    fn from(s: SeqNo) -> Self {
+        s.0
+    }
+}
+
+impl fmt::Display for SeqNo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A half-open sequence range `[lo, hi)`.
+///
+/// Construction enforces `lo <= hi`. `hi == lo` represents an empty
+/// range (syntactically allowed, not currently produced by any code path).
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct SeqRange {
+    pub lo: SeqNo,
+    pub hi: SeqNo,
+}
+
+impl SeqRange {
+    pub fn new(lo: SeqNo, hi: SeqNo) -> Result<Self, LsmError> {
+        if lo > hi {
+            return Err(LsmError::Format(format!(
+                "SeqRange: lo ({lo}) > hi ({hi})"
+            )));
+        }
+        Ok(Self { lo, hi })
+    }
+}
+
+/// An LSM level index. Construction enforces `< NUM_LEVELS`.
+///
+/// The bounds check lives in exactly one place (`Level::new`); all
+/// other code sites trust the invariant once they hold a `Level`.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct Level(u8);
+
+impl Level {
+    pub const L0: Level = Level(0);
+    pub const L1: Level = Level(1);
+    pub const L2: Level = Level(2);
+    pub const L3: Level = Level(3);
+
+    pub fn new(level: u8) -> Option<Self> {
+        if (level as usize) < NUM_LEVELS {
+            Some(Self(level))
+        } else {
+            None
+        }
+    }
+
+    pub fn as_u8(self) -> u8 {
+        self.0
+    }
+
+    pub fn as_index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+impl fmt::Display for Level {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "L{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seqno_display_matches_inner_u64() {
+        assert_eq!(SeqNo(42).to_string(), "42");
+    }
+
+    #[test]
+    fn seqno_ordering_matches_u64() {
+        assert!(SeqNo(1) < SeqNo(2));
+        assert_eq!(SeqNo(5), SeqNo(5));
+    }
+
+    #[test]
+    fn seqrange_rejects_lo_greater_than_hi() {
+        let result = SeqRange::new(SeqNo(10), SeqNo(5));
+        assert!(matches!(result, Err(LsmError::Format(_))));
+    }
+
+    #[test]
+    fn seqrange_accepts_lo_equal_to_hi() {
+        let r = SeqRange::new(SeqNo(5), SeqNo(5)).unwrap();
+        assert_eq!(r.lo, SeqNo(5));
+        assert_eq!(r.hi, SeqNo(5));
+    }
+
+    #[test]
+    fn seqrange_accepts_lo_less_than_hi() {
+        let r = SeqRange::new(SeqNo(0), SeqNo(10)).unwrap();
+        assert_eq!(r.lo.0, 0);
+        assert_eq!(r.hi.0, 10);
+    }
+
+    #[test]
+    fn level_rejects_values_at_or_above_num_levels() {
+        assert!(Level::new(NUM_LEVELS as u8).is_none());
+        assert!(Level::new(255).is_none());
+    }
+
+    #[test]
+    fn level_accepts_values_below_num_levels() {
+        for i in 0..NUM_LEVELS {
+            assert!(Level::new(i as u8).is_some());
+        }
+    }
+
+    #[test]
+    fn level_consts_match_new() {
+        assert_eq!(Level::L0, Level::new(0).unwrap());
+        assert_eq!(Level::L1, Level::new(1).unwrap());
+        assert_eq!(Level::L2, Level::new(2).unwrap());
+        assert_eq!(Level::L3, Level::new(3).unwrap());
+    }
+
+    #[test]
+    fn level_as_u8_and_as_index_agree() {
+        let l = Level::L2;
+        assert_eq!(l.as_u8(), 2);
+        assert_eq!(l.as_index(), 2);
+    }
+}
+```
+
+- [ ] **Step 2: Register the module in lib.rs**
+
+Edit `crates/minkowski-lsm/src/lib.rs` — add to the module list (alphabetical ordering preserved):
+
+```rust
+pub mod error;
+pub mod format;
+pub mod manifest;
+pub mod manifest_log;
+pub mod manifest_ops;
+pub mod reader;
+pub mod schema;
+pub mod types;      // <-- new
+pub mod writer;
+```
+
+- [ ] **Step 3: Run the new tests**
+
+Run: `cargo test -p minkowski-lsm --lib types::tests`
+Expected: 8 tests pass.
+
+- [ ] **Step 4: Run the full crate test suite to verify nothing else broke**
+
+Run: `cargo test -p minkowski-lsm`
+Expected: all existing tests still pass, plus the 8 new `types::tests`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/minkowski-lsm/src/types.rs crates/minkowski-lsm/src/lib.rs
+git commit -m "feat(lsm): add SeqNo, SeqRange, Level newtype primitives
+
+Foundation for the manifest type-safety refactor. Pure addition — no
+existing code changed yet. Each newtype centralizes an invariant that
+was previously scattered across assert! sites or open structural fields."
+```
+
+---
+
+## Task 2: `SortedRunMeta::new` constructor (keep fields pub(crate))
+
+**Files:**
+- Modify: `crates/minkowski-lsm/src/manifest.rs`
+
+- [ ] **Step 1: Write failing unit tests for the constructor**
+
+In `crates/minkowski-lsm/src/manifest.rs`, add to the existing `#[cfg(test)] mod tests` block:
+
+```rust
+    #[test]
+    fn sorted_run_meta_new_accepts_valid_input() {
+        let meta = SortedRunMeta::new(
+            PathBuf::from("0-10.run"),
+            0,
+            SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+            vec![0, 3, 7],
+            1,
+            1024,
+        )
+        .unwrap();
+        assert_eq!(meta.sequence_range().lo, SeqNo(0));
+        assert_eq!(meta.page_count(), 1);
+    }
+
+    #[test]
+    fn sorted_run_meta_new_rejects_unsorted_coverage() {
+        let result = SortedRunMeta::new(
+            PathBuf::from("x.run"),
+            0,
+            SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+            vec![3, 1, 2],
+            1,
+            1024,
+        );
+        assert!(matches!(result, Err(LsmError::Format(_))));
+    }
+
+    #[test]
+    fn sorted_run_meta_new_rejects_duplicated_coverage() {
+        let result = SortedRunMeta::new(
+            PathBuf::from("x.run"),
+            0,
+            SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+            vec![1, 2, 2, 3],
+            1,
+            1024,
+        );
+        assert!(matches!(result, Err(LsmError::Format(_))));
+    }
+
+    #[test]
+    fn sorted_run_meta_new_accepts_empty_coverage() {
+        let meta = SortedRunMeta::new(
+            PathBuf::from("x.run"),
+            0,
+            SeqRange::new(SeqNo(0), SeqNo(0)).unwrap(),
+            vec![],
+            1,
+            1024,
+        );
+        assert!(meta.is_ok());
+    }
+
+    #[test]
+    fn sorted_run_meta_new_rejects_zero_page_count() {
+        let result = SortedRunMeta::new(
+            PathBuf::from("x.run"),
+            0,
+            SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+            vec![0],
+            0,
+            1024,
+        );
+        assert!(matches!(result, Err(LsmError::Format(_))));
+    }
+```
+
+Add to the test module's imports (or `use super::*;` if already present):
+```rust
+    use crate::types::{SeqNo, SeqRange};
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p minkowski-lsm --lib manifest::tests::sorted_run_meta_new`
+Expected: FAIL — `SortedRunMeta::new` doesn't exist yet AND `sequence_range()` still returns `(u64, u64)` not `SeqRange` — compilation error.
+
+- [ ] **Step 3: Add `new()` and intermediate accessor bridge**
+
+In `crates/minkowski-lsm/src/manifest.rs`, at the top of the file, update imports:
+
+```rust
+use std::path::{Path, PathBuf};
+
+use crate::error::LsmError;
+use crate::types::{SeqNo, SeqRange};
+```
+
+Then inside `impl SortedRunMeta { ... }`, add the constructor:
+
+```rust
+    /// Build a `SortedRunMeta` with enforced invariants.
+    ///
+    /// Validates:
+    /// - `archetype_coverage` is strictly sorted ascending (sorted + deduped).
+    /// - `page_count` is non-zero.
+    ///
+    /// `seq_range` is already validated by `SeqRange::new`. `size_bytes` is
+    /// not validated (redundant with `page_count`; a valid run file always
+    /// has a non-empty header).
+    pub fn new(
+        path: PathBuf,
+        level: u8,
+        sequence_range: SeqRange,
+        archetype_coverage: Vec<u16>,
+        page_count: u64,
+        size_bytes: u64,
+    ) -> Result<Self, LsmError> {
+        if archetype_coverage.windows(2).any(|w| w[0] >= w[1]) {
+            return Err(LsmError::Format(
+                "archetype_coverage is not strictly sorted".to_owned(),
+            ));
+        }
+        if page_count == 0 {
+            return Err(LsmError::Format(
+                "page_count must be non-zero".to_owned(),
+            ));
+        }
+        Ok(Self {
+            path,
+            level,
+            sequence_range,
+            archetype_coverage,
+            page_count,
+            size_bytes,
+        })
+    }
+```
+
+Change the `sequence_range` field type in the struct from `(u64, u64)` to `SeqRange`:
+
+```rust
+pub struct SortedRunMeta {
+    pub(crate) path: PathBuf,
+    pub(crate) level: u8,
+    pub(crate) sequence_range: SeqRange,       // was: (u64, u64)
+    pub(crate) archetype_coverage: Vec<u16>,
+    pub(crate) page_count: u64,
+    pub(crate) size_bytes: u64,
+}
+```
+
+Update the existing accessor:
+
+```rust
+    pub fn sequence_range(&self) -> SeqRange {
+        self.sequence_range
+    }
+```
+
+- [ ] **Step 4: Update existing `test_meta` helper to use `SeqRange`**
+
+In the same file's test module, update `test_meta`:
+
+```rust
+    fn test_meta(name: &str, level: u8) -> SortedRunMeta {
+        SortedRunMeta {
+            path: PathBuf::from(name),
+            level,
+            sequence_range: SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+            archetype_coverage: vec![0],
+            page_count: 1,
+            size_bytes: 1024,
+        }
+    }
+```
+
+Note: existing tests use struct literal — this is fine while fields are still `pub(crate)`. Task 5 flips them private.
+
+- [ ] **Step 5: Run tests — expect compilation errors elsewhere now**
+
+Run: `cargo check -p minkowski-lsm`
+Expected: FAIL — `manifest_log.rs`, `manifest_ops.rs`, `reader.rs`, and integration tests all construct `SortedRunMeta` with `sequence_range: (u64, u64)` tuple. These are next to migrate.
+
+- [ ] **Step 6: Update `crates/minkowski-lsm/src/reader.rs` sequence_range accessor**
+
+Find `SortedRunReader::sequence_range()`:
+
+```rust
+    pub fn sequence_range(&self) -> (u64, u64) {
+        (self.header.sequence_lo, self.header.sequence_hi)
+    }
+```
+
+Change return type to `SeqRange`:
+
+```rust
+    pub fn sequence_range(&self) -> SeqRange {
+        // On-disk header validated at open time; these u64s already form
+        // a valid range there, so new() will succeed. unwrap justified by
+        // file-open-time invariant.
+        SeqRange::new(
+            SeqNo(self.header.sequence_lo),
+            SeqNo(self.header.sequence_hi),
+        )
+        .expect("sorted-run header sequence range must be valid")
+    }
+```
+
+Add imports at top of `reader.rs`:
+
+```rust
+use crate::types::{SeqNo, SeqRange};
+```
+
+- [ ] **Step 7: Run cargo check again**
+
+Run: `cargo check -p minkowski-lsm`
+Expected: still FAIL — callers of `SortedRunMeta` struct literal with `(u64, u64)` still remain. Will be fixed in next tasks.
+
+Don't commit yet — the codebase isn't compiling. This entire task commits at the end of Task 3 (below), once all callers are migrated.
+
+---
+
+## Task 3: Migrate all `SortedRunMeta` construction sites
+
+**Files:**
+- Modify: `crates/minkowski-lsm/src/manifest_ops.rs`
+- Modify: `crates/minkowski-lsm/src/manifest_log.rs`
+- Modify: `crates/minkowski-lsm/tests/manifest_integration.rs`
+
+- [ ] **Step 1: Migrate `flush_and_record` in manifest_ops.rs**
+
+Edit the construction site. Current code:
+
+```rust
+    let meta = SortedRunMeta {
+        path: path.clone(),
+        level: 0,
+        sequence_range: reader.sequence_range(),
+        archetype_coverage,
+        page_count: reader.page_count(),
+        size_bytes: file_size,
+    };
+```
+
+Replace with:
+
+```rust
+    let meta = SortedRunMeta::new(
+        path.clone(),
+        0,
+        reader.sequence_range(),
+        archetype_coverage,
+        reader.page_count(),
+        file_size,
+    )?;
+```
+
+`reader.sequence_range()` already returns `SeqRange` after Task 2 Step 6. The `?` propagates any validation error (shouldn't happen in practice — a just-written run has valid coverage — but the type system now demands handling).
+
+- [ ] **Step 2: Migrate the cleanup test in manifest_ops.rs**
+
+Find `cleanup_orphans_removes_untracked` in the test module. Current:
+
+```rust
+        manifest.add_run(
+            0,
+            SortedRunMeta {
+                path: dir.path().join("0-10.run"),
+                level: 0,
+                sequence_range: (0, 10),
+                archetype_coverage: vec![0],
+                page_count: 1,
+                size_bytes: 4,
+            },
+        );
+```
+
+Replace:
+
+```rust
+        manifest.add_run(
+            0,
+            SortedRunMeta::new(
+                dir.path().join("0-10.run"),
+                0,
+                SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+                vec![0],
+                1,
+                4,
+            )
+            .unwrap(),
+        );
+```
+
+Add import at top of file's test module (or `use` at top of file):
+
+```rust
+use crate::types::{SeqNo, SeqRange};
+```
+
+- [ ] **Step 3: Migrate decode_entry in manifest_log.rs — two sites**
+
+Find the `TAG_ADD_RUN` decode arm. Current:
+
+```rust
+            Ok(ManifestEntry::AddRun {
+                level,
+                meta: SortedRunMeta {
+                    path,
+                    level,
+                    sequence_range: (seq_lo, seq_hi),
+                    archetype_coverage: coverage,
+                    page_count,
+                    size_bytes,
+                },
+            })
+```
+
+Replace:
+
+```rust
+            let meta = SortedRunMeta::new(
+                path,
+                level,
+                SeqRange::new(SeqNo(seq_lo), SeqNo(seq_hi))?,
+                coverage,
+                page_count,
+                size_bytes,
+            )?;
+            Ok(ManifestEntry::AddRun { level, meta })
+```
+
+Same pattern for `TAG_ADD_RUN_AND_SEQUENCE`:
+
+```rust
+            let meta = SortedRunMeta::new(
+                path,
+                level,
+                SeqRange::new(SeqNo(seq_lo), SeqNo(seq_hi))?,
+                coverage,
+                page_count,
+                size_bytes,
+            )?;
+            Ok(ManifestEntry::AddRunAndSequence {
+                level,
+                meta,
+                next_sequence,
+            })
+```
+
+Add import at top of `manifest_log.rs`:
+
+```rust
+use crate::types::{SeqNo, SeqRange};
+```
+
+- [ ] **Step 4: Migrate encode sites in manifest_log.rs**
+
+The encoder reads `meta.sequence_range.0` and `meta.sequence_range.1`. After the field type change, these accesses become `.lo.0` and `.hi.0`. Find and update two sites (AddRun and AddRunAndSequence branches in `encode_entry`):
+
+```rust
+            buf.extend_from_slice(&meta.sequence_range.lo.0.to_le_bytes());
+            buf.extend_from_slice(&meta.sequence_range.hi.0.to_le_bytes());
+```
+
+(Previously: `.sequence_range.0.to_le_bytes()` and `.sequence_range.1.to_le_bytes()`.)
+
+- [ ] **Step 5: Migrate the test_meta helper in manifest_log.rs test module**
+
+Find:
+
+```rust
+    fn test_meta(name: &str) -> SortedRunMeta {
+        SortedRunMeta {
+            path: PathBuf::from(name),
+            level: 0,
+            sequence_range: (10, 20),
+            archetype_coverage: vec![0, 3, 7],
+            page_count: 42,
+            size_bytes: 8192,
+        }
+    }
+```
+
+Replace:
+
+```rust
+    fn test_meta(name: &str) -> SortedRunMeta {
+        SortedRunMeta::new(
+            PathBuf::from(name),
+            0,
+            SeqRange::new(SeqNo(10), SeqNo(20)).unwrap(),
+            vec![0, 3, 7],
+            42,
+            8192,
+        )
+        .unwrap()
+    }
+```
+
+- [ ] **Step 6: Integration tests — reader.sequence_range() usage**
+
+In `crates/minkowski-lsm/tests/manifest_integration.rs`, `three_flushes_then_replay` currently asserts:
+
+```rust
+        assert_eq!(original.sequence_range(), recovered.sequence_range());
+```
+
+`SeqRange` has `PartialEq`, so this continues to work unchanged.
+
+If integration tests construct `SortedRunMeta` directly, migrate them using the same pattern. (A quick `grep "SortedRunMeta {" tests/` catches any missed sites.)
+
+Run: `grep -rn "SortedRunMeta {" crates/minkowski-lsm/` — any remaining matches need migrating.
+
+- [ ] **Step 7: Run `cargo check` — expect success now**
+
+Run: `cargo check -p minkowski-lsm`
+Expected: clean compile.
+
+- [ ] **Step 8: Run the full test suite**
+
+Run: `cargo test -p minkowski-lsm`
+Expected: all tests pass, including the 5 new `sorted_run_meta_new_*` tests.
+
+- [ ] **Step 9: Run clippy**
+
+Run: `cargo clippy -p minkowski-lsm --all-targets -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add crates/minkowski-lsm/src/manifest.rs \
+        crates/minkowski-lsm/src/manifest_log.rs \
+        crates/minkowski-lsm/src/manifest_ops.rs \
+        crates/minkowski-lsm/src/reader.rs \
+        crates/minkowski-lsm/tests/manifest_integration.rs
+git commit -m "feat(lsm): validated SortedRunMeta::new constructor + SeqRange
+
+Introduces the SortedRunMeta::new constructor that validates
+archetype_coverage is strictly sorted and page_count is non-zero.
+Migrates all in-crate construction sites through it.
+
+Changes sequence_range field type from (u64, u64) to SeqRange across
+SortedRunMeta, SortedRunReader, and the wire decoder. Encode path now
+accesses .lo.0 / .hi.0 for the u64 bytes. No wire format change.
+
+Fields remain pub(crate) for one more commit — Task 4 flips them fully
+private once all construction has been verified to go through new()."
+```
+
+---
+
+## Task 4: Make `SortedRunMeta` fields fully private
+
+**Files:**
+- Modify: `crates/minkowski-lsm/src/manifest.rs`
+
+- [ ] **Step 1: Flip field visibility**
+
+Change each `pub(crate)` to private (remove the visibility modifier):
+
+```rust
+pub struct SortedRunMeta {
+    path: PathBuf,
+    level: u8,
+    sequence_range: SeqRange,
+    archetype_coverage: Vec<u16>,
+    page_count: u64,
+    size_bytes: u64,
+}
+```
+
+- [ ] **Step 2: Run cargo check — verify no construction site still uses struct literal**
+
+Run: `cargo check -p minkowski-lsm`
+Expected: clean compile. If anything fails, it's a missed construction site — migrate it via `SortedRunMeta::new` and re-run.
+
+- [ ] **Step 3: Run full tests**
+
+Run: `cargo test -p minkowski-lsm`
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/minkowski-lsm/src/manifest.rs
+git commit -m "refactor(lsm): SortedRunMeta fields fully private
+
+All construction now goes through SortedRunMeta::new. Flip field
+visibility from pub(crate) to private to enforce this at the type
+system level — no more struct-literal construction bypassing validation.
+
+Behavior-preserving; all accessors already exist on the impl."
+```
+
+---
+
+## Task 5: Drop `SortedRunMeta::level` field
+
+**Files:**
+- Modify: `crates/minkowski-lsm/src/manifest.rs`
+- Modify: `crates/minkowski-lsm/src/manifest_log.rs`
+
+- [ ] **Step 1: Audit all readers of `meta.level()`**
+
+Run: `grep -rn "\.level()" crates/minkowski-lsm/`
+
+Expected results (as of the current branch):
+- `manifest.rs:183` in `promote_run_moves_between_levels` test — `assert_eq!(promoted.level(), 1);`
+- Possibly `manifest_log.rs` tests or `manifest_integration.rs`.
+
+Each reader needs migration: the level is always known from surrounding context (the `runs_at_level(l)` call, or the outer `AddRun.level` field, or the loop variable).
+
+- [ ] **Step 2: Remove the field and accessor**
+
+In `crates/minkowski-lsm/src/manifest.rs`:
+
+```rust
+pub struct SortedRunMeta {
+    path: PathBuf,
+    // level: u8,   <-- REMOVED
+    sequence_range: SeqRange,
+    archetype_coverage: Vec<u16>,
+    page_count: u64,
+    size_bytes: u64,
+}
+
+impl SortedRunMeta {
+    // Delete the `pub fn level(&self) -> u8` accessor entirely.
+    // ... other accessors unchanged ...
+}
+```
+
+Update the `new` constructor signature to drop the `level` parameter:
+
+```rust
+    pub fn new(
+        path: PathBuf,
+        // level parameter removed
+        sequence_range: SeqRange,
+        archetype_coverage: Vec<u16>,
+        page_count: u64,
+        size_bytes: u64,
+    ) -> Result<Self, LsmError> {
+```
+
+Update `promote_run` — the `meta.level = to_level` line is gone (field doesn't exist):
+
+```rust
+    pub fn promote_run(
+        &mut self,
+        from_level: u8,
+        to_level: u8,
+        path: &Path,
+    ) -> Result<(), LsmError> {
+        let meta = self.remove_run(from_level, path).ok_or_else(|| {
+            LsmError::Format(format!(
+                "run {} not found at level {}",
+                path.display(),
+                from_level
+            ))
+        })?;
+        self.add_run(to_level, meta);
+        Ok(())
+    }
+```
+
+- [ ] **Step 3: Update callers of `SortedRunMeta::new` to drop the level arg**
+
+Expect compile errors in:
+- `manifest_ops.rs::flush_and_record`
+- `manifest_log.rs::decode_entry` (two sites)
+- Test helpers (`test_meta` in manifest.rs, manifest_log.rs; cleanup_orphans test in manifest_ops.rs)
+- The 5 `sorted_run_meta_new_*` unit tests added in Task 2 — drop the `0` level argument from each call.
+
+For `flush_and_record`:
+
+```rust
+    let meta = SortedRunMeta::new(
+        path.clone(),
+        reader.sequence_range(),
+        archetype_coverage,
+        reader.page_count(),
+        file_size,
+    )?;
+```
+
+For `decode_entry` AddRun arm:
+
+```rust
+            let meta = SortedRunMeta::new(
+                path,
+                SeqRange::new(SeqNo(seq_lo), SeqNo(seq_hi))?,
+                coverage,
+                page_count,
+                size_bytes,
+            )?;
+            Ok(ManifestEntry::AddRun { level, meta })
+```
+
+Same pattern for AddRunAndSequence.
+
+Test helpers drop the `level` arg from the `new` call — note `test_meta` in manifest.rs still takes `level: u8` as a parameter, but only uses it for the test's tracking context, not for `SortedRunMeta` construction. Change signature to no longer require it, OR (simpler) keep the parameter for test readability but don't pass it to `new`. Simpler option:
+
+```rust
+    fn test_meta(name: &str, _level: u8) -> SortedRunMeta {
+        SortedRunMeta::new(
+            PathBuf::from(name),
+            SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+            vec![0],
+            1,
+            1024,
+        )
+        .unwrap()
+    }
+```
+
+But cleaner: drop the parameter entirely. Callers of `test_meta("foo.sst", 0)` become `test_meta("foo.sst")`.
+
+- [ ] **Step 4: Update the `promote_run_moves_between_levels` test**
+
+Original:
+
+```rust
+    #[test]
+    fn promote_run_moves_between_levels() {
+        let mut m = LsmManifest::new();
+        let meta = test_meta("run_x.sst", 0);
+        m.add_run(0, meta);
+        m.promote_run(0, 1, Path::new("run_x.sst")).unwrap();
+        assert!(m.runs_at_level(0).is_empty());
+        let promoted = &m.runs_at_level(1)[0];
+        assert_eq!(promoted.path(), Path::new("run_x.sst"));
+        assert_eq!(promoted.level(), 1);
+    }
+```
+
+Replace the `promoted.level()` check — it's gone. Level is now implicit from `runs_at_level(1)`:
+
+```rust
+    #[test]
+    fn promote_run_moves_between_levels() {
+        let mut m = LsmManifest::new();
+        let meta = test_meta("run_x.sst");
+        m.add_run(0, meta);
+        m.promote_run(0, 1, Path::new("run_x.sst")).unwrap();
+        assert!(m.runs_at_level(0).is_empty());
+        assert_eq!(m.runs_at_level(1).len(), 1);
+        assert_eq!(m.runs_at_level(1)[0].path(), Path::new("run_x.sst"));
+    }
+```
+
+- [ ] **Step 5: Run cargo check**
+
+Run: `cargo check -p minkowski-lsm`
+Expected: clean. Any remaining error is a missed `meta.level()` reader or `test_meta(_, level)` call site.
+
+- [ ] **Step 6: Run full tests**
+
+Run: `cargo test -p minkowski-lsm`
+Expected: all pass.
+
+- [ ] **Step 7: Run clippy**
+
+Run: `cargo clippy -p minkowski-lsm --all-targets -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/minkowski-lsm/
+git commit -m "refactor(lsm): drop redundant SortedRunMeta::level field
+
+The field was always a derived copy of the outer ManifestEntry::AddRun
+level (never independently stored on disk). Its in-memory existence
+created two sources of truth for one fact, surfacing as a real bug in
+PR #160 where promote_run left the field stale.
+
+The field and its accessor are gone. Callers that need the level know
+it from the runs_at_level(l) call or the outer entry variant — no
+information lost. No wire format change.
+
+promote_run simplifies: no more meta.level = to_level sync step."
+```
+
+---
+
+## Task 6: Migrate `LsmManifest` signatures + `ManifestEntry` variants to `Level`
+
+**Files:**
+- Modify: `crates/minkowski-lsm/src/manifest.rs`
+- Modify: `crates/minkowski-lsm/src/manifest_log.rs`
+- Modify: `crates/minkowski-lsm/src/manifest_ops.rs`
+- Modify: `crates/minkowski-lsm/tests/manifest_integration.rs`
+
+- [ ] **Step 1: Update LsmManifest public signatures**
+
+In `crates/minkowski-lsm/src/manifest.rs`:
+
+```rust
+use crate::types::{Level, SeqNo, SeqRange};
+
+impl LsmManifest {
+    pub fn add_run(&mut self, level: Level, meta: SortedRunMeta) {
+        self.levels[level.as_index()].push(meta);
+    }
+
+    pub fn remove_run(&mut self, level: Level, path: &Path) -> Option<SortedRunMeta> {
+        let runs = &mut self.levels[level.as_index()];
+        runs.iter()
+            .position(|r| r.path() == path)
+            .map(|pos| runs.remove(pos))
+    }
+
+    pub fn promote_run(
+        &mut self,
+        from: Level,
+        to: Level,
+        path: &Path,
+    ) -> Result<(), LsmError> {
+        let meta = self.remove_run(from, path).ok_or_else(|| {
+            LsmError::Format(format!(
+                "run {} not found at level {}",
+                path.display(),
+                from
+            ))
+        })?;
+        self.add_run(to, meta);
+        Ok(())
+    }
+
+    pub fn runs_at_level(&self, level: Level) -> &[SortedRunMeta] {
+        &self.levels[level.as_index()]
+    }
+}
+```
+
+The `assert!((level as usize) < NUM_LEVELS, ...)` in `add_run` goes away — `Level::new` enforced it at construction.
+
+Note: `remove_run` used `r.path` (direct field access). After Task 4 private fields, that field is private. Use the accessor `r.path()` instead.
+
+- [ ] **Step 2: Update ManifestEntry variants**
+
+In `crates/minkowski-lsm/src/manifest_log.rs`:
+
+```rust
+use crate::types::{Level, SeqNo, SeqRange};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ManifestEntry {
+    AddRun {
+        level: Level,
+        meta: SortedRunMeta,
+    },
+    RemoveRun {
+        level: Level,
+        path: PathBuf,
+    },
+    PromoteRun {
+        from_level: Level,
+        to_level: Level,
+        path: PathBuf,
+    },
+    SetSequence {
+        next_sequence: SeqNo,
+    },
+    AddRunAndSequence {
+        level: Level,
+        meta: SortedRunMeta,
+        next_sequence: SeqNo,
+    },
+}
+```
+
+- [ ] **Step 3: Update encode_entry for Level and SeqNo**
+
+In `encode_entry`:
+
+```rust
+        ManifestEntry::AddRun { level, meta } => {
+            buf.push(TAG_ADD_RUN);
+            buf.push(level.as_u8());            // was: *level
+            ...
+        }
+        ManifestEntry::RemoveRun { level, path } => {
+            buf.push(TAG_REMOVE_RUN);
+            buf.push(level.as_u8());            // was: *level
+            ...
+        }
+        ManifestEntry::PromoteRun { from_level, to_level, path } => {
+            buf.push(TAG_PROMOTE_RUN);
+            buf.push(from_level.as_u8());       // was: *from_level
+            buf.push(to_level.as_u8());         // was: *to_level
+            ...
+        }
+        ManifestEntry::SetSequence { next_sequence } => {
+            buf.push(TAG_SET_SEQUENCE);
+            buf.extend_from_slice(&next_sequence.0.to_le_bytes());   // was: next_sequence.to_le_bytes()
+        }
+        ManifestEntry::AddRunAndSequence { level, meta, next_sequence } => {
+            buf.push(TAG_ADD_RUN_AND_SEQUENCE);
+            buf.push(level.as_u8());
+            ...
+            buf.extend_from_slice(&next_sequence.0.to_le_bytes());
+        }
+```
+
+- [ ] **Step 4: Update decode_entry for Level and SeqNo**
+
+Every `data[offset]` that represents a level now needs `Level::new(...)`:
+
+```rust
+        TAG_ADD_RUN => {
+            if offset >= data.len() {
+                return Err(LsmError::Format("truncated AddRun".to_owned()));
+            }
+            let level_byte = data[offset];
+            offset += 1;
+            let level = Level::new(level_byte)
+                .ok_or_else(|| LsmError::Format(format!("invalid level {level_byte}")))?;
+            let path = decode_path(data, &mut offset)?;
+            let seq_lo = read_u64_le(data, &mut offset)?;
+            let seq_hi = read_u64_le(data, &mut offset)?;
+            let count = read_u16_le(data, &mut offset)? as usize;
+            // ... (coverage loop unchanged)
+            let page_count = read_u64_le(data, &mut offset)?;
+            let size_bytes = read_u64_le(data, &mut offset)?;
+
+            let meta = SortedRunMeta::new(
+                path,
+                SeqRange::new(SeqNo(seq_lo), SeqNo(seq_hi))?,
+                coverage,
+                page_count,
+                size_bytes,
+            )?;
+            Ok(ManifestEntry::AddRun { level, meta })
+        }
+```
+
+Apply the same `level_byte → Level::new(...)?` pattern to `TAG_REMOVE_RUN`, `TAG_PROMOTE_RUN` (two bytes), and `TAG_ADD_RUN_AND_SEQUENCE`.
+
+For `TAG_SET_SEQUENCE`:
+
+```rust
+        TAG_SET_SEQUENCE => {
+            let next_sequence = SeqNo(read_u64_le(data, &mut offset)?);
+            Ok(ManifestEntry::SetSequence { next_sequence })
+        }
+```
+
+- [ ] **Step 5: Update `apply_entry`**
+
+Inside `apply_entry`:
+
+```rust
+        ManifestEntry::AddRun { level, meta } => manifest.add_run(*level, meta.clone()),
+        ManifestEntry::RemoveRun { level, path } => {
+            manifest.remove_run(*level, path);
+        }
+        ManifestEntry::PromoteRun { from_level, to_level, path } => {
+            manifest.promote_run(*from_level, *to_level, path)?;
+        }
+        ManifestEntry::SetSequence { next_sequence } => {
+            manifest.set_next_sequence(*next_sequence);
+        }
+        ManifestEntry::AddRunAndSequence { level, meta, next_sequence } => {
+            manifest.add_run(*level, meta.clone());
+            manifest.set_next_sequence(*next_sequence);
+        }
+```
+
+`*level` is now `Level` (Copy), `*next_sequence` is `SeqNo` (Copy). Signatures downstream take these types; no conversion needed.
+
+- [ ] **Step 6: Update LsmManifest::set_next_sequence and next_sequence signatures**
+
+In `manifest.rs`:
+
+```rust
+    pub fn set_next_sequence(&mut self, seq: SeqNo) {
+        self.next_sequence = seq.0;
+    }
+
+    pub fn next_sequence(&self) -> SeqNo {
+        SeqNo(self.next_sequence)
+    }
+```
+
+Keep the internal `next_sequence: u64` storage — the public face is `SeqNo`, the internal representation stays the same.
+
+- [ ] **Step 7: Migrate flush_and_record in manifest_ops.rs**
+
+```rust
+    log.append(&ManifestEntry::AddRunAndSequence {
+        level: Level::L0,                                      // was: 0
+        meta: meta.clone(),
+        next_sequence: SeqNo(sequence_range.1),                // was: sequence_range.1
+    })?;
+
+    manifest.add_run(Level::L0, meta);                         // was: 0
+    manifest.set_next_sequence(SeqNo(sequence_range.1));       // was: sequence_range.1
+```
+
+Wait — `sequence_range` here is still `(u64, u64)` because it's the function parameter tuple, not the SeqRange on the meta. Keep as is (external callers still pass the tuple for now). Internal conversion to SeqRange happens when building the meta.
+
+Update import at top of file:
+
+```rust
+use crate::types::{Level, SeqNo, SeqRange};
+```
+
+- [ ] **Step 8: Migrate test call sites**
+
+Throughout `manifest.rs` test module, `manifest_log.rs` test module, `manifest_ops.rs` test module, and `manifest_integration.rs`:
+
+- Change `manifest.add_run(0, meta)` → `manifest.add_run(Level::L0, meta)`.
+- Change `manifest.runs_at_level(0)` → `manifest.runs_at_level(Level::L0)`.
+- Change `manifest.promote_run(0, 1, path)` → `manifest.promote_run(Level::L0, Level::L1, path)`.
+- Change `ManifestEntry::AddRun { level: 0, ... }` → `ManifestEntry::AddRun { level: Level::L0, ... }`.
+- Change `ManifestEntry::SetSequence { next_sequence: 10 }` → `ManifestEntry::SetSequence { next_sequence: SeqNo(10) }`.
+- For assertion sites comparing `next_sequence()`, compare to `SeqNo(value)`: `assert_eq!(manifest.next_sequence(), SeqNo(10));`.
+
+Import in integration tests:
+
+```rust
+use minkowski_lsm::types::{Level, SeqNo, SeqRange};
+```
+
+Run `cargo check -p minkowski-lsm` and iterate — the compiler enumerates the remaining sites. Expect ~20-40 line-level edits across all test files.
+
+- [ ] **Step 9: Run cargo check, tests, clippy**
+
+```
+cargo check -p minkowski-lsm
+cargo test -p minkowski-lsm
+cargo clippy -p minkowski-lsm --all-targets -- -D warnings
+```
+
+All expected to pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add crates/minkowski-lsm/
+git commit -m "refactor(lsm): migrate LsmManifest and ManifestEntry to Level/SeqNo
+
+All public APIs taking levels now take Level. All public APIs exposing
+sequence numbers use SeqNo. ManifestEntry variants follow suit.
+
+Bounds checking centralizes in Level::new. The scattered assert! sites
+in LsmManifest are gone — the type system has already rejected invalid
+levels at decode time (Level::new returns None -> LsmError::Format).
+
+Wire format unchanged: Level.as_u8()/Level::new(byte) at codec edges,
+SeqNo.0/SeqNo(u64) at seq-field edges. Internal u8/u64 storage is
+unchanged; only the API surface shifts."
+```
+
+---
+
+## Task 7: Regression test — corrupted archetype_coverage triggers tail truncation
+
+**Files:**
+- Modify: `crates/minkowski-lsm/tests/manifest_integration.rs`
+
+- [ ] **Step 1: Write the regression test**
+
+Add to `manifest_integration.rs`:
+
+```rust
+/// Regression for PR A: a frame whose decoded SortedRunMeta fails
+/// validation (unsorted coverage) must be treated as tail garbage.
+/// This wires the new constructor's validation into the existing
+/// torn-tail recovery path.
+#[test]
+fn replay_truncates_log_on_unsorted_coverage() {
+    let dir = tempfile::tempdir().unwrap();
+    let log_path = dir.path().join("manifest.log");
+    let mut manifest = LsmManifest::new();
+    let mut log = ManifestLog::create(&log_path).unwrap();
+
+    let mut world = World::new();
+    world.spawn((Pos { x: 1.0, y: 0.0 },));
+    // One real flush, produces a valid AddRunAndSequence frame.
+    flush_and_record(&world, (0, 10), &mut manifest, &mut log, dir.path()).unwrap();
+
+    let len_after_first_frame = fs::metadata(&log_path).unwrap().len();
+
+    // Manually craft an AddRun frame with unsorted archetype_coverage.
+    // Bypasses SortedRunMeta::new (can't call it — would error) by
+    // encoding the bytes directly.
+    let mut payload = Vec::new();
+    payload.push(0x01); // TAG_ADD_RUN
+    payload.push(0);    // level
+    // path: "x.run"
+    let path_bytes = b"x.run";
+    payload.extend_from_slice(&(path_bytes.len() as u16).to_le_bytes());
+    payload.extend_from_slice(path_bytes);
+    payload.extend_from_slice(&0u64.to_le_bytes()); // seq_lo
+    payload.extend_from_slice(&10u64.to_le_bytes()); // seq_hi
+    // archetype_coverage: [3, 1] — intentionally unsorted
+    payload.extend_from_slice(&2u16.to_le_bytes()); // count
+    payload.extend_from_slice(&3u16.to_le_bytes());
+    payload.extend_from_slice(&1u16.to_le_bytes());
+    payload.extend_from_slice(&1u64.to_le_bytes()); // page_count
+    payload.extend_from_slice(&1024u64.to_le_bytes()); // size_bytes
+
+    // Write frame: [len: u32 LE][crc32: u32 LE][payload]
+    let mut f = fs::OpenOptions::new().append(true).open(&log_path).unwrap();
+    let len = payload.len() as u32;
+    let crc = crc32fast::hash(&payload);
+    f.write_all(&len.to_le_bytes()).unwrap();
+    f.write_all(&crc.to_le_bytes()).unwrap();
+    f.write_all(&payload).unwrap();
+    f.sync_all().unwrap();
+    drop(f);
+
+    // Replay must truncate back to the end of the first valid frame.
+    let recovered = ManifestLog::replay(&log_path).unwrap();
+    assert_eq!(recovered.total_runs(), 1, "only the valid first flush survives");
+
+    let len_after_replay = fs::metadata(&log_path).unwrap().len();
+    assert_eq!(
+        len_after_replay, len_after_first_frame,
+        "replay truncated the bad frame"
+    );
+}
+```
+
+Add `std::io::Write` to imports at the top of the integration test file (already present from existing tests; verify).
+
+`crc32fast` is already a main dependency of `minkowski-lsm` (see `crates/minkowski-lsm/Cargo.toml:11`), so it's usable directly from integration tests via `minkowski_lsm`-adjacent imports. Specifically, access it as `use crc32fast;` at the top of `manifest_integration.rs` — integration tests can depend on main dependencies of the crate under test.
+
+If the import fails at compile time (integration tests sometimes need transitive deps declared explicitly in `[dev-dependencies]`), add to `crates/minkowski-lsm/Cargo.toml`:
+
+```toml
+[dev-dependencies]
+crc32fast = "1"
+# existing dev deps unchanged
+```
+
+- [ ] **Step 2: Run the new test to verify it passes**
+
+Run: `cargo test -p minkowski-lsm --test manifest_integration replay_truncates_log_on_unsorted_coverage`
+Expected: PASS.
+
+- [ ] **Step 3: Run full crate tests**
+
+Run: `cargo test -p minkowski-lsm`
+Expected: all pass, including this new test.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/minkowski-lsm/
+git commit -m "test(lsm): replay truncates on SortedRunMeta validation failure
+
+Regression covering the new SortedRunMeta::new validation: a log frame
+whose decoded coverage vec fails the sorted+deduped check must be
+treated as tail garbage, not propagated as a fatal error. Wires the
+new validation into the existing torn-tail recovery path.
+
+Handcrafts the bad frame with raw bytes + crc32 to bypass the
+constructor (which would otherwise reject the payload at construction)."
+```
+
+---
+
+## Task 8: Final verification
+
+**No code changes. Green-light gate before PR.**
+
+- [ ] **Step 1: Update local toolchain to match CI**
+
+Run: `rustup update stable`
+Expected: toolchain updates (or no-op if already current).
+
+- [ ] **Step 2: Run workspace clippy (matches CI)**
+
+Run: `cargo clippy --workspace --all-targets -- -D warnings`
+Expected: clean.
+
+If any lint fires that your local 1.93 missed, fix it and amend the relevant commit (or add a new chore commit).
+
+- [ ] **Step 3: Run workspace test suite**
+
+Run: `cargo test --workspace`
+Expected: all pass.
+
+- [ ] **Step 4: Run cargo fmt check**
+
+Run: `cargo fmt --all -- --check`
+Expected: clean.
+
+- [ ] **Step 5: Push and open PR**
+
+```bash
+git push -u origin docs/lsm-type-safety-design
+gh pr create --title "feat(lsm): manifest type-safety refactor (PR A)" --body "$(cat <<'EOF'
+## Summary
+
+First half of the type-safety follow-up from PR #160's review. Introduces
+`SeqNo` / `SeqRange` / `Level` newtype primitives, a validated
+`SortedRunMeta::new` constructor, and drops the redundant
+`SortedRunMeta::level` field.
+
+Design: docs/plans/2026-04-16-lsm-manifest-type-safety-design.md
+
+No wire format change — purely internal type refactor.
+
+## Test plan
+
+- [x] cargo test -p minkowski-lsm (all pass, including 13 new tests across types + constructor + regression)
+- [x] cargo clippy --workspace --all-targets -- -D warnings (clean)
+- [x] cargo test --workspace (all pass)
+
+🤖 Generated with Claude Code
+EOF
+)"
+```
+
+- [ ] **Step 6: Update project memory after merge**
+
+Once the PR merges, update `project_lsm_phase2_type_safety.md` to reflect PR A completion. Trim items 1-4 from the follow-up list; PR B scope remains (items 5-7).
+
+---
+
+## Self-review (done inline before saving)
+
+- **Spec coverage:** Each of the 7 design sections in the spec has a task:
+  - Section 1 (new types) → Task 1
+  - Section 2 (SortedRunMeta shape) → Tasks 2, 4, 5
+  - Section 3 (LsmManifest signatures) → Task 6
+  - Section 4 (wire format unchanged) → enforced by Task 6's encode/decode edits
+  - Section 5 (decode integration) → Task 6 Step 4
+  - Section 6 (migration inventory) → spread across Tasks 2-6
+  - Section 7 (error type reuse) → enforced by using `LsmError::Format` throughout
+  - Testing strategy → Tasks 1, 2, 7
+
+- **Placeholder scan:** None. Every code block is full code.
+
+- **Type consistency:** `Level::L0` / `Level::new(0).unwrap()` / `Level::new(byte).ok_or(...)?` used consistently. `SeqNo(u64)` / `SeqNo(seq_hi)` / `seq.0` consistently. `SortedRunMeta::new` signature in Task 2 takes 6 args; in Task 5 drops `level` to 5 args. Documented at the Task 5 transition.
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/plans/2026-04-16-lsm-manifest-type-safety-implementation-plan.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. Good for an 8-task plan with compiler-driven migrations where the model could get lost in the weeds.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints for review.
+
+Which approach?

--- a/docs/plans/2026-04-16-lsm-manifest-type-safety-implementation-plan.md
+++ b/docs/plans/2026-04-16-lsm-manifest-type-safety-implementation-plan.md
@@ -82,8 +82,8 @@ impl fmt::Display for SeqNo {
 /// range (syntactically allowed, not currently produced by any code path).
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct SeqRange {
-    pub lo: SeqNo,
-    pub hi: SeqNo,
+    pub(crate) lo: SeqNo,
+    pub(crate) hi: SeqNo,
 }
 
 impl SeqRange {
@@ -164,8 +164,8 @@ mod tests {
     #[test]
     fn seqrange_accepts_lo_less_than_hi() {
         let r = SeqRange::new(SeqNo(0), SeqNo(10)).unwrap();
-        assert_eq!(r.lo.0, 0);
-        assert_eq!(r.hi.0, 10);
+        assert_eq!(r.lo, SeqNo(0));
+        assert_eq!(r.hi, SeqNo(10));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

First half of the type-safety follow-up from PR #160's review. Introduces `SeqNo` / `SeqRange` / `Level` newtype primitives, a validated `SortedRunMeta::new` constructor, and drops the redundant `SortedRunMeta::level` field across the `minkowski-lsm` crate.

**Wire format: unchanged.** Pure in-memory refactor. Existing on-disk manifest logs replay unchanged.

## What landed

- **`types` module** (new): `SeqNo`, `SeqRange` (half-open `[lo, hi)`), `Level` with `L0..L3` consts. Each newtype centralizes one invariant at construction.
- **`SortedRunMeta::new`**: validates `archetype_coverage` is strictly sorted+deduped and `page_count > 0`. Every in-crate construction site now goes through it; fields are fully private.
- **`SortedRunMeta.level` field dropped**: was a derived copy of the outer `ManifestEntry.level` byte (PR #160 caught a real bug from keeping the two in sync on promotion). Array slot in `LsmManifest::levels[i]` is the single source of truth.
- **`LsmManifest` + `ManifestEntry`**: public APIs now take `Level` / `SeqNo`. The scattered `assert!((level as usize) < NUM_LEVELS)` checks are gone — `Level::new` enforces the invariant once.
- **Decode validation**: `Level::new(byte).ok_or(LsmError::Format)?` + `SortedRunMeta::new(...)?` at every decode site. Integrates with the existing torn-tail truncation path from PR #160.

## Tests

83 total (81 before + 2 new regression tests):
- 5 unit tests for `SortedRunMeta::new` validation paths.
- 9 unit tests for the new types (`SeqNo`, `SeqRange`, `Level`).
- 2 integration regression tests — `replay_truncates_log_on_unsorted_coverage` and `replay_truncates_log_on_invalid_level_byte` — confirm decode-stage validation errors trigger tail truncation rather than fatal error propagation.

## Design

- Design doc: `docs/plans/2026-04-16-lsm-manifest-type-safety-design.md`
- Implementation plan: `docs/plans/2026-04-16-lsm-manifest-type-safety-implementation-plan.md`

## Deferred to PR B

- `ManifestLog::recover(path) -> (LsmManifest, ManifestLog)` unified entry (closes the "append on torn tail" footgun).
- Magic + version header at byte 0 of the log.
- Parent-directory fsync after `truncate_at`.

## Test plan

- [x] `cargo test -p minkowski-lsm` — 83/83 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI pipeline (fmt, clippy, test, tsan, loom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)