### PR TITLE
chore(lsm): manifest type-safety polish (PR B3)

### DIFF
--- a/crates/minkowski-lsm/src/manifest.rs
+++ b/crates/minkowski-lsm/src/manifest.rs
@@ -46,7 +46,7 @@ impl SortedRunMeta {
     /// Build a `SortedRunMeta` with enforced invariants.
     ///
     /// Validates:
-    /// - `archetype_coverage` is strictly sorted ascending (sorted + deduped).
+    /// - `archetype_coverage` is strictly ascending (no duplicates, no reordering).
     ///
     /// `page_count` is already non-zero (enforced by `PageCount::new` at the
     /// call site). `sequence_range` is already validated by `SeqRange::new`.

--- a/crates/minkowski-lsm/src/manifest.rs
+++ b/crates/minkowski-lsm/src/manifest.rs
@@ -118,12 +118,12 @@ impl LsmManifest {
 
     /// Record the next sequence number to assign on flush.
     pub fn set_next_sequence(&mut self, seq: SeqNo) {
-        self.next_sequence = seq.0;
+        self.next_sequence = seq.get();
     }
 
     /// The next sequence number to assign on the next flush.
     pub fn next_sequence(&self) -> SeqNo {
-        SeqNo(self.next_sequence)
+        SeqNo::from(self.next_sequence)
     }
 
     /// All sorted runs currently tracked at the given level.
@@ -158,7 +158,7 @@ mod tests {
     fn test_meta(name: &str) -> SortedRunMeta {
         SortedRunMeta::new(
             PathBuf::from(name),
-            SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
             vec![0],
             1,
             1024,
@@ -172,7 +172,7 @@ mod tests {
         for lvl in 0..NUM_LEVELS {
             assert!(m.runs_at_level(Level::new(lvl as u8).unwrap()).is_empty());
         }
-        assert_eq!(m.next_sequence(), SeqNo(0));
+        assert_eq!(m.next_sequence(), SeqNo::from(0u64));
         assert_eq!(m.total_runs(), 0);
     }
 
@@ -246,21 +246,21 @@ mod tests {
     #[test]
     fn set_and_get_next_sequence() {
         let mut m = LsmManifest::new();
-        m.set_next_sequence(SeqNo(42));
-        assert_eq!(m.next_sequence(), SeqNo(42));
+        m.set_next_sequence(SeqNo::from(42u64));
+        assert_eq!(m.next_sequence(), SeqNo::from(42u64));
     }
 
     #[test]
     fn sorted_run_meta_new_accepts_valid_input() {
         let meta = SortedRunMeta::new(
             PathBuf::from("0-10.run"),
-            SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
             vec![0, 3, 7],
             1,
             1024,
         )
         .unwrap();
-        assert_eq!(meta.sequence_range().lo(), SeqNo(0));
+        assert_eq!(meta.sequence_range().lo(), SeqNo::from(0u64));
         assert_eq!(meta.page_count().get(), 1);
     }
 
@@ -268,7 +268,7 @@ mod tests {
     fn sorted_run_meta_new_rejects_unsorted_coverage() {
         let result = SortedRunMeta::new(
             PathBuf::from("x.run"),
-            SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
             vec![3, 1, 2],
             1,
             1024,
@@ -280,7 +280,7 @@ mod tests {
     fn sorted_run_meta_new_rejects_duplicated_coverage() {
         let result = SortedRunMeta::new(
             PathBuf::from("x.run"),
-            SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
             vec![1, 2, 2, 3],
             1,
             1024,
@@ -292,7 +292,7 @@ mod tests {
     fn sorted_run_meta_new_accepts_empty_coverage() {
         let meta = SortedRunMeta::new(
             PathBuf::from("x.run"),
-            SeqRange::new(SeqNo(0), SeqNo(0)).unwrap(),
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(0u64)).unwrap(),
             vec![],
             1,
             1024,
@@ -305,7 +305,7 @@ mod tests {
     fn sorted_run_meta_new_rejects_zero_page_count() {
         let result = SortedRunMeta::new(
             PathBuf::from("x.run"),
-            SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
             vec![0],
             0,
             1024,

--- a/crates/minkowski-lsm/src/manifest.rs
+++ b/crates/minkowski-lsm/src/manifest.rs
@@ -259,6 +259,7 @@ mod tests {
         .unwrap();
         assert_eq!(meta.sequence_range().lo(), SeqNo::from(0u64));
         assert_eq!(meta.page_count().get(), 1);
+        assert_eq!(meta.size_bytes().get(), 1024);
     }
 
     #[test]

--- a/crates/minkowski-lsm/src/manifest.rs
+++ b/crates/minkowski-lsm/src/manifest.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::error::LsmError;
-use crate::types::{Level, PageCount, SeqNo, SeqRange};
+use crate::types::{Level, PageCount, SeqNo, SeqRange, SizeBytes};
 
 /// Number of LSM levels (L0 through L3).
 pub const NUM_LEVELS: usize = 4;
@@ -19,7 +19,7 @@ pub struct SortedRunMeta {
     sequence_range: SeqRange,
     archetype_coverage: Box<[u16]>,
     page_count: PageCount,
-    size_bytes: u64,
+    size_bytes: SizeBytes,
 }
 
 impl SortedRunMeta {
@@ -39,7 +39,7 @@ impl SortedRunMeta {
         self.page_count
     }
 
-    pub fn size_bytes(&self) -> u64 {
+    pub fn size_bytes(&self) -> SizeBytes {
         self.size_bytes
     }
 
@@ -47,25 +47,22 @@ impl SortedRunMeta {
     ///
     /// Validates:
     /// - `archetype_coverage` is strictly sorted ascending (sorted + deduped).
-    /// - `page_count` is non-zero.
     ///
-    /// `sequence_range` is already validated by `SeqRange::new`. `size_bytes` is
-    /// not validated (redundant with `page_count`; a valid run file always
-    /// has a non-empty header).
+    /// `page_count` is already non-zero (enforced by `PageCount::new` at the
+    /// call site). `sequence_range` is already validated by `SeqRange::new`.
+    /// `size_bytes` is not validated (zero is permitted for this newtype).
     pub fn new(
         path: PathBuf,
         sequence_range: SeqRange,
         archetype_coverage: Vec<u16>,
-        page_count: u64,
-        size_bytes: u64,
+        page_count: PageCount,
+        size_bytes: SizeBytes,
     ) -> Result<Self, LsmError> {
         if archetype_coverage.windows(2).any(|w| w[0] >= w[1]) {
             return Err(LsmError::Format(
                 "archetype_coverage is not strictly sorted".to_owned(),
             ));
         }
-        let page_count = PageCount::new(page_count)
-            .ok_or_else(|| LsmError::Format("page_count must be non-zero".to_owned()))?;
         Ok(Self {
             path,
             sequence_range,
@@ -153,15 +150,15 @@ impl Default for LsmManifest {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{Level, SeqNo, SeqRange};
+    use crate::types::{Level, PageCount, SeqNo, SeqRange, SizeBytes};
 
     fn test_meta(name: &str) -> SortedRunMeta {
         SortedRunMeta::new(
             PathBuf::from(name),
             SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
             vec![0],
-            1,
-            1024,
+            PageCount::new(1).unwrap(),
+            SizeBytes::new(1024),
         )
         .unwrap()
     }
@@ -256,8 +253,8 @@ mod tests {
             PathBuf::from("0-10.run"),
             SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
             vec![0, 3, 7],
-            1,
-            1024,
+            PageCount::new(1).unwrap(),
+            SizeBytes::new(1024),
         )
         .unwrap();
         assert_eq!(meta.sequence_range().lo(), SeqNo::from(0u64));
@@ -270,8 +267,8 @@ mod tests {
             PathBuf::from("x.run"),
             SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
             vec![3, 1, 2],
-            1,
-            1024,
+            PageCount::new(1).unwrap(),
+            SizeBytes::new(1024),
         );
         assert!(matches!(result, Err(LsmError::Format(_))));
     }
@@ -282,8 +279,8 @@ mod tests {
             PathBuf::from("x.run"),
             SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
             vec![1, 2, 2, 3],
-            1,
-            1024,
+            PageCount::new(1).unwrap(),
+            SizeBytes::new(1024),
         );
         assert!(matches!(result, Err(LsmError::Format(_))));
     }
@@ -294,22 +291,10 @@ mod tests {
             PathBuf::from("x.run"),
             SeqRange::new(SeqNo::from(0u64), SeqNo::from(0u64)).unwrap(),
             vec![],
-            1,
-            1024,
+            PageCount::new(1).unwrap(),
+            SizeBytes::new(1024),
         )
         .unwrap();
         assert_eq!(meta.archetype_coverage().len(), 0);
-    }
-
-    #[test]
-    fn sorted_run_meta_new_rejects_zero_page_count() {
-        let result = SortedRunMeta::new(
-            PathBuf::from("x.run"),
-            SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
-            vec![0],
-            0,
-            1024,
-        );
-        assert!(matches!(result, Err(LsmError::Format(_))));
     }
 }

--- a/crates/minkowski-lsm/src/manifest_log.rs
+++ b/crates/minkowski-lsm/src/manifest_log.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 
 use crate::error::LsmError;
 use crate::manifest::{LsmManifest, SortedRunMeta};
-use crate::types::{Level, SeqNo, SeqRange};
+use crate::types::{Level, PageCount, SeqNo, SeqRange, SizeBytes};
 
 // ── File header ─────────────────────────────────────────────────────────────
 
@@ -243,7 +243,7 @@ fn encode_entry(entry: &ManifestEntry) -> Result<Vec<u8>, LsmError> {
             buf.extend_from_slice(&meta.sequence_range().hi().get().to_le_bytes());
             encode_coverage(&mut buf, meta.archetype_coverage())?;
             buf.extend_from_slice(&meta.page_count().get().to_le_bytes());
-            buf.extend_from_slice(&meta.size_bytes().to_le_bytes());
+            buf.extend_from_slice(&meta.size_bytes().get().to_le_bytes());
         }
         ManifestEntry::RemoveRun { level, path } => {
             buf.push(TAG_REMOVE_RUN);
@@ -276,7 +276,7 @@ fn encode_entry(entry: &ManifestEntry) -> Result<Vec<u8>, LsmError> {
             buf.extend_from_slice(&meta.sequence_range().hi().get().to_le_bytes());
             encode_coverage(&mut buf, meta.archetype_coverage())?;
             buf.extend_from_slice(&meta.page_count().get().to_le_bytes());
-            buf.extend_from_slice(&meta.size_bytes().to_le_bytes());
+            buf.extend_from_slice(&meta.size_bytes().get().to_le_bytes());
             buf.extend_from_slice(&next_sequence.get().to_le_bytes());
         }
     }
@@ -312,13 +312,14 @@ fn decode_entry(data: &[u8]) -> Result<ManifestEntry, LsmError> {
             }
             let page_count = read_u64_le(data, &mut offset)?;
             let size_bytes = read_u64_le(data, &mut offset)?;
-
+            let page_count = PageCount::new(page_count)
+                .ok_or_else(|| LsmError::Format("page_count must be non-zero".to_owned()))?;
             let meta = SortedRunMeta::new(
                 path,
                 SeqRange::new(SeqNo::from(seq_lo), SeqNo::from(seq_hi))?,
                 coverage,
                 page_count,
-                size_bytes,
+                SizeBytes::new(size_bytes),
             )?;
             Ok(ManifestEntry::AddRun { level, meta })
         }
@@ -378,13 +379,14 @@ fn decode_entry(data: &[u8]) -> Result<ManifestEntry, LsmError> {
             let page_count = read_u64_le(data, &mut offset)?;
             let size_bytes = read_u64_le(data, &mut offset)?;
             let next_sequence = SeqNo::from(read_u64_le(data, &mut offset)?);
-
+            let page_count = PageCount::new(page_count)
+                .ok_or_else(|| LsmError::Format("page_count must be non-zero".to_owned()))?;
             let meta = SortedRunMeta::new(
                 path,
                 SeqRange::new(SeqNo::from(seq_lo), SeqNo::from(seq_hi))?,
                 coverage,
                 page_count,
-                size_bytes,
+                SizeBytes::new(size_bytes),
             )?;
             Ok(ManifestEntry::AddRunAndSequence {
                 level,
@@ -549,15 +551,15 @@ mod tests {
     use std::fs;
 
     use super::*;
-    use crate::types::Level;
+    use crate::types::{Level, PageCount, SizeBytes};
 
     fn test_meta(name: &str) -> SortedRunMeta {
         SortedRunMeta::new(
             PathBuf::from(name),
             SeqRange::new(SeqNo::from(10u64), SeqNo::from(20u64)).unwrap(),
             vec![0, 3, 7],
-            42,
-            8192,
+            PageCount::new(42).unwrap(),
+            SizeBytes::new(8192),
         )
         .unwrap()
     }

--- a/crates/minkowski-lsm/src/manifest_log.rs
+++ b/crates/minkowski-lsm/src/manifest_log.rs
@@ -239,8 +239,8 @@ fn encode_entry(entry: &ManifestEntry) -> Result<Vec<u8>, LsmError> {
             buf.push(TAG_ADD_RUN);
             buf.push(level.as_u8());
             encode_path(&mut buf, meta.path())?;
-            buf.extend_from_slice(&meta.sequence_range().lo().0.to_le_bytes());
-            buf.extend_from_slice(&meta.sequence_range().hi().0.to_le_bytes());
+            buf.extend_from_slice(&meta.sequence_range().lo().get().to_le_bytes());
+            buf.extend_from_slice(&meta.sequence_range().hi().get().to_le_bytes());
             encode_coverage(&mut buf, meta.archetype_coverage())?;
             buf.extend_from_slice(&meta.page_count().get().to_le_bytes());
             buf.extend_from_slice(&meta.size_bytes().to_le_bytes());
@@ -262,7 +262,7 @@ fn encode_entry(entry: &ManifestEntry) -> Result<Vec<u8>, LsmError> {
         }
         ManifestEntry::SetSequence { next_sequence } => {
             buf.push(TAG_SET_SEQUENCE);
-            buf.extend_from_slice(&next_sequence.0.to_le_bytes());
+            buf.extend_from_slice(&next_sequence.get().to_le_bytes());
         }
         ManifestEntry::AddRunAndSequence {
             level,
@@ -272,12 +272,12 @@ fn encode_entry(entry: &ManifestEntry) -> Result<Vec<u8>, LsmError> {
             buf.push(TAG_ADD_RUN_AND_SEQUENCE);
             buf.push(level.as_u8());
             encode_path(&mut buf, meta.path())?;
-            buf.extend_from_slice(&meta.sequence_range().lo().0.to_le_bytes());
-            buf.extend_from_slice(&meta.sequence_range().hi().0.to_le_bytes());
+            buf.extend_from_slice(&meta.sequence_range().lo().get().to_le_bytes());
+            buf.extend_from_slice(&meta.sequence_range().hi().get().to_le_bytes());
             encode_coverage(&mut buf, meta.archetype_coverage())?;
             buf.extend_from_slice(&meta.page_count().get().to_le_bytes());
             buf.extend_from_slice(&meta.size_bytes().to_le_bytes());
-            buf.extend_from_slice(&next_sequence.0.to_le_bytes());
+            buf.extend_from_slice(&next_sequence.get().to_le_bytes());
         }
     }
     Ok(buf)
@@ -315,7 +315,7 @@ fn decode_entry(data: &[u8]) -> Result<ManifestEntry, LsmError> {
 
             let meta = SortedRunMeta::new(
                 path,
-                SeqRange::new(SeqNo(seq_lo), SeqNo(seq_hi))?,
+                SeqRange::new(SeqNo::from(seq_lo), SeqNo::from(seq_hi))?,
                 coverage,
                 page_count,
                 size_bytes,
@@ -353,7 +353,7 @@ fn decode_entry(data: &[u8]) -> Result<ManifestEntry, LsmError> {
             })
         }
         TAG_SET_SEQUENCE => {
-            let next_sequence = SeqNo(read_u64_le(data, &mut offset)?);
+            let next_sequence = SeqNo::from(read_u64_le(data, &mut offset)?);
             Ok(ManifestEntry::SetSequence { next_sequence })
         }
         TAG_ADD_RUN_AND_SEQUENCE => {
@@ -377,11 +377,11 @@ fn decode_entry(data: &[u8]) -> Result<ManifestEntry, LsmError> {
             }
             let page_count = read_u64_le(data, &mut offset)?;
             let size_bytes = read_u64_le(data, &mut offset)?;
-            let next_sequence = SeqNo(read_u64_le(data, &mut offset)?);
+            let next_sequence = SeqNo::from(read_u64_le(data, &mut offset)?);
 
             let meta = SortedRunMeta::new(
                 path,
-                SeqRange::new(SeqNo(seq_lo), SeqNo(seq_hi))?,
+                SeqRange::new(SeqNo::from(seq_lo), SeqNo::from(seq_hi))?,
                 coverage,
                 page_count,
                 size_bytes,
@@ -554,7 +554,7 @@ mod tests {
     fn test_meta(name: &str) -> SortedRunMeta {
         SortedRunMeta::new(
             PathBuf::from(name),
-            SeqRange::new(SeqNo(10), SeqNo(20)).unwrap(),
+            SeqRange::new(SeqNo::from(10u64), SeqNo::from(20u64)).unwrap(),
             vec![0, 3, 7],
             42,
             8192,
@@ -612,7 +612,7 @@ mod tests {
     #[test]
     fn encode_decode_set_sequence() {
         let entry = ManifestEntry::SetSequence {
-            next_sequence: SeqNo(12345),
+            next_sequence: SeqNo::from(12345u64),
         };
         let payload = encode_entry(&entry).unwrap();
         let decoded = decode_entry(&payload).unwrap();
@@ -625,7 +625,7 @@ mod tests {
         let entry = ManifestEntry::AddRunAndSequence {
             level: Level::L0,
             meta,
-            next_sequence: SeqNo(99),
+            next_sequence: SeqNo::from(99u64),
         };
         let payload = encode_entry(&entry).unwrap();
         let decoded = decode_entry(&payload).unwrap();
@@ -638,7 +638,7 @@ mod tests {
         let entry = ManifestEntry::AddRunAndSequence {
             level: Level::L3,
             meta,
-            next_sequence: SeqNo(42),
+            next_sequence: SeqNo::from(42u64),
         };
         let payload = encode_entry(&entry).unwrap();
         let decoded = decode_entry(&payload).unwrap();
@@ -654,14 +654,14 @@ mod tests {
         log.append(&ManifestEntry::AddRunAndSequence {
             level: Level::L0,
             meta: test_meta("atomic.run"),
-            next_sequence: SeqNo(42),
+            next_sequence: SeqNo::from(42u64),
         })
         .unwrap();
         drop(log);
 
         let (manifest, _) = ManifestLog::recover(&path).unwrap();
         assert_eq!(manifest.total_runs(), 1);
-        assert_eq!(manifest.next_sequence(), SeqNo(42));
+        assert_eq!(manifest.next_sequence(), SeqNo::from(42u64));
         assert_eq!(
             manifest.runs_at_level(Level::L0)[0].path(),
             Path::new("atomic.run")
@@ -729,7 +729,7 @@ mod tests {
         // File doesn't exist → empty manifest.
         let (manifest, _) = ManifestLog::recover(&path).unwrap();
         assert_eq!(manifest.total_runs(), 0);
-        assert_eq!(manifest.next_sequence(), SeqNo(0));
+        assert_eq!(manifest.next_sequence(), SeqNo::from(0u64));
     }
 
     #[test]
@@ -910,7 +910,7 @@ mod tests {
 
         let (manifest, _log) = ManifestLog::recover(&path).unwrap();
         assert_eq!(manifest.total_runs(), 0);
-        assert_eq!(manifest.next_sequence(), SeqNo(0));
+        assert_eq!(manifest.next_sequence(), SeqNo::from(0u64));
 
         assert!(path.exists());
         let bytes = fs::read(&path).unwrap();
@@ -967,12 +967,12 @@ mod tests {
         // Reopen via recover, append an entry, reopen again.
         let (_, mut log) = ManifestLog::recover(&path).unwrap();
         log.append(&ManifestEntry::SetSequence {
-            next_sequence: SeqNo(42),
+            next_sequence: SeqNo::from(42u64),
         })
         .unwrap();
         drop(log);
 
         let (manifest, _log) = ManifestLog::recover(&path).unwrap();
-        assert_eq!(manifest.next_sequence(), SeqNo(42));
+        assert_eq!(manifest.next_sequence(), SeqNo::from(42u64));
     }
 }

--- a/crates/minkowski-lsm/src/manifest_ops.rs
+++ b/crates/minkowski-lsm/src/manifest_ops.rs
@@ -10,7 +10,7 @@ use crate::error::LsmError;
 use crate::manifest::{LsmManifest, SortedRunMeta};
 use crate::manifest_log::{ManifestEntry, ManifestLog};
 use crate::reader::SortedRunReader;
-use crate::types::{Level, SeqRange};
+use crate::types::{Level, PageCount, SeqRange, SizeBytes};
 use crate::writer::flush;
 
 /// Flush dirty pages and record the new sorted run in the manifest.
@@ -32,12 +32,14 @@ pub fn flush_and_record(
     let file_size = fs::metadata(&path)?.len();
     let archetype_coverage = reader.archetype_ids();
 
+    let page_count = PageCount::new(reader.page_count())
+        .ok_or_else(|| LsmError::Format("page_count must be non-zero".to_owned()))?;
     let meta = SortedRunMeta::new(
         path.clone(),
         reader.sequence_range(),
         archetype_coverage,
-        reader.page_count(),
-        file_size,
+        page_count,
+        SizeBytes::new(file_size),
     )?;
 
     // Persist to log first, then update in-memory state.
@@ -98,7 +100,7 @@ pub fn cleanup_orphans(dir: &Path, manifest: &LsmManifest) -> Result<usize, LsmE
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{Level, SeqNo, SeqRange};
+    use crate::types::{Level, PageCount, SeqNo, SeqRange, SizeBytes};
 
     #[derive(Clone, Copy)]
     #[expect(dead_code)]
@@ -174,8 +176,8 @@ mod tests {
                 dir.path().join("0-10.run"),
                 SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
                 vec![0],
-                1,
-                4,
+                PageCount::new(1).unwrap(),
+                SizeBytes::new(4),
             )
             .unwrap(),
         );

--- a/crates/minkowski-lsm/src/manifest_ops.rs
+++ b/crates/minkowski-lsm/src/manifest_ops.rs
@@ -122,7 +122,7 @@ mod tests {
 
         let result = flush_and_record(
             &world,
-            SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
             &mut manifest,
             &mut log,
             dir.path(),
@@ -130,7 +130,7 @@ mod tests {
         .unwrap();
         assert!(result.is_some());
         assert_eq!(manifest.total_runs(), 1);
-        assert_eq!(manifest.next_sequence(), SeqNo(10));
+        assert_eq!(manifest.next_sequence(), SeqNo::from(10u64));
         assert_eq!(manifest.runs_at_level(Level::L0).len(), 1);
     }
 
@@ -146,7 +146,7 @@ mod tests {
 
         let result = flush_and_record(
             &world,
-            SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
             &mut manifest,
             &mut log,
             dir.path(),
@@ -172,7 +172,7 @@ mod tests {
             Level::L0,
             SortedRunMeta::new(
                 dir.path().join("0-10.run"),
-                SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+                SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
                 vec![0],
                 1,
                 4,

--- a/crates/minkowski-lsm/src/reader.rs
+++ b/crates/minkowski-lsm/src/reader.rs
@@ -113,13 +113,16 @@ fn validate_and_parse(buf: &[u8]) -> Result<ParsedMetadata, LsmError> {
     }
 
     let schema_count = header.schema_count;
-    let sequence_range = SeqRange::new(SeqNo(header.sequence_lo), SeqNo(header.sequence_hi))
-        .map_err(|_| {
-            LsmError::Format(format!(
-                "header sequence range invalid: lo={} > hi={}",
-                header.sequence_lo, header.sequence_hi
-            ))
-        })?;
+    let sequence_range = SeqRange::new(
+        SeqNo::from(header.sequence_lo),
+        SeqNo::from(header.sequence_hi),
+    )
+    .map_err(|_| {
+        LsmError::Format(format!(
+            "header sequence range invalid: lo={} > hi={}",
+            header.sequence_lo, header.sequence_hi
+        ))
+    })?;
     let page_count = header.page_count;
 
     // 5. Read footer (last 64 bytes).
@@ -381,7 +384,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = flush(
             &world,
-            SeqRange::new(SeqNo(10), SeqNo(20)).unwrap(),
+            SeqRange::new(SeqNo::from(10u64), SeqNo::from(20u64)).unwrap(),
             dir.path(),
         )
         .unwrap()
@@ -396,7 +399,7 @@ mod tests {
 
         assert_eq!(
             reader.sequence_range(),
-            SeqRange::new(SeqNo(10), SeqNo(20)).unwrap()
+            SeqRange::new(SeqNo::from(10u64), SeqNo::from(20u64)).unwrap()
         );
         assert_eq!(reader.schema().len(), 1); // Pos only
         assert!(reader.page_count() > 0);
@@ -471,7 +474,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = flush(
             &world,
-            SeqRange::new(SeqNo(0), SeqNo(0)).unwrap(),
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(0u64)).unwrap(),
             dir.path(),
         )
         .unwrap()
@@ -552,7 +555,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = flush(
             &world,
-            SeqRange::new(SeqNo(0), SeqNo(100)).unwrap(),
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(100u64)).unwrap(),
             dir.path(),
         )
         .unwrap()

--- a/crates/minkowski-lsm/src/types.rs
+++ b/crates/minkowski-lsm/src/types.rs
@@ -1,3 +1,10 @@
+//! Newtype primitives for the LSM manifest subsystem.
+//!
+//! Construction idiom reflects the validity story:
+//! - `From<u64>` — total, interchangeable with `u64` (e.g., `SeqNo`).
+//! - `new(u64) -> Option<Self>` — fallible with a precondition (e.g., `PageCount::new` rejects zero, `Level::new` rejects out-of-range).
+//! - `new(u64) -> Self` without `From<u64>` — infallible but nominally distinct; `From` is deliberately omitted to block silent `.into()` conversions at adjacent-arg call sites (e.g., `SizeBytes`).
+//!
 //! Invariant-carrying newtype primitives shared across the manifest.
 
 use std::fmt;
@@ -144,7 +151,7 @@ impl fmt::Display for PageCount {
 /// Infallible newtype — zero is permitted (matches the semantics of
 /// `fs::metadata(...).len()`, which returns `0` for empty files).
 /// Type-level distinction from `PageCount` prevents arg-swap bugs at
-/// `SortedRunMeta::new`.
+/// any call site taking both.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default)]
 pub struct SizeBytes(u64);
 
@@ -168,7 +175,9 @@ impl fmt::Display for SizeBytes {
 mod tests {
     use super::*;
 
-    // Tombstone tests: SeqNo must NOT implement any arithmetic.
+    // Tombstones: sequences are identities, not sizes — arithmetic must
+    // stay unimplemented so `seq + 1` or `seq - other` fails to compile.
+    // See the SeqNo type doc comment above for the rationale.
     use static_assertions::{assert_eq_size, assert_not_impl_all};
     use std::ops::{Add, AddAssign, Div, Mul, Neg, Rem, Sub, SubAssign};
 

--- a/crates/minkowski-lsm/src/types.rs
+++ b/crates/minkowski-lsm/src/types.rs
@@ -168,12 +168,13 @@ impl fmt::Display for SizeBytes {
 mod tests {
     use super::*;
 
-    // Tombstone tests: SeqNo must NOT implement Add/Sub/AddAssign/SubAssign.
+    // Tombstone tests: SeqNo must NOT implement any arithmetic.
     use static_assertions::{assert_eq_size, assert_not_impl_all};
-    use std::ops::{Add, AddAssign, Sub, SubAssign};
+    use std::ops::{Add, AddAssign, Div, Mul, Neg, Rem, Sub, SubAssign};
 
     assert_not_impl_all!(SeqNo: Add<SeqNo>, Sub<SeqNo>, AddAssign<SeqNo>, SubAssign<SeqNo>);
     assert_not_impl_all!(SeqNo: Add<u64>, Sub<u64>, AddAssign<u64>, SubAssign<u64>);
+    assert_not_impl_all!(SeqNo: Mul<u64>, Div<u64>, Rem<u64>, Neg);
 
     // Pin the PageCount layout claims documented on the type:
     // - PageCount itself is 8 bytes (same as u64).

--- a/crates/minkowski-lsm/src/types.rs
+++ b/crates/minkowski-lsm/src/types.rs
@@ -10,9 +10,24 @@ use crate::manifest::NUM_LEVELS;
 ///
 /// Raw `u64` arithmetic on sequence numbers is disallowed by the type
 /// (no `Add`/`Sub` impls) because sequences are identities, not sizes.
-/// Callers that need "next seq" do so explicitly: `SeqNo(x.0 + 1)`.
+/// Use `.next()` for "advance by one"; use `.get()` to extract the raw value.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default)]
-pub struct SeqNo(pub u64);
+pub struct SeqNo(u64);
+
+impl SeqNo {
+    /// Extract the underlying `u64`.
+    pub fn get(self) -> u64 {
+        self.0
+    }
+
+    /// The next sequence number. Panics on `u64::MAX + 1` — an internal
+    /// invariant violation, since the WAL is the only `SeqNo` producer
+    /// and a 64-bit sequence space exhausts long after any realistic
+    /// process lifetime.
+    pub fn next(self) -> Self {
+        Self(self.0.checked_add(1).expect("SeqNo overflow"))
+    }
+}
 
 impl From<u64> for SeqNo {
     fn from(v: u64) -> Self {
@@ -140,6 +155,26 @@ mod tests {
     // - Option<PageCount> is 8 bytes via NonZeroU64's niche.
     assert_eq_size!(PageCount, u64);
     assert_eq_size!(Option<PageCount>, u64);
+
+    #[test]
+    fn seqno_get_returns_inner_u64() {
+        let s = SeqNo::from(42u64);
+        assert_eq!(s.get(), 42);
+    }
+
+    #[test]
+    fn seqno_next_advances_by_one() {
+        let s = SeqNo::from(5u64);
+        let n = s.next();
+        assert_eq!(n.get(), 6);
+    }
+
+    #[test]
+    #[should_panic(expected = "SeqNo overflow")]
+    fn seqno_next_panics_on_overflow() {
+        let s = SeqNo::from(u64::MAX);
+        let _ = s.next();
+    }
 
     #[test]
     fn seqno_display_matches_inner_u64() {

--- a/crates/minkowski-lsm/src/types.rs
+++ b/crates/minkowski-lsm/src/types.rs
@@ -139,6 +139,31 @@ impl fmt::Display for PageCount {
     }
 }
 
+/// Size in bytes of an on-disk artifact.
+///
+/// Infallible newtype — zero is permitted (matches the semantics of
+/// `fs::metadata(...).len()`, which returns `0` for empty files).
+/// Type-level distinction from `PageCount` prevents arg-swap bugs at
+/// `SortedRunMeta::new`.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default)]
+pub struct SizeBytes(u64);
+
+impl SizeBytes {
+    pub fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub fn get(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for SizeBytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -155,6 +180,10 @@ mod tests {
     // - Option<PageCount> is 8 bytes via NonZeroU64's niche.
     assert_eq_size!(PageCount, u64);
     assert_eq_size!(Option<PageCount>, u64);
+
+    // SizeBytes is a plain u64 wrapper — no niche, so only the direct size holds.
+    // Option<SizeBytes> is 16 bytes, not 8.
+    assert_eq_size!(SizeBytes, u64);
 
     #[test]
     fn seqno_get_returns_inner_u64() {
@@ -258,5 +287,22 @@ mod tests {
         let raw: u64 = pc.get();
         let restored = PageCount::new(raw).unwrap();
         assert_eq!(pc, restored);
+    }
+
+    #[test]
+    fn sizebytes_get_returns_inner_u64() {
+        let s = SizeBytes::new(1024);
+        assert_eq!(s.get(), 1024);
+    }
+
+    #[test]
+    fn sizebytes_allows_zero() {
+        let s = SizeBytes::new(0);
+        assert_eq!(s.get(), 0);
+    }
+
+    #[test]
+    fn sizebytes_display() {
+        assert_eq!(SizeBytes::new(42).to_string(), "42");
     }
 }

--- a/crates/minkowski-lsm/src/writer.rs
+++ b/crates/minkowski-lsm/src/writer.rs
@@ -84,8 +84,8 @@ pub fn flush(
         .collect();
 
     // ── 4. Write to temp file ───────────────────────────────────────────────
-    let seq_lo = sequence_range.lo().0;
-    let seq_hi = sequence_range.hi().0;
+    let seq_lo = sequence_range.lo().get();
+    let seq_hi = sequence_range.hi().get();
     let tmp_name = format!("{seq_lo}-{seq_hi}.run.tmp");
     let final_name = format!("{seq_lo}-{seq_hi}.run");
     let tmp_path = output_dir.join(&tmp_name);
@@ -407,7 +407,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let result = flush(
             &world,
-            SeqRange::new(SeqNo(0), SeqNo(0)).unwrap(),
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(0u64)).unwrap(),
             dir.path(),
         )
         .unwrap();
@@ -422,7 +422,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let result = flush(
             &world,
-            SeqRange::new(SeqNo(1), SeqNo(5)).unwrap(),
+            SeqRange::new(SeqNo::from(1u64), SeqNo::from(5u64)).unwrap(),
             dir.path(),
         )
         .unwrap();
@@ -439,7 +439,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let result = flush(
             &world,
-            SeqRange::new(SeqNo(10), SeqNo(20)).unwrap(),
+            SeqRange::new(SeqNo::from(10u64), SeqNo::from(20u64)).unwrap(),
             dir.path(),
         )
         .unwrap();
@@ -456,7 +456,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let result = flush(
             &world,
-            SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
             dir.path(),
         )
         .unwrap();
@@ -481,7 +481,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = flush(
             &world,
-            SeqRange::new(SeqNo(0), SeqNo(1)).unwrap(),
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(1u64)).unwrap(),
             dir.path(),
         )
         .unwrap()

--- a/crates/minkowski-lsm/tests/integration.rs
+++ b/crates/minkowski-lsm/tests/integration.rs
@@ -31,7 +31,7 @@ fn flush_and_open(world: &World) -> (tempfile::TempDir, SortedRunReader) {
     let dir = tempfile::tempdir().unwrap();
     let path = flush(
         world,
-        SeqRange::new(SeqNo(0), SeqNo(100)).unwrap(),
+        SeqRange::new(SeqNo::from(0u64), SeqNo::from(100u64)).unwrap(),
         dir.path(),
     )
     .unwrap()
@@ -225,7 +225,7 @@ fn no_dirty_pages_no_file() {
     let dir = tempfile::tempdir().unwrap();
     let result = flush(
         &world,
-        SeqRange::new(SeqNo(0), SeqNo(0)).unwrap(),
+        SeqRange::new(SeqNo::from(0u64), SeqNo::from(0u64)).unwrap(),
         dir.path(),
     )
     .unwrap();
@@ -260,7 +260,7 @@ fn crc_corruption_detected() {
     let dir = tempfile::tempdir().unwrap();
     let path = flush(
         &world,
-        SeqRange::new(SeqNo(0), SeqNo(50)).unwrap(),
+        SeqRange::new(SeqNo::from(0u64), SeqNo::from(50u64)).unwrap(),
         dir.path(),
     )
     .unwrap()
@@ -332,7 +332,7 @@ fn header_crc_corruption_detected() {
     let dir = tempfile::tempdir().unwrap();
     let path = flush(
         &world,
-        SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+        SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
         dir.path(),
     )
     .unwrap()
@@ -524,7 +524,7 @@ fn zst_component_round_trip() {
     let dir = tempfile::tempdir().unwrap();
     let path = flush(
         &world,
-        SeqRange::new(SeqNo(0), SeqNo(0)).unwrap(),
+        SeqRange::new(SeqNo::from(0u64), SeqNo::from(0u64)).unwrap(),
         dir.path(),
     )
     .unwrap()

--- a/crates/minkowski-lsm/tests/manifest_integration.rs
+++ b/crates/minkowski-lsm/tests/manifest_integration.rs
@@ -514,6 +514,76 @@ fn replay_truncates_log_on_inverted_seq_range() {
     );
 }
 
+/// Regression: a frame whose decoded page_count is zero must be treated
+/// as tail garbage. PR B3 moved the `PageCount::new` validation from
+/// `SortedRunMeta::new` to the decode call sites; this test pins the
+/// decode-site rejection into the replay tail-truncation path.
+#[test]
+fn replay_truncates_log_on_zero_page_count() {
+    let dir = tempfile::tempdir().unwrap();
+    let log_path = dir.path().join("manifest.log");
+    let (mut manifest, mut log) = ManifestLog::recover(&log_path).unwrap();
+
+    let mut world = World::new();
+    world.spawn((Pos { x: 1.0, y: 0.0 },));
+    // One real flush — produces a valid AddRunAndSequence entry.
+    flush_and_record(
+        &world,
+        SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
+        &mut manifest,
+        &mut log,
+        dir.path(),
+    )
+    .unwrap();
+
+    let len_after_first_frame = fs::metadata(&log_path).unwrap().len();
+
+    // Handcraft an AddRun frame with page_count = 0.
+    // Wire layout (see manifest_log.rs::encode_entry AddRun branch):
+    //   [tag=0x01][level=0][path_len: u16 LE][path bytes]
+    //   [seq_lo: u64 LE][seq_hi: u64 LE]
+    //   [coverage_count: u16 LE][coverage: u16 × count LE]
+    //   [page_count: u64 LE][size_bytes: u64 LE]
+    let mut payload = Vec::new();
+    payload.push(TAG_ADD_RUN);
+    payload.push(0); // level = 0
+    let path_bytes = b"zero.run";
+    payload.extend_from_slice(&(path_bytes.len() as u16).to_le_bytes());
+    payload.extend_from_slice(path_bytes);
+    payload.extend_from_slice(&0u64.to_le_bytes()); // seq_lo
+    payload.extend_from_slice(&10u64.to_le_bytes()); // seq_hi
+    payload.extend_from_slice(&1u16.to_le_bytes()); // coverage_count
+    payload.extend_from_slice(&0u16.to_le_bytes()); // coverage[0]
+    payload.extend_from_slice(&0u64.to_le_bytes()); // page_count = 0 — invalid
+    payload.extend_from_slice(&1024u64.to_le_bytes()); // size_bytes
+
+    // Wrap in a frame with valid CRC so the frame layer accepts it.
+    let len = payload.len() as u32;
+    let crc = crc32fast::hash(&payload);
+    let mut frame = Vec::new();
+    frame.extend_from_slice(&len.to_le_bytes());
+    frame.extend_from_slice(&crc.to_le_bytes());
+    frame.extend_from_slice(&payload);
+
+    let mut f = fs::OpenOptions::new().append(true).open(&log_path).unwrap();
+    f.write_all(&frame).unwrap();
+    f.sync_all().unwrap();
+    drop(f);
+
+    // Replay must truncate at the bad frame.
+    let (recovered, _) = ManifestLog::recover(&log_path).unwrap();
+    assert_eq!(
+        recovered.total_runs(),
+        1,
+        "only the first valid flush should survive"
+    );
+    let len_after_replay = fs::metadata(&log_path).unwrap().len();
+    assert_eq!(
+        len_after_replay, len_after_first_frame,
+        "replay should have truncated the zero-page_count frame"
+    );
+}
+
 /// Regression: a RemoveRun frame referencing a path the manifest doesn't
 /// know is log corruption. apply_entry must propagate the error so replay
 /// treats the rest of the log as tail garbage — same policy as PromoteRun.
@@ -681,6 +751,8 @@ fn recover_preserves_reserved_bytes_through_append_cycle() {
 
     // Start with a valid header whose reserved bytes carry a non-zero
     // "flag" pattern.
+    // Layout: bytes 0..4 = magic ("MKMF"), byte 4 = version (0x01),
+    // bytes 5..8 = reserved (here 0xFF, 0xAA, 0x55).
     fs::write(&log_path, b"MKMF\x01\xFF\xAA\x55").unwrap();
 
     // Open, append one entry, close.

--- a/crates/minkowski-lsm/tests/manifest_integration.rs
+++ b/crates/minkowski-lsm/tests/manifest_integration.rs
@@ -671,6 +671,41 @@ fn recover_ignores_nonzero_reserved_bytes() {
     assert_eq!(recovered.next_sequence(), SeqNo::from(0u64));
 }
 
+/// Reserved bytes must survive an append round trip. Guards against a
+/// future refactor that "normalizes" the header on every recover — which
+/// would silently drop forward-compat flags a future version wrote there.
+#[test]
+fn recover_preserves_reserved_bytes_through_append_cycle() {
+    let dir = tempfile::tempdir().unwrap();
+    let log_path = dir.path().join("reserved_append.log");
+
+    // Start with a valid header whose reserved bytes carry a non-zero
+    // "flag" pattern.
+    fs::write(&log_path, b"MKMF\x01\xFF\xAA\x55").unwrap();
+
+    // Open, append one entry, close.
+    let (_, mut log) = ManifestLog::recover(&log_path).unwrap();
+    log.append(&ManifestEntry::SetSequence {
+        next_sequence: SeqNo::from(42),
+    })
+    .unwrap();
+    drop(log);
+
+    // Reserved bytes at offsets 5..8 must still be intact.
+    let bytes = fs::read(&log_path).unwrap();
+    assert_eq!(&bytes[0..4], b"MKMF", "magic preserved");
+    assert_eq!(bytes[4], 0x01, "version preserved");
+    assert_eq!(
+        &bytes[5..8],
+        &[0xFF, 0xAA, 0x55],
+        "reserved bytes preserved"
+    );
+
+    // And the entry must replay.
+    let (m, _) = ManifestLog::recover(&log_path).unwrap();
+    assert_eq!(m.next_sequence(), SeqNo::from(42));
+}
+
 /// Calling recover() twice on the same path with no intervening writes
 /// must produce identical state. Guards against a bug where re-opening
 /// mutates the header or resets write_pos.

--- a/crates/minkowski-lsm/tests/manifest_integration.rs
+++ b/crates/minkowski-lsm/tests/manifest_integration.rs
@@ -43,7 +43,7 @@ fn three_flushes_then_replay() {
     }
     let p1 = flush_and_record(
         &world,
-        SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+        SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
         &mut manifest,
         &mut log,
         dir.path(),
@@ -61,7 +61,7 @@ fn three_flushes_then_replay() {
     }
     let p2 = flush_and_record(
         &world,
-        SeqRange::new(SeqNo(10), SeqNo(20)).unwrap(),
+        SeqRange::new(SeqNo::from(10u64), SeqNo::from(20u64)).unwrap(),
         &mut manifest,
         &mut log,
         dir.path(),
@@ -74,7 +74,7 @@ fn three_flushes_then_replay() {
     world.spawn((Vel { dx: 1.0, dy: 2.0 },));
     let p3 = flush_and_record(
         &world,
-        SeqRange::new(SeqNo(20), SeqNo(30)).unwrap(),
+        SeqRange::new(SeqNo::from(20u64), SeqNo::from(30u64)).unwrap(),
         &mut manifest,
         &mut log,
         dir.path(),
@@ -83,7 +83,7 @@ fn three_flushes_then_replay() {
     .unwrap();
 
     assert_eq!(manifest.total_runs(), 3);
-    assert_eq!(manifest.next_sequence(), SeqNo(30));
+    assert_eq!(manifest.next_sequence(), SeqNo::from(30u64));
     assert!(p1.exists());
     assert!(p2.exists());
     assert!(p3.exists());
@@ -91,7 +91,7 @@ fn three_flushes_then_replay() {
     // Replay the log from scratch — should reconstruct identical state.
     let (recovered, _) = ManifestLog::recover(&log_path).unwrap();
     assert_eq!(recovered.total_runs(), 3);
-    assert_eq!(recovered.next_sequence(), SeqNo(30));
+    assert_eq!(recovered.next_sequence(), SeqNo::from(30u64));
     assert_eq!(recovered.runs_at_level(Level::L0).len(), 3);
 
     // Verify run metadata matches.
@@ -120,7 +120,7 @@ fn corrupt_tail_partial_recovery() {
     // Two good flushes.
     flush_and_record(
         &world,
-        SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+        SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
         &mut manifest,
         &mut log,
         dir.path(),
@@ -131,7 +131,7 @@ fn corrupt_tail_partial_recovery() {
     world.spawn((Pos { x: 3.0, y: 4.0 },));
     flush_and_record(
         &world,
-        SeqRange::new(SeqNo(10), SeqNo(20)).unwrap(),
+        SeqRange::new(SeqNo::from(10u64), SeqNo::from(20u64)).unwrap(),
         &mut manifest,
         &mut log,
         dir.path(),
@@ -147,7 +147,7 @@ fn corrupt_tail_partial_recovery() {
     // Replay should recover the 2 good entries (each flush writes one atomic AddRunAndSequence entry).
     let (recovered, _) = ManifestLog::recover(&log_path).unwrap();
     assert_eq!(recovered.total_runs(), 2);
-    assert_eq!(recovered.next_sequence(), SeqNo(20));
+    assert_eq!(recovered.next_sequence(), SeqNo::from(20u64));
 }
 
 /// Truncate the log to every byte prefix 0..=file_len and replay each time.
@@ -173,7 +173,7 @@ fn replay_converges_at_every_truncation_prefix() {
         let hi = lo + 10;
         flush_and_record(
             &world,
-            SeqRange::new(SeqNo(lo), SeqNo(hi)).unwrap(),
+            SeqRange::new(SeqNo::from(lo), SeqNo::from(hi)).unwrap(),
             &mut manifest,
             &mut log,
             dir.path(),
@@ -186,7 +186,7 @@ fn replay_converges_at_every_truncation_prefix() {
     assert!(!full_bytes.is_empty(), "log must have content");
 
     let mut prev_total_runs = 0usize;
-    let mut prev_next_seq = SeqNo(0);
+    let mut prev_next_seq = SeqNo::from(0u64);
 
     for truncate_len in 0..=full_bytes.len() {
         let truncated_path = dir.path().join(format!("truncated_{truncate_len:05}.log"));
@@ -233,7 +233,7 @@ fn replay_converges_at_every_truncation_prefix() {
     assert_eq!(prev_total_runs, 3, "full replay must recover all 3 runs");
     assert_eq!(
         prev_next_seq,
-        SeqNo(30),
+        SeqNo::from(30u64),
         "full replay must recover final sequence"
     );
 }
@@ -251,7 +251,7 @@ fn replay_truncates_log_on_promote_of_missing_run() {
     // Real flush: produces a genuine AddRunAndSequence entry.
     flush_and_record(
         &world,
-        SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+        SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
         &mut manifest,
         &mut log,
         dir.path(),
@@ -268,7 +268,7 @@ fn replay_truncates_log_on_promote_of_missing_run() {
     .unwrap();
     // Anything after the bad entry must be discarded on replay.
     log.append(&ManifestEntry::SetSequence {
-        next_sequence: SeqNo(999),
+        next_sequence: SeqNo::from(999u64),
     })
     .unwrap();
     drop(log);
@@ -280,11 +280,11 @@ fn replay_truncates_log_on_promote_of_missing_run() {
         "only the first flush should survive replay"
     );
     assert!(
-        recovered.next_sequence() < SeqNo(999),
+        recovered.next_sequence() < SeqNo::from(999u64),
         "SetSequence past the bad PromoteRun must not apply"
     );
     // The surviving AddRunAndSequence set next_sequence to 10.
-    assert_eq!(recovered.next_sequence(), SeqNo(10));
+    assert_eq!(recovered.next_sequence(), SeqNo::from(10u64));
 }
 
 // ── Cleanup ─────────────────────────────────────────────────────────────────
@@ -301,7 +301,7 @@ fn cleanup_removes_orphans_and_tmp() {
     // One real flush.
     flush_and_record(
         &world,
-        SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+        SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
         &mut manifest,
         &mut log,
         dir.path(),
@@ -338,7 +338,7 @@ fn replay_truncates_log_on_unsorted_coverage() {
     // One real flush, produces a valid AddRunAndSequence frame.
     flush_and_record(
         &world,
-        SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+        SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
         &mut manifest,
         &mut log,
         dir.path(),
@@ -405,7 +405,7 @@ fn replay_truncates_log_on_invalid_level_byte() {
     world.spawn((Pos { x: 1.0, y: 0.0 },));
     flush_and_record(
         &world,
-        SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+        SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
         &mut manifest,
         &mut log,
         dir.path(),
@@ -462,7 +462,7 @@ fn replay_truncates_log_on_inverted_seq_range() {
     // One real flush, produces a valid AddRunAndSequence frame.
     flush_and_record(
         &world,
-        SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+        SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
         &mut manifest,
         &mut log,
         dir.path(),
@@ -528,7 +528,7 @@ fn replay_truncates_log_on_remove_of_missing_run() {
     // One real flush — produces a valid AddRunAndSequence entry.
     flush_and_record(
         &world,
-        SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+        SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
         &mut manifest,
         &mut log,
         dir.path(),
@@ -543,7 +543,7 @@ fn replay_truncates_log_on_remove_of_missing_run() {
     .unwrap();
     // Anything after the bad entry must be discarded on replay.
     log.append(&ManifestEntry::SetSequence {
-        next_sequence: SeqNo(999),
+        next_sequence: SeqNo::from(999u64),
     })
     .unwrap();
     drop(log);
@@ -556,10 +556,10 @@ fn replay_truncates_log_on_remove_of_missing_run() {
     );
     // The trailing SetSequence must not have been applied.
     assert!(
-        recovered.next_sequence() < SeqNo(999),
+        recovered.next_sequence() < SeqNo::from(999u64),
         "SetSequence past the bad RemoveRun must not apply"
     );
-    assert_eq!(recovered.next_sequence(), SeqNo(10));
+    assert_eq!(recovered.next_sequence(), SeqNo::from(10u64));
 }
 
 // ── recover() lifecycle and rejection regressions ───────────────────────────
@@ -581,7 +581,7 @@ fn recover_then_flush_then_recover_roundtrips_state() {
     world.spawn((Pos { x: 1.0, y: 0.0 },));
     flush_and_record(
         &world,
-        SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+        SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
         &mut manifest,
         &mut log,
         dir.path(),
@@ -591,7 +591,7 @@ fn recover_then_flush_then_recover_roundtrips_state() {
     world.spawn((Pos { x: 2.0, y: 0.0 },));
     flush_and_record(
         &world,
-        SeqRange::new(SeqNo(10), SeqNo(20)).unwrap(),
+        SeqRange::new(SeqNo::from(10u64), SeqNo::from(20u64)).unwrap(),
         &mut manifest,
         &mut log,
         dir.path(),
@@ -602,7 +602,7 @@ fn recover_then_flush_then_recover_roundtrips_state() {
     // Second recover replays both entries.
     let (recovered, _) = ManifestLog::recover(&log_path).unwrap();
     assert_eq!(recovered.total_runs(), 2);
-    assert_eq!(recovered.next_sequence(), SeqNo(20));
+    assert_eq!(recovered.next_sequence(), SeqNo::from(20u64));
 
     // Metadata round-trips faithfully.
     for (orig, rec) in manifest
@@ -668,7 +668,7 @@ fn recover_ignores_nonzero_reserved_bytes() {
     // Recover should succeed on an otherwise-empty log.
     let (recovered, _) = ManifestLog::recover(&log_path).unwrap();
     assert_eq!(recovered.total_runs(), 0);
-    assert_eq!(recovered.next_sequence(), SeqNo(0));
+    assert_eq!(recovered.next_sequence(), SeqNo::from(0u64));
 }
 
 /// Calling recover() twice on the same path with no intervening writes
@@ -708,7 +708,7 @@ fn flush_and_record_clean_world_no_change() {
 
     let result = flush_and_record(
         &world,
-        SeqRange::new(SeqNo(0), SeqNo(10)).unwrap(),
+        SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
         &mut manifest,
         &mut log,
         dir.path(),
@@ -716,7 +716,7 @@ fn flush_and_record_clean_world_no_change() {
     .unwrap();
     assert!(result.is_none());
     assert_eq!(manifest.total_runs(), 0);
-    assert_eq!(manifest.next_sequence(), SeqNo(0));
+    assert_eq!(manifest.next_sequence(), SeqNo::from(0u64));
 
     // Log should be empty — recover produces empty manifest.
     let (replayed, _) = ManifestLog::recover(&log_path).unwrap();

--- a/docs/plans/2026-04-18-lsm-pr-b3-polish-implementation-plan.md
+++ b/docs/plans/2026-04-18-lsm-pr-b3-polish-implementation-plan.md
@@ -1,0 +1,778 @@
+# LSM PR B3 Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply the five deferred polish items from PR B2's review queue: `SeqNo` privatization + `.next()`, `SizeBytes(u64)` newtype, `SortedRunMeta::new` taking both newtypes at the boundary, expanded arithmetic tombstones, and a `recover → append → recover` reserved-bytes round-trip test.
+
+**Architecture:** Type-level hardening on the manifest subsystem. No wire format changes, no public API consumer impact outside the crate (no external consumers exist today). Privatizes `SeqNo.0`, introduces `SizeBytes(u64)` as `PageCount`'s companion, and pushes validation/wrapping up to callers of `SortedRunMeta::new` so the constructor takes type-safe arguments that make the swap-at-call-site bug a compile error. Each task ends with green `cargo test -p minkowski-lsm` + `cargo clippy --workspace --all-targets -- -D warnings`.
+
+**Tech Stack:** Rust 2024 edition, `minkowski-lsm` workspace crate, existing `SeqNo`/`SeqRange`/`Level`/`PageCount` newtypes, `static_assertions` dev-dep (from PR B2).
+
+**Spec:** `project_lsm_phase2_type_safety.md` in memory — the "PR B3 candidate queue" section.
+
+---
+
+## Starting state
+
+- Branch: `lsm/pr-b3-polish` already created off `origin/main` (post-PR-B2 squash `d521e51`).
+- 107 tests currently passing in `minkowski-lsm`.
+
+## File structure
+
+**Modify (by task):**
+
+- Task 1: `crates/minkowski-lsm/src/types.rs` (privatize `SeqNo.0`, add `.get()` + `.next()`), plus ~40 call sites across `manifest_log.rs`, `manifest_ops.rs`, `writer.rs`, `reader.rs`, `manifest.rs`, and the two integration-test files.
+- Task 2: `crates/minkowski-lsm/src/types.rs` (new `SizeBytes(u64)` type with unit tests).
+- Task 3: `crates/minkowski-lsm/src/manifest.rs` (constructor signature + `size_bytes` field + accessor), `crates/minkowski-lsm/src/manifest_ops.rs` (construction site wraps), `crates/minkowski-lsm/src/manifest_log.rs` (decode wraps).
+- Task 4: `crates/minkowski-lsm/src/types.rs` (expand tombstones), `crates/minkowski-lsm/tests/manifest_integration.rs` (new test).
+- Task 5: Final verification + push + PR.
+
+**No new files.**
+
+---
+
+## Task 1: Privatize `SeqNo.0`; add `.get()` and `.next()`
+
+**Goal:** Move `SeqNo` from "transparent newtype with `pub u64`" (Encapsulation 5/10) to "opaque newtype with validated advance" (10/10). Adds `.next()` as the named `succ` operation with panic-on-overflow semantics (an internal-invariant violation, per TigerStyle).
+
+**Files:**
+- Modify: `crates/minkowski-lsm/src/types.rs`
+- Modify (cascade): every call site constructing `SeqNo(u64)` or reading `seq.0` — primarily `manifest_log.rs`, `manifest_ops.rs`, `writer.rs`, `reader.rs`, `manifest.rs`, and both test files.
+
+- [ ] **Step 1: Write failing unit tests for `.get()` and `.next()`**
+
+In `crates/minkowski-lsm/src/types.rs`, inside the `#[cfg(test)] mod tests` block, add:
+
+```rust
+    #[test]
+    fn seqno_get_returns_inner_u64() {
+        let s = SeqNo::from(42u64);
+        assert_eq!(s.get(), 42);
+    }
+
+    #[test]
+    fn seqno_next_advances_by_one() {
+        let s = SeqNo::from(5u64);
+        let n = s.next();
+        assert_eq!(n.get(), 6);
+    }
+
+    #[test]
+    #[should_panic(expected = "SeqNo overflow")]
+    fn seqno_next_panics_on_overflow() {
+        let s = SeqNo::from(u64::MAX);
+        let _ = s.next();
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p minkowski-lsm --lib types::tests -- seqno_get seqno_next`
+Expected: FAIL — `.get()` and `.next()` methods don't exist yet. Compilation error.
+
+- [ ] **Step 3: Privatize the field and add methods**
+
+In `crates/minkowski-lsm/src/types.rs`, find the `SeqNo` struct:
+
+```rust
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default)]
+pub struct SeqNo(pub u64);
+```
+
+Change to private field and add the two methods (keep the existing `From`/`Display` impls unchanged — they're inside the module so they retain field access):
+
+```rust
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default)]
+pub struct SeqNo(u64);
+
+impl SeqNo {
+    /// Extract the underlying `u64`.
+    pub fn get(self) -> u64 {
+        self.0
+    }
+
+    /// The next sequence number. Panics on `u64::MAX + 1` — an internal
+    /// invariant violation, since the WAL is the only `SeqNo` producer
+    /// and a 64-bit sequence space exhausts long after any realistic
+    /// process lifetime.
+    pub fn next(self) -> Self {
+        Self(self.0.checked_add(1).expect("SeqNo overflow"))
+    }
+}
+```
+
+Verify the existing `impl From<u64> for SeqNo { fn from(v: u64) -> Self { Self(v) } }` and `impl From<SeqNo> for u64 { fn from(s: SeqNo) -> Self { s.0 } }` remain unchanged — they're in the same module so they access the now-private field just fine.
+
+- [ ] **Step 4: Run the new tests**
+
+Run: `cargo test -p minkowski-lsm --lib types::tests -- seqno_get seqno_next`
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Run `cargo check` to enumerate external call sites**
+
+Run: `cargo check -p minkowski-lsm 2>&1 | head -60`
+Expected: compile errors at every `SeqNo(x)` tuple-construction call site and every `seq.0` field-access site outside `types.rs`.
+
+Known call sites (approximate count ~40):
+- `crates/minkowski-lsm/src/manifest_log.rs` — `next_sequence.0.to_le_bytes()` at encode sites (2x), `SeqNo(read_u64_le(...)?)` at decode sites (2x), `SeqRange::new(SeqNo(seq_lo), SeqNo(seq_hi))?` (2x).
+- `crates/minkowski-lsm/src/writer.rs` — `sequence_range.lo().0` / `sequence_range.hi().0` (2x).
+- `crates/minkowski-lsm/src/reader.rs` — similar header byte-extraction sites.
+- `crates/minkowski-lsm/src/manifest.rs` tests — `test_meta` helper, `SeqRange::new(SeqNo(0), SeqNo(10))` patterns.
+- `crates/minkowski-lsm/src/manifest_ops.rs` tests — test setup sites.
+- `crates/minkowski-lsm/tests/manifest_integration.rs` — ~25 sites constructing `SeqNo(...)` in `SeqRange::new` calls and assertions.
+- `crates/minkowski-lsm/tests/integration.rs` — ~5 sites.
+
+- [ ] **Step 6: Migrate `SeqNo(x)` construction sites to `SeqNo::from(x)`**
+
+Every `SeqNo(literal)` or `SeqNo(variable)` pattern becomes `SeqNo::from(literal)` / `SeqNo::from(variable)`.
+
+For the decode path in `manifest_log.rs`:
+
+```rust
+// Before:
+let next_sequence = SeqNo(read_u64_le(data, &mut offset)?);
+
+// After:
+let next_sequence = SeqNo::from(read_u64_le(data, &mut offset)?);
+```
+
+For `SeqRange::new(SeqNo(lo), SeqNo(hi))?` in two decode branches:
+
+```rust
+// Before:
+SeqRange::new(SeqNo(seq_lo), SeqNo(seq_hi))?,
+
+// After:
+SeqRange::new(SeqNo::from(seq_lo), SeqNo::from(seq_hi))?,
+```
+
+In tests, every `SeqNo(N)` literal becomes `SeqNo::from(N)` with the `u64` type ascription preserved where required. The compiler complains at every site — iterate until clean.
+
+- [ ] **Step 7: Migrate `seq.0` field-access sites to `seq.get()`**
+
+For encode sites in `manifest_log.rs`:
+
+```rust
+// Before:
+buf.extend_from_slice(&next_sequence.0.to_le_bytes());
+
+// After:
+buf.extend_from_slice(&next_sequence.get().to_le_bytes());
+```
+
+For `sequence_range.lo().0` / `.hi().0` in `writer.rs`:
+
+```rust
+// Before:
+header.sequence_lo = sequence_range.lo().0;
+header.sequence_hi = sequence_range.hi().0;
+
+// After:
+header.sequence_lo = sequence_range.lo().get();
+header.sequence_hi = sequence_range.hi().get();
+```
+
+Apply `.get()` substitution everywhere the compiler flags `.0` on a `SeqNo` value.
+
+- [ ] **Step 8: Run cargo check**
+
+Run: `cargo check -p minkowski-lsm --all-targets`
+Expected: clean compile.
+
+- [ ] **Step 9: Run full tests**
+
+Run: `cargo test -p minkowski-lsm`
+Expected: 110 tests pass (107 existing + 3 new `seqno_*`).
+
+- [ ] **Step 10: Run clippy**
+
+Run: `cargo clippy -p minkowski-lsm --all-targets -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add crates/minkowski-lsm/
+git commit -m "feat(lsm): privatize SeqNo.0; add .get() and .next()
+
+Moves SeqNo from a transparent newtype (pub u64) to an opaque newtype
+with explicit accessor and named 'advance' operation. Closes the
+Encapsulation 5/10 → 10/10 gap the type-design reviewer flagged across
+PR A / PR B1 / PR B2 reviews.
+
+- .get(self) -> u64 for explicit, grep-friendly extraction.
+- .next(self) -> Self for 'next sequence' with checked_add(1).expect()
+  semantics — overflow is an internal invariant violation (WAL is the
+  only producer; 2^64 seqs exhausts long after any realistic lifetime).
+
+From<u64> and From<SeqNo> for u64 impls retained — callers can still
+use .into() or From::from for infallible construction. All ~40
+call sites migrated: SeqNo(x) -> SeqNo::from(x), seq.0 -> seq.get().
+
+No wire format change. No public API change visible to external
+consumers (there are none today)."
+```
+
+If the pre-commit fmt hook modifies files, re-stage and re-commit (never amend — TigerStyle rule).
+
+---
+
+## Task 2: `SizeBytes(u64)` newtype
+
+**Goal:** Add `SizeBytes(u64)` as the companion to `PageCount`, preparing for Task 3 where `SortedRunMeta::new` takes both newtypes. Pure addition; no caller migration yet.
+
+**Files:**
+- Modify: `crates/minkowski-lsm/src/types.rs`
+
+- [ ] **Step 1: Write failing unit tests for `SizeBytes`**
+
+Add to the `#[cfg(test)] mod tests` block:
+
+```rust
+    #[test]
+    fn sizebytes_get_returns_inner_u64() {
+        let s = SizeBytes::new(1024);
+        assert_eq!(s.get(), 1024);
+    }
+
+    #[test]
+    fn sizebytes_allows_zero() {
+        let s = SizeBytes::new(0);
+        assert_eq!(s.get(), 0);
+    }
+
+    #[test]
+    fn sizebytes_display() {
+        assert_eq!(SizeBytes::new(42).to_string(), "42");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p minkowski-lsm --lib types::tests -- sizebytes`
+Expected: FAIL — `SizeBytes` doesn't exist.
+
+- [ ] **Step 3: Add `SizeBytes`**
+
+In `crates/minkowski-lsm/src/types.rs`, after the `PageCount` definition (they're symmetric newtypes; place them together), add:
+
+```rust
+/// Size in bytes of an on-disk artifact.
+///
+/// Infallible newtype — zero is permitted (matches the semantics of
+/// `fs::metadata(...).len()`, which returns `0` for empty files).
+/// Type-level distinction from `PageCount` prevents arg-swap bugs at
+/// `SortedRunMeta::new`.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default)]
+pub struct SizeBytes(u64);
+
+impl SizeBytes {
+    pub fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub fn get(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for SizeBytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+```
+
+Note the difference from `PageCount`: `SizeBytes::new` is infallible (returns `Self` directly, not `Option<Self>`). The `u64` field is private, matching the privatization precedent set by Task 1's `SeqNo`. No `From<u64>` impl — the spec item #2 doesn't mention one, and adding it invites silent arg-swap via `.into()` at `SortedRunMeta::new` call sites. Keep construction explicit via `::new`.
+
+- [ ] **Step 4: Add layout assertions matching `PageCount`**
+
+Find the `assert_eq_size!` block for `PageCount` in the test module. Add matching assertions for `SizeBytes`:
+
+```rust
+    assert_eq_size!(SizeBytes, u64);
+    assert_eq_size!(Option<SizeBytes>, u64);
+```
+
+Wait — the second one is false: `Option<SizeBytes>` is NOT u64-sized because `SizeBytes` has no niche (plain `u64` uses the full range). Use only the first assertion:
+
+```rust
+    assert_eq_size!(SizeBytes, u64);
+```
+
+- [ ] **Step 5: Run the new tests**
+
+Run: `cargo test -p minkowski-lsm --lib types::tests -- sizebytes`
+Expected: 3 tests pass. The `assert_eq_size!` is a compile-time check, not a runtime test.
+
+- [ ] **Step 6: Run full tests + clippy**
+
+```bash
+cargo test -p minkowski-lsm
+cargo clippy -p minkowski-lsm --all-targets -- -D warnings
+```
+
+Expected: 113 tests pass (110 from Task 1 + 3 new `sizebytes_*`). Clippy clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/minkowski-lsm/src/types.rs
+git commit -m "feat(lsm): add SizeBytes(u64) newtype
+
+Infallible newtype — zero is permitted (matches fs::metadata.len()
+semantics). Private u64 field; pub fn new/get/Display only. No From<u64>
+impl to prevent arg-swap via .into() at the SortedRunMeta::new
+call site (Task 3 uses SizeBytes::new explicitly).
+
+No callers migrated yet. Task 3 threads this and PageCount through
+SortedRunMeta::new so the existing arg-swap hazard (two adjacent u64s)
+becomes a compile error."
+```
+
+---
+
+## Task 3: `SortedRunMeta::new` takes `PageCount` + `SizeBytes`
+
+**Goal:** Push `PageCount::new` validation up to callers; replace raw `u64` constructor args with the type-safe wrappers. Closes the "two adjacent u64s can be swapped" hazard the type-design reviewer flagged.
+
+**Files:**
+- Modify: `crates/minkowski-lsm/src/manifest.rs` (constructor signature + field type for `size_bytes` + accessor)
+- Modify: `crates/minkowski-lsm/src/manifest_ops.rs` (`flush_and_record` construction site)
+- Modify: `crates/minkowski-lsm/src/manifest_log.rs` (two decode construction sites)
+
+- [ ] **Step 1: Change the field type and accessor for `size_bytes`**
+
+In `crates/minkowski-lsm/src/manifest.rs`, update imports:
+
+```rust
+use crate::types::{PageCount, SeqRange, SizeBytes};
+```
+
+Find the `SortedRunMeta` struct definition and change `size_bytes`:
+
+```rust
+pub struct SortedRunMeta {
+    path: PathBuf,
+    sequence_range: SeqRange,
+    archetype_coverage: Box<[u16]>,
+    page_count: PageCount,
+    size_bytes: SizeBytes,       // was: u64
+}
+```
+
+Update the accessor:
+
+```rust
+    pub fn size_bytes(&self) -> SizeBytes {
+        self.size_bytes
+    }
+```
+
+- [ ] **Step 2: Update `SortedRunMeta::new` signature**
+
+Change the signature to take `PageCount` and `SizeBytes` directly:
+
+```rust
+    pub fn new(
+        path: PathBuf,
+        sequence_range: SeqRange,
+        archetype_coverage: Vec<u16>,
+        page_count: PageCount,       // was: u64
+        size_bytes: SizeBytes,       // was: u64
+    ) -> Result<Self, LsmError> {
+        if archetype_coverage.windows(2).any(|w| w[0] >= w[1]) {
+            return Err(LsmError::Format(
+                "archetype_coverage is not strictly sorted".to_owned(),
+            ));
+        }
+        // Note: the PageCount::new fallibility has moved up to callers.
+        // SortedRunMeta::new is now only responsible for the coverage
+        // sort check.
+        Ok(Self {
+            path,
+            sequence_range,
+            archetype_coverage: archetype_coverage.into_boxed_slice(),
+            page_count,
+            size_bytes,
+        })
+    }
+```
+
+Delete the old `PageCount::new(page_count).ok_or_else(...)?` line — the validation is now at the call sites.
+
+- [ ] **Step 3: Migrate `flush_and_record` in `manifest_ops.rs`**
+
+In `crates/minkowski-lsm/src/manifest_ops.rs`, update imports:
+
+```rust
+use crate::types::{Level, PageCount, SeqNo, SeqRange, SizeBytes};
+```
+
+Find the `SortedRunMeta::new(...)` call. Currently:
+
+```rust
+    let meta = SortedRunMeta::new(
+        path.clone(),
+        reader.sequence_range(),
+        archetype_coverage,
+        reader.page_count(),            // u64
+        file_size,                       // u64
+    )?;
+```
+
+`reader.page_count()` already returns `u64`; `file_size` is `u64`. Wrap both:
+
+```rust
+    let page_count = PageCount::new(reader.page_count()).ok_or_else(|| {
+        LsmError::Format("page_count must be non-zero".to_owned())
+    })?;
+    let meta = SortedRunMeta::new(
+        path.clone(),
+        reader.sequence_range(),
+        archetype_coverage,
+        page_count,
+        SizeBytes::new(file_size),
+    )?;
+```
+
+- [ ] **Step 4: Migrate `decode_entry` sites in `manifest_log.rs`**
+
+Find the `TAG_ADD_RUN` decode arm. Currently:
+
+```rust
+            let page_count = read_u64_le(data, &mut offset)?;
+            let size_bytes = read_u64_le(data, &mut offset)?;
+            let meta = SortedRunMeta::new(
+                path,
+                SeqRange::new(SeqNo::from(seq_lo), SeqNo::from(seq_hi))?,
+                coverage,
+                page_count,        // u64
+                size_bytes,        // u64
+            )?;
+```
+
+Update to wrap inline:
+
+```rust
+            let page_count = read_u64_le(data, &mut offset)?;
+            let size_bytes = read_u64_le(data, &mut offset)?;
+            let page_count = PageCount::new(page_count).ok_or_else(|| {
+                LsmError::Format("page_count must be non-zero".to_owned())
+            })?;
+            let meta = SortedRunMeta::new(
+                path,
+                SeqRange::new(SeqNo::from(seq_lo), SeqNo::from(seq_hi))?,
+                coverage,
+                page_count,
+                SizeBytes::new(size_bytes),
+            )?;
+```
+
+Apply the same pattern to the `TAG_ADD_RUN_AND_SEQUENCE` decode arm. Both sites now call `PageCount::new(...).ok_or_else(...)?` before `SortedRunMeta::new`, surfacing `LsmError::Format` on a zero `page_count` — same behavior as before, just at a slightly earlier layer. The replay loop's error handling (truncate-on-Format) is unchanged.
+
+- [ ] **Step 5: Migrate test construction sites**
+
+In `manifest.rs` test module, find the `test_meta` helper. Update it to use the new signature:
+
+```rust
+    fn test_meta(name: &str, coverage: Vec<u16>) -> SortedRunMeta {
+        SortedRunMeta::new(
+            PathBuf::from(name),
+            SeqRange::new(SeqNo::from(0), SeqNo::from(10)).unwrap(),
+            coverage,
+            PageCount::new(42).unwrap(),
+            SizeBytes::new(8192),
+        )
+        .unwrap()
+    }
+```
+
+Also update test-module imports to include `PageCount` and `SizeBytes`.
+
+Any direct `SortedRunMeta::new` call in unit tests or integration tests needs the same treatment. The existing 4 `sorted_run_meta_new_*` tests in `manifest.rs` construct with bare `u64`s — each needs updating:
+
+```rust
+    #[test]
+    fn sorted_run_meta_new_rejects_unsorted_coverage() {
+        let result = SortedRunMeta::new(
+            PathBuf::from("x.run"),
+            SeqRange::new(SeqNo::from(0), SeqNo::from(10)).unwrap(),
+            vec![3, 1, 2],
+            PageCount::new(1).unwrap(),
+            SizeBytes::new(1024),
+        );
+        assert!(matches!(result, Err(LsmError::Format(_))));
+    }
+```
+
+Apply to all four constructor tests. The test `sorted_run_meta_new_rejects_zero_page_count` changes semantics — zero page_count is no longer caught by `SortedRunMeta::new`; it's caught by the caller at `PageCount::new(0)`. Rename to `page_count_new_rejects_zero` and move to `types.rs` test module if not already covered there (the existing `pagecount_rejects_zero` test covers this). The redundant test can be deleted.
+
+Similarly, any `.size_bytes()` assertion that compared to a `u64` literal now needs `.get()`:
+
+```rust
+// Before:
+assert_eq!(meta.size_bytes(), 4);
+
+// After:
+assert_eq!(meta.size_bytes().get(), 4);
+```
+
+- [ ] **Step 6: Run cargo check**
+
+Run: `cargo check -p minkowski-lsm --all-targets`
+Expected: clean compile. If anything fails, it's a missed constructor call site — enumerate via the compile error and fix.
+
+- [ ] **Step 7: Run full tests**
+
+Run: `cargo test -p minkowski-lsm`
+Expected: test count may shift depending on whether `sorted_run_meta_new_rejects_zero_page_count` was removed (-1) or kept with new semantics. Target: ~112 tests pass.
+
+- [ ] **Step 8: Run clippy**
+
+Run: `cargo clippy -p minkowski-lsm --all-targets -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/minkowski-lsm/
+git commit -m "refactor(lsm): SortedRunMeta::new takes PageCount and SizeBytes
+
+Pushes PageCount::new validation from inside the constructor up to
+the two decode sites and flush_and_record. Constructor signature is now
+(path, SeqRange, Vec<u16>, PageCount, SizeBytes) — two adjacent
+newtypes instead of two adjacent u64s. Swap-at-call-site is now a
+compile error.
+
+size_bytes field and accessor return type change from u64 to SizeBytes.
+Tests comparing .size_bytes() to a u64 literal migrated to .get().
+
+No wire format change. Decode still reads u64 bytes; PageCount::new
+runs at the decode site, surfacing zero as LsmError::Format as before —
+replay loop truncation handles it unchanged.
+
+The in-crate test 'sorted_run_meta_new_rejects_zero_page_count' is
+removed — the zero-page_count behavior is now covered by
+pagecount_rejects_zero (types.rs) plus the in-place decode path
+in manifest_log.rs."
+```
+
+---
+
+## Task 4: Expand tombstones + reserved-bytes round-trip test
+
+**Goal:** Belt-and-suspenders: add `Mul/Div/Rem/Neg` to `SeqNo` arithmetic tombstones. Add an integration test pinning "reserved bytes survive a `recover → append → recover` cycle."
+
+**Files:**
+- Modify: `crates/minkowski-lsm/src/types.rs` (expand tombstone macro calls)
+- Modify: `crates/minkowski-lsm/tests/manifest_integration.rs` (new test)
+
+- [ ] **Step 1: Expand `SeqNo` arithmetic tombstones**
+
+In `crates/minkowski-lsm/src/types.rs`, find the `assert_not_impl_all!` block for `SeqNo`. Extend the imports and macro calls:
+
+```rust
+    use static_assertions::{assert_eq_size, assert_not_impl_all};
+    use std::ops::{Add, AddAssign, Div, Mul, Neg, Rem, Sub, SubAssign};
+
+    // Tombstone tests: SeqNo must NOT implement any arithmetic.
+    assert_not_impl_all!(SeqNo: Add<SeqNo>, Sub<SeqNo>, AddAssign<SeqNo>, SubAssign<SeqNo>);
+    assert_not_impl_all!(SeqNo: Add<u64>, Sub<u64>, AddAssign<u64>, SubAssign<u64>);
+    assert_not_impl_all!(SeqNo: Mul<u64>, Div<u64>, Rem<u64>, Neg);
+```
+
+The third line is the new one. `Neg` has no type parameter (it's unary). The Mul/Div/Rem against `u64` cover the realistic "sequences divided into chunks" misuse.
+
+- [ ] **Step 2: Run tests to verify the tombstones compile**
+
+Run: `cargo test -p minkowski-lsm --lib`
+Expected: clean build. If `SeqNo` accidentally had any of the added traits, compile would fail — none should today.
+
+- [ ] **Step 3: Add the `recover → append → recover` reserved-bytes test**
+
+In `crates/minkowski-lsm/tests/manifest_integration.rs`, near the existing `recover_ignores_nonzero_reserved_bytes` test, add:
+
+```rust
+/// Reserved bytes must survive an append round trip. Guards against a
+/// future refactor that "normalizes" the header on every recover — which
+/// would silently drop forward-compat flags a future version wrote there.
+#[test]
+fn recover_preserves_reserved_bytes_through_append_cycle() {
+    let dir = tempfile::tempdir().unwrap();
+    let log_path = dir.path().join("reserved_append.log");
+
+    // Start with a valid header whose reserved bytes carry a non-zero
+    // "flag" pattern.
+    fs::write(&log_path, b"MKMF\x01\xFF\xAA\x55").unwrap();
+
+    // Open, append one entry, close.
+    let (_, mut log) = ManifestLog::recover(&log_path).unwrap();
+    log.append(&ManifestEntry::SetSequence {
+        next_sequence: SeqNo::from(42),
+    })
+    .unwrap();
+    drop(log);
+
+    // Reserved bytes at offsets 5..8 must still be intact.
+    let bytes = fs::read(&log_path).unwrap();
+    assert_eq!(&bytes[0..4], b"MKMF", "magic preserved");
+    assert_eq!(bytes[4], 0x01, "version preserved");
+    assert_eq!(&bytes[5..8], &[0xFF, 0xAA, 0x55], "reserved bytes preserved");
+
+    // And the entry must replay.
+    let (m, _) = ManifestLog::recover(&log_path).unwrap();
+    assert_eq!(m.next_sequence(), SeqNo::from(42));
+}
+```
+
+Imports at the top of the file should already include `SeqNo`, `ManifestEntry`, `ManifestLog` from prior PRs. Verify.
+
+- [ ] **Step 4: Run the new test**
+
+Run: `cargo test -p minkowski-lsm --test manifest_integration recover_preserves_reserved_bytes_through_append_cycle`
+Expected: PASS.
+
+- [ ] **Step 5: Run full tests + clippy**
+
+```bash
+cargo test -p minkowski-lsm
+cargo clippy -p minkowski-lsm --all-targets -- -D warnings
+```
+
+Expected: 113 tests pass (Task 3's count + 1 new integration test). Clippy clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/minkowski-lsm/src/types.rs \
+        crates/minkowski-lsm/tests/manifest_integration.rs
+git commit -m "test(lsm): expand SeqNo tombstones + reserved-bytes round trip
+
+Two items from the PR B2 review's deferred-polish queue:
+
+- Add Mul/Div/Rem/Neg to SeqNo arithmetic tombstones. The Add/Sub/
+  AddAssign/SubAssign set covered the realistic accident surface;
+  these additional traits close the 'why only additive?' question
+  belt-and-suspenders style.
+- Add recover_preserves_reserved_bytes_through_append_cycle. The
+  existing recover_ignores_nonzero_reserved_bytes covers the empty-
+  body case; this variant verifies that append doesn't rewrite the
+  header and that forward-compat reserved-byte flags survive round
+  trips through append + reopen."
+```
+
+---
+
+## Task 5: Final verification + push + PR
+
+**No code changes. Green-light gate.**
+
+- [ ] **Step 1: Update local toolchain**
+
+Run: `rustup update stable`
+Expected: toolchain update or no-op.
+
+- [ ] **Step 2: Run workspace clippy**
+
+Run: `cargo clippy --workspace --all-targets -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 3: Run workspace tests**
+
+Run: `cargo test --workspace`
+Expected: the 3 pre-existing `minkowski-observe` failures will still fail (pre-existing on main; CI doesn't run them). All other tests pass, including the 113 in `minkowski-lsm`.
+
+- [ ] **Step 4: Run cargo fmt check**
+
+Run: `cargo fmt --all -- --check`
+Expected: clean.
+
+- [ ] **Step 5: Push and open PR**
+
+```bash
+git push -u origin lsm/pr-b3-polish
+gh pr create --title "chore(lsm): manifest type-safety polish (PR B3)" --body "$(cat <<'EOF'
+## Summary
+
+Five deferred polish items from PR B2's review queue. Type-level hardening on the manifest subsystem; no wire format or external API changes.
+
+Plan: \`docs/plans/2026-04-18-lsm-pr-b3-polish-implementation-plan.md\`
+
+## What landed
+
+- **\`SeqNo\` privatization + \`.get()\` + \`.next()\`**: the inner \`u64\` is now private. Explicit accessor and named \`succ\` operation (\`.next()\` with \`checked_add(1).expect("SeqNo overflow")\` semantics — overflow is an internal invariant violation per TigerStyle).
+- **\`SizeBytes(u64)\` newtype**: companion to \`PageCount\`, infallible (zero permitted per \`fs::metadata().len()\` semantics).
+- **\`SortedRunMeta::new\` takes \`PageCount\` + \`SizeBytes\`**: pushes \`PageCount::new\` validation up to callers (decode + flush_and_record); closes the arg-swap hazard where two adjacent \`u64\`s could be transposed.
+- **Expanded \`SeqNo\` tombstones**: \`Mul/Div/Rem/Neg\` added to the existing \`Add/Sub/AddAssign/SubAssign\` set.
+- **\`recover → append → recover\` reserved-bytes test**: pins the forward-compat contract that append doesn't rewrite the header.
+
+## Breaking changes
+
+Internal only — no external consumers of \`minkowski-lsm\` exist.
+
+- \`SeqNo\` inner field is private. Construction via \`SeqNo::from(u64)\` / \`.into()\`, extraction via \`.get()\` or \`u64::from(seq)\`.
+- \`SortedRunMeta::new\` signature changes: takes \`PageCount\`, \`SizeBytes\` instead of two \`u64\`s. Callers wrap at construction.
+- \`SortedRunMeta::size_bytes()\` returns \`SizeBytes\` instead of \`u64\`. Test assertions against \`u64\` literals need \`.get()\`.
+
+No wire format changes — encode/decode still reads/writes \`u64\` bytes, wrapping at codec boundaries.
+
+## Tests
+
+113 total in \`minkowski-lsm\` (up from 107):
+- 3 new \`SeqNo::next/get\` unit tests (including overflow panic)
+- 3 new \`SizeBytes\` unit tests
+- 1 new \`recover_preserves_reserved_bytes_through_append_cycle\` integration test
+- 1 redundant test removed (\`sorted_run_meta_new_rejects_zero_page_count\` — now covered by \`pagecount_rejects_zero\`)
+
+## Test plan
+
+- [x] \`cargo test -p minkowski-lsm\` — 113/113 pass
+- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
+- [x] \`cargo fmt --all -- --check\` — clean
+- [ ] CI pipeline (fmt, clippy, test, tsan, loom, claude-review)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6: Monitor CI; update memory after merge**
+
+Once the PR merges, update:
+- \`project_scaling_roadmap.md\`: note PR B3 landed.
+- \`project_lsm_phase2_type_safety.md\`: items are all consumed — repurpose as a Phase 3 notes file or delete.
+
+---
+
+## Self-review (done inline before saving)
+
+- **Spec coverage:**
+  - Item 1 (SortedRunMeta::new takes PageCount) → Task 3
+  - Item 2 (SizeBytes newtype) → Task 2 + Task 3
+  - Item 3 (SeqNo privatization + .next()) → Task 1
+  - Item 4 (Mul/Div/Rem/Neg tombstones) → Task 4 Step 1
+  - Item 5 (reserved-bytes round trip) → Task 4 Step 3
+
+- **Placeholder scan:** None. Every code block has complete code.
+
+- **Type consistency:**
+  - `SeqNo::get(self) -> u64` method referenced in Task 1 is used in Task 3's encode sites and test assertions. Consistent.
+  - `SeqNo::next(self) -> Self` — defined in Task 1, not used in later tasks (no call sites migrate to use it in this PR; it's available for future callers). Correct scope.
+  - `SizeBytes::new(u64) -> Self` / `SizeBytes::get(self) -> u64` — defined in Task 2, used consistently in Task 3.
+  - `SortedRunMeta::new(path, SeqRange, Vec<u16>, PageCount, SizeBytes) -> Result<Self>` — final signature across Task 3 and Task 4's test. Consistent.
+  - `.into_boxed_slice()` at the coverage conversion boundary — preserved from PR B2, unchanged.
+
+Self-review complete. Plan is ready.
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/plans/2026-04-18-lsm-pr-b3-polish-implementation-plan.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — five tasks, each reasonably scoped. Task 1 has the biggest mechanical cascade (~40 SeqNo migration sites); Task 3 cascades through three files. Matches the pattern that worked for PR B1, PR B2.
+
+**2. Inline Execution** — batch execution with checkpoints here.
+
+Which approach?


### PR DESCRIPTION
## Summary

Five deferred polish items from the PR B2 review queue. Type-level hardening on the manifest subsystem; no wire format or external API consumer impact.

Plan: \`docs/plans/2026-04-18-lsm-pr-b3-polish-implementation-plan.md\`

## What landed

- **\`SeqNo\` privatization + \`.get()\` + \`.next()\`**: inner \`u64\` is now private. Explicit \`.get()\` accessor and \`.next()\` advance method with \`checked_add(1).expect("SeqNo overflow")\` — panic-on-overflow matches TigerStyle \"internal invariant violation\" semantics (WAL is the only producer; 2^64 seqs exhausts long after any realistic lifetime).
- **\`SizeBytes(u64)\` newtype**: companion to \`PageCount\`. Infallible (zero permitted per \`fs::metadata().len()\` semantics). No \`From<u64>\` impl — explicit \`::new\` at call sites prevents arg-swap via \`.into()\`.
- **\`SortedRunMeta::new\` takes \`PageCount\` + \`SizeBytes\`**: \`PageCount::new\` validation moves up to decode sites + \`flush_and_record\`. The previously-trivial arg-swap bug (two adjacent \`u64\`s) is now a compile error — the two newtypes are structurally incompatible.
- **Expanded \`SeqNo\` tombstones**: \`Mul/Div/Rem/Neg\` added to the existing \`Add/Sub/AddAssign/SubAssign\` set.
- **\`recover → append → recover\` reserved-bytes round-trip test**: pins the forward-compat contract that \`append\` doesn't rewrite the header.

## Breaking changes

Internal only — no external consumers of \`minkowski-lsm\` exist.

- \`SeqNo\` inner field is private. Construction via \`SeqNo::from(u64)\` / \`.into()\`; extraction via \`.get()\` or \`u64::from(seq)\`.
- \`SortedRunMeta::new\` signature takes \`PageCount\`, \`SizeBytes\` instead of two \`u64\`s.
- \`SortedRunMeta::size_bytes()\` returns \`SizeBytes\` instead of \`u64\`.

No wire format changes — encode/decode still reads/writes \`u64\` bytes, wrapping at codec boundaries.

## Tests

113 total in \`minkowski-lsm\` (up from 107):
- 3 new \`SeqNo::next/get\` unit tests (including \`#[should_panic]\` for overflow)
- 3 new \`SizeBytes\` unit tests + layout assertion
- 4 expanded arithmetic tombstones (compile-time, not runtime)
- 1 new \`recover_preserves_reserved_bytes_through_append_cycle\` integration test
- 1 test \`sorted_run_meta_new_rejects_zero_page_count\` removed — redundant with \`pagecount_rejects_zero\` + decode-site validation
- Assertion symmetry fix: \`.size_bytes().get()\` added alongside the existing \`.page_count().get()\` assertion

## Test plan

- [x] \`cargo test -p minkowski-lsm\` — 113/113 pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] CI pipeline (fmt, clippy, test, tsan, loom, claude-review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)