### PR TITLE
refactor(lsm): Phase 3 PR 1 — infrastructure (codec move + const-generic + CrcProof hook)

### DIFF
--- a/crates/minkowski-lsm/Cargo.toml
+++ b/crates/minkowski-lsm/Cargo.toml
@@ -10,6 +10,8 @@ workspace = true
 minkowski = { path = "../minkowski" }
 crc32fast = "1"
 memmap2 = "0.9"
+rkyv = { version = "0.8", features = ["alloc", "bytecheck"] }
+thiserror = "2"
 
 [dev-dependencies]
 static_assertions = "1"

--- a/crates/minkowski-lsm/src/codec.rs
+++ b/crates/minkowski-lsm/src/codec.rs
@@ -10,6 +10,21 @@ use rkyv::rancor;
 use rkyv::ser::allocator::ArenaHandle;
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 
+/// Schema entry describing a component type. Used in both snapshot schemas
+/// and WAL preambles. Fields are sender-local: `id` is meaningful only in
+/// the originating World's ID space.
+///
+/// Defined here (in `minkowski-lsm::codec`) so that [`CodecRegistry::build_remap`]
+/// can reference it without a dependency on `minkowski-persist`. Re-exported by
+/// `minkowski-persist::record` for WAL and snapshot consumers.
+#[derive(Archive, RkyvSerialize, RkyvDeserialize, Debug, Clone)]
+pub struct ComponentSchema {
+    pub id: ComponentId,
+    pub name: String,
+    pub size: usize,
+    pub align: usize,
+}
+
 /// Type-erased serialize: reads T from raw pointer, serializes to output buffer.
 type SerializeFn = unsafe fn(*const u8, &mut Vec<u8>) -> Result<(), CodecError>;
 
@@ -310,7 +325,7 @@ impl CodecRegistry {
     ///
     /// Without a proof, falls through to [`deserialize`](Self::deserialize)
     /// which runs full rkyv validation — safe for untrusted bytes.
-    pub(crate) fn decode(
+    pub fn decode(
         &self,
         id: ComponentId,
         bytes: &[u8],
@@ -376,7 +391,7 @@ impl CodecRegistry {
     /// mapping from sender ComponentId → receiver ComponentId.
     pub fn build_remap(
         &self,
-        schema: &[crate::record::ComponentSchema],
+        schema: &[ComponentSchema],
     ) -> Result<HashMap<ComponentId, ComponentId>, CodecError> {
         let mut remap = HashMap::new();
         for def in schema {
@@ -407,17 +422,19 @@ impl Default for CodecRegistry {
     }
 }
 
-/// Zero-sized proof that a byte payload has been CRC32-verified.
+/// A proof token returned by [`CrcProof::verify`] after successful CRC32
+/// validation of a byte payload. Unforgeable: the only public constructor
+/// is [`CrcProof::verify`], which runs the actual checksum.
 ///
-/// Unforgeable: the only constructor runs the actual CRC computation
-/// and compares against the expected checksum. The `raw_copy_size` fast
-/// path in [`CodecRegistry::decode`] requires this proof — unverified
-/// bytes go through full rkyv bytecheck validation instead.
-pub(crate) struct CrcProof(());
+/// Used by [`CodecRegistry::decode`] to gate the `raw_copy_size` fast path
+/// (direct memcpy, skipping rkyv bytecheck). Producers: WAL frame reader
+/// ([`minkowski_persist::wal::read_next_frame`]), LSM page validator
+/// ([`SortedRunReader::validate_page_crc`]).
+pub struct CrcProof(());
 
 impl CrcProof {
     /// Verify a payload's CRC32 checksum. Returns proof on success, `None` on mismatch.
-    pub(crate) fn verify(payload: &[u8], expected_crc: u32) -> Option<Self> {
+    pub fn verify(payload: &[u8], expected_crc: u32) -> Option<Self> {
         if crc32fast::hash(payload) == expected_crc {
             Some(Self(()))
         } else {
@@ -571,7 +588,7 @@ mod tests {
         ));
     }
 
-    use crate::record::ComponentSchema;
+    use super::ComponentSchema;
 
     #[test]
     fn build_remap_same_order() {

--- a/crates/minkowski-lsm/src/lib.rs
+++ b/crates/minkowski-lsm/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod codec;
 pub mod error;
 pub mod format;
 pub mod manifest;

--- a/crates/minkowski-lsm/src/manifest.rs
+++ b/crates/minkowski-lsm/src/manifest.rs
@@ -15,6 +15,19 @@
 //! history), construct [`LsmManifest<7>`] instead. Merge logic is
 //! level-count-agnostic; only bounds checks and manifest serialization
 //! care about `N`.
+//!
+//! ## Cross-N log portability (known limitation)
+//!
+//! The manifest-log wire format does not yet carry an `N` field. A log
+//! written by an `LsmManifest<7>` replayed by an `LsmManifest<4>` will
+//! silently truncate every frame referencing level 4..=6 as tail
+//! garbage (those bytes fail the `level.as_index() < N` bounds check
+//! in `apply_entry`, which the replay loop treats as torn-tail).
+//!
+//! Practical rule: **do not move a manifest log between builds that use
+//! different `N` values.** A fix (manifest-header `max_level` byte with
+//! fatal mismatch on recover) is in scope for the Phase 3 compactor PR,
+//! where on-disk format changes are already expected.
 
 use std::path::{Path, PathBuf};
 
@@ -358,5 +371,66 @@ mod tests {
         // DefaultManifest alias resolves to N=4.
         let md: DefaultManifest = LsmManifest::new();
         assert_eq!(md.total_runs(), 0);
+    }
+
+    #[test]
+    fn lsm_manifest_n7_exercises_level_beyond_default() {
+        // Confirm that LsmManifest<7>'s extra levels (4..=6) actually work
+        // for add/query. This guards against a hypothetical future
+        // regression where the fixed-size [Vec<_>; N] array is indexed by
+        // a hardcoded 4.
+        let mut m7: LsmManifest<7> = LsmManifest::new();
+        let level_6 = Level::new(6).unwrap();
+
+        m7.add_run(level_6, test_meta("l6.run")).unwrap();
+        assert_eq!(m7.runs_at_level(level_6).len(), 1);
+        assert_eq!(m7.total_runs(), 1);
+
+        // Same level on LsmManifest<4> returns the OOR signals.
+        let mut m4: DefaultManifest = LsmManifest::new();
+        let err = m4.add_run(level_6, test_meta("l6.run")).unwrap_err();
+        assert!(matches!(err, LsmError::Format(_)));
+        assert!(m4.runs_at_level(level_6).is_empty());
+    }
+
+    #[test]
+    fn add_run_rejects_out_of_range_level() {
+        let mut m: DefaultManifest = LsmManifest::new();
+        let oor = Level::new(4).unwrap(); // valid Level, but OOR for N=4.
+        let err = m.add_run(oor, test_meta("oor.run")).unwrap_err();
+        assert!(matches!(err, LsmError::Format(_)));
+        assert_eq!(m.total_runs(), 0, "failed add_run must not mutate state");
+    }
+
+    #[test]
+    fn remove_run_returns_none_for_out_of_range_level() {
+        let mut m: DefaultManifest = LsmManifest::new();
+        let oor = Level::new(4).unwrap();
+        assert!(m.remove_run(oor, Path::new("anything.run")).is_none());
+    }
+
+    #[test]
+    fn promote_run_rejects_out_of_range_levels() {
+        let mut m: DefaultManifest = LsmManifest::new();
+        let oor = Level::new(4).unwrap();
+
+        // OOR as destination.
+        let err = m
+            .promote_run(Level::L0, oor, Path::new("x.run"))
+            .unwrap_err();
+        assert!(matches!(err, LsmError::Format(_)));
+
+        // OOR as source.
+        let err = m
+            .promote_run(oor, Level::L0, Path::new("x.run"))
+            .unwrap_err();
+        assert!(matches!(err, LsmError::Format(_)));
+    }
+
+    #[test]
+    fn runs_at_level_returns_empty_for_out_of_range_level() {
+        let m: DefaultManifest = LsmManifest::new();
+        let oor = Level::new(4).unwrap();
+        assert!(m.runs_at_level(oor).is_empty());
     }
 }

--- a/crates/minkowski-lsm/src/manifest.rs
+++ b/crates/minkowski-lsm/src/manifest.rs
@@ -1,16 +1,37 @@
+//! # LsmManifest
+//!
+//! In-memory index of sorted runs across LSM levels.
+//!
+//! ## Level Count
+//!
+//! Defaults to 4 levels. This fits the expected minkowski regime:
+//! on-disk data up to ~100× RAM, with reads served from the in-memory
+//! World rather than from level traversal (the in-memory World IS the
+//! merged view).
+//!
+//! At T=10 size ratio: 4 levels covers ~0.1× to 100× RAM on disk.
+//!
+//! For ledger-style workloads (TigerBeetle territory, ever-growing
+//! history), construct [`LsmManifest<7>`] instead. Merge logic is
+//! level-count-agnostic; only bounds checks and manifest serialization
+//! care about `N`.
+
 use std::path::{Path, PathBuf};
 
 use crate::error::LsmError;
 use crate::types::{Level, PageCount, SeqNo, SeqRange, SizeBytes};
 
-/// Number of LSM levels (L0 through L3).
-pub const NUM_LEVELS: usize = 4;
-
-/// In-memory manifest tracking all sorted runs across levels.
-pub struct LsmManifest {
-    levels: [Vec<SortedRunMeta>; NUM_LEVELS],
+/// In-memory manifest tracking all sorted runs across `N` levels.
+///
+/// `N` is a const generic with default 4. Use [`DefaultManifest`] as
+/// the conventional alias.
+pub struct LsmManifest<const N: usize = 4> {
+    levels: [Vec<SortedRunMeta>; N],
     next_sequence: u64,
 }
+
+/// Conventional alias for the default 4-level manifest.
+pub type DefaultManifest = LsmManifest<4>;
 
 /// Metadata for a single sorted run file.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -73,7 +94,7 @@ impl SortedRunMeta {
     }
 }
 
-impl LsmManifest {
+impl<const N: usize> LsmManifest<N> {
     /// Create an empty manifest.
     pub fn new() -> Self {
         Self {
@@ -83,12 +104,26 @@ impl LsmManifest {
     }
 
     /// Add a sorted run to a level.
-    pub fn add_run(&mut self, level: Level, meta: SortedRunMeta) {
+    ///
+    /// Returns `Err(LsmError::Format)` if `level.as_index() >= N`.
+    pub fn add_run(&mut self, level: Level, meta: SortedRunMeta) -> Result<(), LsmError> {
+        if level.as_index() >= N {
+            return Err(LsmError::Format(format!(
+                "level {} out of range for {}-level manifest",
+                level, N
+            )));
+        }
         self.levels[level.as_index()].push(meta);
+        Ok(())
     }
 
     /// Remove a sorted run by path from a level. Returns the removed entry.
+    ///
+    /// Returns `None` if the level is out of range or the path is not found.
     pub fn remove_run(&mut self, level: Level, path: &Path) -> Option<SortedRunMeta> {
+        if level.as_index() >= N {
+            return None;
+        }
         let runs = &mut self.levels[level.as_index()];
         runs.iter()
             .position(|r| r.path() == path)
@@ -102,6 +137,12 @@ impl LsmManifest {
         to_level: Level,
         path: &Path,
     ) -> Result<(), LsmError> {
+        if from_level.as_index() >= N || to_level.as_index() >= N {
+            return Err(LsmError::Format(format!(
+                "level out of range for {}-level manifest: from={}, to={}",
+                N, from_level, to_level
+            )));
+        }
         let meta = self.remove_run(from_level, path).ok_or_else(|| {
             LsmError::Format(format!(
                 "run {} not found at level {}",
@@ -109,7 +150,7 @@ impl LsmManifest {
                 from_level
             ))
         })?;
-        self.add_run(to_level, meta);
+        self.add_run(to_level, meta)?;
         Ok(())
     }
 
@@ -124,7 +165,12 @@ impl LsmManifest {
     }
 
     /// All sorted runs currently tracked at the given level.
+    ///
+    /// Returns `&[]` if `level.as_index() >= N`.
     pub fn runs_at_level(&self, level: Level) -> &[SortedRunMeta] {
+        if level.as_index() >= N {
+            return &[];
+        }
         &self.levels[level.as_index()]
     }
 
@@ -141,7 +187,7 @@ impl LsmManifest {
     }
 }
 
-impl Default for LsmManifest {
+impl<const N: usize> Default for LsmManifest<N> {
     fn default() -> Self {
         Self::new()
     }
@@ -165,8 +211,8 @@ mod tests {
 
     #[test]
     fn new_manifest_is_empty() {
-        let m = LsmManifest::new();
-        for lvl in 0..NUM_LEVELS {
+        let m: DefaultManifest = LsmManifest::new();
+        for lvl in 0..4 {
             assert!(m.runs_at_level(Level::new(lvl as u8).unwrap()).is_empty());
         }
         assert_eq!(m.next_sequence(), SeqNo::from(0u64));
@@ -175,18 +221,18 @@ mod tests {
 
     #[test]
     fn add_run_places_at_correct_level() {
-        let mut m = LsmManifest::new();
+        let mut m: DefaultManifest = LsmManifest::new();
         let meta = test_meta("run_l1.sst");
-        m.add_run(Level::L1, meta.clone());
+        m.add_run(Level::L1, meta.clone()).unwrap();
         assert_eq!(m.runs_at_level(Level::L1), &[meta]);
         assert!(m.runs_at_level(Level::L0).is_empty());
     }
 
     #[test]
     fn remove_run_by_path() {
-        let mut m = LsmManifest::new();
+        let mut m: DefaultManifest = LsmManifest::new();
         let meta = test_meta("run_a.sst");
-        m.add_run(Level::L0, meta.clone());
+        m.add_run(Level::L0, meta.clone()).unwrap();
         let removed = m.remove_run(Level::L0, Path::new("run_a.sst"));
         assert_eq!(removed, Some(meta));
         assert!(m.runs_at_level(Level::L0).is_empty());
@@ -194,7 +240,7 @@ mod tests {
 
     #[test]
     fn remove_run_missing_returns_none() {
-        let mut m = LsmManifest::new();
+        let mut m: DefaultManifest = LsmManifest::new();
         assert!(
             m.remove_run(Level::L0, Path::new("nonexistent.sst"))
                 .is_none()
@@ -203,9 +249,9 @@ mod tests {
 
     #[test]
     fn promote_run_moves_between_levels() {
-        let mut m = LsmManifest::new();
+        let mut m: DefaultManifest = LsmManifest::new();
         let meta = test_meta("run_x.sst");
-        m.add_run(Level::L0, meta);
+        m.add_run(Level::L0, meta).unwrap();
         m.promote_run(Level::L0, Level::L1, Path::new("run_x.sst"))
             .unwrap();
         assert!(m.runs_at_level(Level::L0).is_empty());
@@ -215,16 +261,16 @@ mod tests {
 
     #[test]
     fn promote_run_missing_returns_error() {
-        let mut m = LsmManifest::new();
+        let mut m: DefaultManifest = LsmManifest::new();
         let result = m.promote_run(Level::L0, Level::L1, Path::new("missing.sst"));
         assert!(matches!(result, Err(LsmError::Format(_))));
     }
 
     #[test]
     fn all_run_paths_collects_all_levels() {
-        let mut m = LsmManifest::new();
-        m.add_run(Level::L0, test_meta("l0.sst"));
-        m.add_run(Level::L2, test_meta("l2.sst"));
+        let mut m: DefaultManifest = LsmManifest::new();
+        m.add_run(Level::L0, test_meta("l0.sst")).unwrap();
+        m.add_run(Level::L2, test_meta("l2.sst")).unwrap();
         let paths = m.all_run_paths();
         assert_eq!(paths.len(), 2);
         assert!(paths.contains(&Path::new("l0.sst")));
@@ -233,16 +279,16 @@ mod tests {
 
     #[test]
     fn total_runs_counts_correctly() {
-        let mut m = LsmManifest::new();
-        m.add_run(Level::L0, test_meta("a.sst"));
-        m.add_run(Level::L0, test_meta("b.sst"));
-        m.add_run(Level::L2, test_meta("c.sst"));
+        let mut m: DefaultManifest = LsmManifest::new();
+        m.add_run(Level::L0, test_meta("a.sst")).unwrap();
+        m.add_run(Level::L0, test_meta("b.sst")).unwrap();
+        m.add_run(Level::L2, test_meta("c.sst")).unwrap();
         assert_eq!(m.total_runs(), 3);
     }
 
     #[test]
     fn set_and_get_next_sequence() {
-        let mut m = LsmManifest::new();
+        let mut m: DefaultManifest = LsmManifest::new();
         m.set_next_sequence(SeqNo::from(42u64));
         assert_eq!(m.next_sequence(), SeqNo::from(42u64));
     }
@@ -297,5 +343,20 @@ mod tests {
         )
         .unwrap();
         assert_eq!(meta.archetype_coverage().len(), 0);
+    }
+
+    #[test]
+    fn lsm_manifest_alternate_level_count_compiles_and_works() {
+        // Default N=4 path still works.
+        let m4: LsmManifest<4> = LsmManifest::new();
+        assert_eq!(m4.total_runs(), 0);
+
+        // Alternate N=7 manifest constructs and is distinct at the type level.
+        let m7: LsmManifest<7> = LsmManifest::new();
+        assert_eq!(m7.total_runs(), 0);
+
+        // DefaultManifest alias resolves to N=4.
+        let md: DefaultManifest = LsmManifest::new();
+        assert_eq!(md.total_runs(), 0);
     }
 }

--- a/crates/minkowski-lsm/src/manifest_log.rs
+++ b/crates/minkowski-lsm/src/manifest_log.rs
@@ -423,9 +423,12 @@ fn decode_entry(data: &[u8]) -> Result<ManifestEntry, LsmError> {
 
 // ── ManifestLog ─────────────────────────────────────────────────────────────
 
-fn apply_entry(manifest: &mut LsmManifest, entry: &ManifestEntry) -> Result<(), LsmError> {
+fn apply_entry<const N: usize>(
+    manifest: &mut LsmManifest<N>,
+    entry: &ManifestEntry,
+) -> Result<(), LsmError> {
     match entry {
-        ManifestEntry::AddRun { level, meta } => manifest.add_run(*level, meta.clone()),
+        ManifestEntry::AddRun { level, meta } => manifest.add_run(*level, meta.clone())?,
         ManifestEntry::RemoveRun { level, path } => {
             // A RemoveRun for a path the manifest doesn't know means log
             // corruption — the corresponding AddRun was lost, or entries
@@ -457,7 +460,7 @@ fn apply_entry(manifest: &mut LsmManifest, entry: &ManifestEntry) -> Result<(), 
             meta,
             next_sequence,
         } => {
-            manifest.add_run(*level, meta.clone());
+            manifest.add_run(*level, meta.clone())?;
             manifest.set_next_sequence(*next_sequence);
         }
     }
@@ -468,7 +471,11 @@ fn apply_entry(manifest: &mut LsmManifest, entry: &ManifestEntry) -> Result<(), 
 /// Truncates on torn-tail / decode / apply errors, as the existing
 /// recovery contract requires. Returns the recovered manifest and the
 /// post-truncation position (end of the valid frame region).
-fn replay_frames(file: &File, path: &Path, start: u64) -> Result<(LsmManifest, u64), LsmError> {
+fn replay_frames<const N: usize>(
+    file: &File,
+    path: &Path,
+    start: u64,
+) -> Result<(LsmManifest<N>, u64), LsmError> {
     let mut manifest = LsmManifest::new();
     let mut pos: u64 = start;
 
@@ -527,7 +534,7 @@ impl ManifestLog {
     /// replays frames from offset 8 onward (truncating torn tails), and
     /// returns `(recovered_manifest, log_handle)` with `write_pos` at
     /// end of valid data.
-    pub fn recover(path: &Path) -> Result<(LsmManifest, Self), LsmError> {
+    pub fn recover<const N: usize>(path: &Path) -> Result<(LsmManifest<N>, Self), LsmError> {
         if !path.exists() {
             let mut file = OpenOptions::new()
                 .create(true)
@@ -713,7 +720,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("manifest.log");
 
-        let (_, mut log) = ManifestLog::recover(&path).unwrap();
+        let (_, mut log) = ManifestLog::recover::<4>(&path).unwrap();
         log.append(&ManifestEntry::AddRunAndSequence {
             level: Level::L0,
             meta: test_meta("atomic.run"),
@@ -722,7 +729,7 @@ mod tests {
         .unwrap();
         drop(log);
 
-        let (manifest, _) = ManifestLog::recover(&path).unwrap();
+        let (manifest, _) = ManifestLog::recover::<4>(&path).unwrap();
         assert_eq!(manifest.total_runs(), 1);
         assert_eq!(manifest.next_sequence(), SeqNo::from(42u64));
         assert_eq!(
@@ -790,7 +797,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("manifest.log");
         // File doesn't exist → empty manifest.
-        let (manifest, _) = ManifestLog::recover(&path).unwrap();
+        let (manifest, _) = ManifestLog::recover::<4>(&path).unwrap();
         assert_eq!(manifest.total_runs(), 0);
         assert_eq!(manifest.next_sequence(), SeqNo::from(0u64));
     }
@@ -800,7 +807,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("manifest.log");
 
-        let (_, mut log) = ManifestLog::recover(&path).unwrap();
+        let (_, mut log) = ManifestLog::recover::<4>(&path).unwrap();
         for i in 0..3 {
             let meta = test_meta(&format!("{i}.run"));
             log.append(&ManifestEntry::AddRun {
@@ -811,7 +818,7 @@ mod tests {
         }
         drop(log);
 
-        let (manifest, _) = ManifestLog::recover(&path).unwrap();
+        let (manifest, _) = ManifestLog::recover::<4>(&path).unwrap();
         assert_eq!(manifest.total_runs(), 3);
         assert_eq!(manifest.runs_at_level(Level::L0).len(), 3);
     }
@@ -821,7 +828,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("manifest.log");
 
-        let (_, mut log) = ManifestLog::recover(&path).unwrap();
+        let (_, mut log) = ManifestLog::recover::<4>(&path).unwrap();
         let meta = test_meta("ephemeral.run");
         log.append(&ManifestEntry::AddRun {
             level: Level::L0,
@@ -835,7 +842,7 @@ mod tests {
         .unwrap();
         drop(log);
 
-        let (manifest, _) = ManifestLog::recover(&path).unwrap();
+        let (manifest, _) = ManifestLog::recover::<4>(&path).unwrap();
         assert_eq!(manifest.total_runs(), 0);
     }
 
@@ -845,7 +852,7 @@ mod tests {
         let path = dir.path().join("manifest.log");
 
         // Write 2 good entries.
-        let (_, mut log) = ManifestLog::recover(&path).unwrap();
+        let (_, mut log) = ManifestLog::recover::<4>(&path).unwrap();
         log.append(&ManifestEntry::AddRun {
             level: Level::L0,
             meta: test_meta("a.run"),
@@ -865,7 +872,7 @@ mod tests {
         }
 
         // Replay should recover the 2 good entries.
-        let (manifest, mut log2) = ManifestLog::recover(&path).unwrap();
+        let (manifest, mut log2) = ManifestLog::recover::<4>(&path).unwrap();
         assert_eq!(manifest.total_runs(), 2);
 
         // File should be truncated to remove garbage; write_pos should be at end of valid data.
@@ -880,7 +887,7 @@ mod tests {
         .unwrap();
         drop(log2);
 
-        let (manifest2, _) = ManifestLog::recover(&path).unwrap();
+        let (manifest2, _) = ManifestLog::recover::<4>(&path).unwrap();
         assert_eq!(manifest2.total_runs(), 3);
     }
 
@@ -971,7 +978,7 @@ mod tests {
         let path = dir.path().join("new.log");
         assert!(!path.exists());
 
-        let (manifest, _log) = ManifestLog::recover(&path).unwrap();
+        let (manifest, _log) = ManifestLog::recover::<4>(&path).unwrap();
         assert_eq!(manifest.total_runs(), 0);
         assert_eq!(manifest.next_sequence(), SeqNo::from(0u64));
 
@@ -992,7 +999,7 @@ mod tests {
             write_header(&mut file).unwrap();
             file.sync_all().unwrap();
         }
-        let (manifest, log) = ManifestLog::recover(&path).unwrap();
+        let (manifest, log) = ManifestLog::recover::<4>(&path).unwrap();
         assert_eq!(manifest.total_runs(), 0);
         assert_eq!(log.write_pos, 8);
     }
@@ -1002,7 +1009,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("bad.log");
         fs::write(&path, b"XXXXv1\x00\x00\x00").unwrap();
-        let err = ManifestLog::recover(&path).err().unwrap();
+        let err = ManifestLog::recover::<4>(&path).err().unwrap();
         assert!(matches!(err, LsmError::Format(_)));
     }
 
@@ -1011,7 +1018,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("v99.log");
         fs::write(&path, b"MKMF\x63\x00\x00\x00").unwrap();
-        let err = ManifestLog::recover(&path).err().unwrap();
+        let err = ManifestLog::recover::<4>(&path).err().unwrap();
         assert!(matches!(err, LsmError::Format(_)));
     }
 
@@ -1028,14 +1035,14 @@ mod tests {
         }
 
         // Reopen via recover, append an entry, reopen again.
-        let (_, mut log) = ManifestLog::recover(&path).unwrap();
+        let (_, mut log) = ManifestLog::recover::<4>(&path).unwrap();
         log.append(&ManifestEntry::SetSequence {
             next_sequence: SeqNo::from(42u64),
         })
         .unwrap();
         drop(log);
 
-        let (manifest, _log) = ManifestLog::recover(&path).unwrap();
+        let (manifest, _log) = ManifestLog::recover::<4>(&path).unwrap();
         assert_eq!(manifest.next_sequence(), SeqNo::from(42u64));
     }
 }

--- a/crates/minkowski-lsm/src/manifest_ops.rs
+++ b/crates/minkowski-lsm/src/manifest_ops.rs
@@ -16,10 +16,10 @@ use crate::writer::flush;
 /// Flush dirty pages and record the new sorted run in the manifest.
 ///
 /// Returns `Ok(Some(path))` if a run was written, `Ok(None)` if no dirty pages.
-pub fn flush_and_record(
+pub fn flush_and_record<const N: usize>(
     world: &World,
     sequence_range: SeqRange,
-    manifest: &mut LsmManifest,
+    manifest: &mut LsmManifest<N>,
     log: &mut ManifestLog,
     output_dir: &Path,
 ) -> Result<Option<PathBuf>, LsmError> {
@@ -51,7 +51,7 @@ pub fn flush_and_record(
         next_sequence: sequence_range.hi(),
     })?;
 
-    manifest.add_run(Level::L0, meta);
+    manifest.add_run(Level::L0, meta)?;
     manifest.set_next_sequence(sequence_range.hi());
 
     Ok(Some(path))
@@ -61,7 +61,10 @@ pub fn flush_and_record(
 ///
 /// Also removes any `.run.tmp` files (incomplete flushes).
 /// Returns the number of files deleted.
-pub fn cleanup_orphans(dir: &Path, manifest: &LsmManifest) -> Result<usize, LsmError> {
+pub fn cleanup_orphans<const N: usize>(
+    dir: &Path,
+    manifest: &LsmManifest<N>,
+) -> Result<usize, LsmError> {
     let known: HashSet<PathBuf> = manifest
         .all_run_paths()
         .into_iter()
@@ -120,7 +123,7 @@ mod tests {
         }
         let dir = tempfile::tempdir().unwrap();
         let log_path = dir.path().join("manifest.log");
-        let (mut manifest, mut log) = ManifestLog::recover(&log_path).unwrap();
+        let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
         let result = flush_and_record(
             &world,
@@ -144,7 +147,7 @@ mod tests {
 
         let dir = tempfile::tempdir().unwrap();
         let log_path = dir.path().join("manifest.log");
-        let (mut manifest, mut log) = ManifestLog::recover(&log_path).unwrap();
+        let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
         let result = flush_and_record(
             &world,
@@ -169,18 +172,20 @@ mod tests {
         fs::write(dir.path().join("notes.txt"), b"not a run").unwrap();
 
         // Manifest only knows about 0-10.run.
-        let mut manifest = LsmManifest::new();
-        manifest.add_run(
-            Level::L0,
-            SortedRunMeta::new(
-                dir.path().join("0-10.run"),
-                SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
-                vec![0],
-                PageCount::new(1).unwrap(),
-                SizeBytes::new(4),
+        let mut manifest: crate::manifest::DefaultManifest = LsmManifest::new();
+        manifest
+            .add_run(
+                Level::L0,
+                SortedRunMeta::new(
+                    dir.path().join("0-10.run"),
+                    SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
+                    vec![0],
+                    PageCount::new(1).unwrap(),
+                    SizeBytes::new(4),
+                )
+                .unwrap(),
             )
-            .unwrap(),
-        );
+            .unwrap();
 
         let deleted = cleanup_orphans(dir.path(), &manifest).unwrap();
         assert_eq!(deleted, 2); // 10-20.run + crash.run.tmp

--- a/crates/minkowski-lsm/src/reader.rs
+++ b/crates/minkowski-lsm/src/reader.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::Path;
 
+use crate::codec::CrcProof;
 use crate::error::LsmError;
 use crate::format::*;
 use crate::schema::SchemaSection;
@@ -271,23 +272,21 @@ impl SortedRunReader {
         }))
     }
 
-    /// Validate the CRC of a specific page.
+    /// Validate the CRC of a specific page and return a [`CrcProof`] on success.
     ///
-    /// The CRC covers `row_count * item_size` bytes (the actual data, not
-    /// zero-padding).
-    pub fn validate_page_crc(&self, page: &PageRef<'_>) -> Result<(), LsmError> {
+    /// The returned token feeds into [`CodecRegistry::decode`]'s `raw_copy_size`
+    /// fast path (direct memcpy, skipping rkyv bytecheck). The CRC covers
+    /// `row_count * item_size` bytes — the actual data, not zero-padding.
+    pub fn validate_page_crc(&self, page: &PageRef<'_>) -> Result<CrcProof, LsmError> {
         let item_size = self.item_size_for_slot(page.header().slot)?;
         let actual_len = page.header().row_count as usize * item_size;
-        let computed = crc32fast::hash(&page.data()[..actual_len]);
+        let payload = &page.data()[..actual_len];
 
-        if computed != page.header().page_crc32 {
-            return Err(LsmError::Crc {
-                offset: page.file_offset(),
-                expected: page.header().page_crc32,
-                actual: computed,
-            });
-        }
-        Ok(())
+        CrcProof::verify(payload, page.header().page_crc32).ok_or_else(|| LsmError::Crc {
+            offset: page.file_offset(),
+            expected: page.header().page_crc32,
+            actual: crc32fast::hash(payload),
+        })
     }
 
     /// Get the schema section.
@@ -579,5 +578,23 @@ mod tests {
         // Verify entity pages are present (slot == ENTITY_SLOT).
         let has_entity_page = reader.index.iter().any(|e| e.slot == ENTITY_SLOT);
         assert!(has_entity_page, "must have at least one entity page");
+    }
+
+    #[test]
+    fn validate_page_crc_returns_proof_token() {
+        use crate::codec::CrcProof;
+
+        let (_dir, path, _world) = flush_world_with_pos(5);
+        let reader = SortedRunReader::open(&path).unwrap();
+
+        // Find the first page and validate its CRC, extracting the proof.
+        assert!(reader.index_len() > 0);
+        let entry = &reader.index[0];
+        let page = reader
+            .get_page(entry.arch_id, entry.slot, entry.page_index)
+            .unwrap()
+            .unwrap();
+        let proof: CrcProof = reader.validate_page_crc(&page).unwrap();
+        let _ = proof;
     }
 }

--- a/crates/minkowski-lsm/src/types.rs
+++ b/crates/minkowski-lsm/src/types.rs
@@ -87,10 +87,14 @@ impl SeqRange {
     }
 }
 
-/// An LSM level index. Construction enforces `< NUM_LEVELS`.
+/// An LSM level index. Construction enforces `< MAX_LEVELS` as a sanity
+/// bound; per-manifest bounds (`< N`) are checked by [`LsmManifest<N>`]
+/// at each public entry point.
 ///
-/// The bounds check lives in exactly one place (`Level::new`); all
-/// other code sites trust the invariant once they hold a `Level`.
+/// A `Level` is thus a "fits in some manifest somewhere" witness, not a
+/// "fits in *this* manifest" guarantee. Constructing `Level::new(5)` for
+/// a `LsmManifest<4>` is legal; the manifest returns an error or empty
+/// result at the API boundary rather than the type boundary.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct Level(u8);
 

--- a/crates/minkowski-lsm/src/types.rs
+++ b/crates/minkowski-lsm/src/types.rs
@@ -11,7 +11,11 @@ use std::fmt;
 use std::num::NonZeroU64;
 
 use crate::error::LsmError;
-use crate::manifest::NUM_LEVELS;
+/// Maximum level count accepted by [`Level::new`]. A generous upper bound:
+/// the default manifest uses 4 levels, TigerBeetle-style configurations
+/// use 7. `Level::new` rejects anything >= `MAX_LEVELS`; per-manifest
+/// bounds are enforced at the manifest boundary.
+pub const MAX_LEVELS: usize = 32;
 
 /// A WAL sequence number.
 ///
@@ -96,21 +100,21 @@ impl Level {
     pub const L2: Level = Level(2);
     pub const L3: Level = Level(3);
 
-    /// Construct a level index. Returns `None` if `level >= NUM_LEVELS`.
+    /// Construct a level index. Returns `None` if `level >= MAX_LEVELS`.
     pub fn new(level: u8) -> Option<Self> {
-        if (level as usize) < NUM_LEVELS {
+        if (level as usize) < MAX_LEVELS {
             Some(Self(level))
         } else {
             None
         }
     }
 
-    /// The underlying level byte (always `< NUM_LEVELS`).
+    /// The underlying level byte (always `< MAX_LEVELS`).
     pub fn as_u8(self) -> u8 {
         self.0
     }
 
-    /// Convert to a `usize` for indexing `[T; NUM_LEVELS]` arrays.
+    /// Convert to a `usize` for indexing manifest level arrays.
     pub fn as_index(self) -> usize {
         self.0 as usize
     }
@@ -247,14 +251,14 @@ mod tests {
     }
 
     #[test]
-    fn level_rejects_values_at_or_above_num_levels() {
-        assert!(Level::new(NUM_LEVELS as u8).is_none());
+    fn level_rejects_values_at_or_above_max_levels() {
+        assert!(Level::new(MAX_LEVELS as u8).is_none());
         assert!(Level::new(255).is_none());
     }
 
     #[test]
-    fn level_accepts_values_below_num_levels() {
-        for i in 0..NUM_LEVELS {
+    fn level_accepts_values_below_max_levels() {
+        for i in 0..4 {
             assert!(Level::new(i as u8).is_some());
         }
     }

--- a/crates/minkowski-lsm/tests/manifest_integration.rs
+++ b/crates/minkowski-lsm/tests/manifest_integration.rs
@@ -392,9 +392,10 @@ fn replay_truncates_log_on_unsorted_coverage() {
 }
 
 /// Regression: a frame with a valid CRC but an invalid level byte
-/// (>= NUM_LEVELS) must be treated as tail garbage. Level::new returns
-/// None on invalid input, decode_entry surfaces LsmError::Format, and
-/// the replay loop must truncate.
+/// (>= MAX_LEVELS, or >= N for the target manifest) must be treated as
+/// tail garbage. Level::new returns None for bytes >= MAX_LEVELS (32),
+/// decode_entry surfaces LsmError::Format, and the replay loop must
+/// truncate.
 #[test]
 fn replay_truncates_log_on_invalid_level_byte() {
     let dir = tempfile::tempdir().unwrap();
@@ -414,8 +415,9 @@ fn replay_truncates_log_on_invalid_level_byte() {
 
     let len_after_first_frame = fs::metadata(&log_path).unwrap().len();
 
-    // Craft a REMOVE_RUN frame with level=255 (invalid; NUM_LEVELS is 4).
-    // REMOVE_RUN is the simplest level-bearing entry to fabricate.
+    // Craft a REMOVE_RUN frame with level=255 (invalid; Level::new rejects
+    // >= MAX_LEVELS = 32). REMOVE_RUN is the simplest level-bearing entry
+    // to fabricate.
     let mut payload = Vec::new();
     payload.push(ManifestTag::RemoveRun as u8);
     payload.push(255); // invalid level byte

--- a/crates/minkowski-lsm/tests/manifest_integration.rs
+++ b/crates/minkowski-lsm/tests/manifest_integration.rs
@@ -30,7 +30,7 @@ struct Vel {
 fn three_flushes_then_replay() {
     let dir = tempfile::tempdir().unwrap();
     let log_path = dir.path().join("manifest.log");
-    let (mut manifest, mut log) = ManifestLog::recover(&log_path).unwrap();
+    let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
 
@@ -89,7 +89,7 @@ fn three_flushes_then_replay() {
     assert!(p3.exists());
 
     // Replay the log from scratch — should reconstruct identical state.
-    let (recovered, _) = ManifestLog::recover(&log_path).unwrap();
+    let (recovered, _) = ManifestLog::recover::<4>(&log_path).unwrap();
     assert_eq!(recovered.total_runs(), 3);
     assert_eq!(recovered.next_sequence(), SeqNo::from(30u64));
     assert_eq!(recovered.runs_at_level(Level::L0).len(), 3);
@@ -112,7 +112,7 @@ fn three_flushes_then_replay() {
 fn corrupt_tail_partial_recovery() {
     let dir = tempfile::tempdir().unwrap();
     let log_path = dir.path().join("manifest.log");
-    let (mut manifest, mut log) = ManifestLog::recover(&log_path).unwrap();
+    let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
     world.spawn((Pos { x: 1.0, y: 2.0 },));
@@ -145,7 +145,7 @@ fn corrupt_tail_partial_recovery() {
     }
 
     // Replay should recover the 2 good entries (each flush writes one atomic AddRunAndSequence entry).
-    let (recovered, _) = ManifestLog::recover(&log_path).unwrap();
+    let (recovered, _) = ManifestLog::recover::<4>(&log_path).unwrap();
     assert_eq!(recovered.total_runs(), 2);
     assert_eq!(recovered.next_sequence(), SeqNo::from(20u64));
 }
@@ -161,7 +161,7 @@ fn corrupt_tail_partial_recovery() {
 fn replay_converges_at_every_truncation_prefix() {
     let dir = tempfile::tempdir().unwrap();
     let log_path = dir.path().join("manifest.log");
-    let (mut manifest, mut log) = ManifestLog::recover(&log_path).unwrap();
+    let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
     for i in 0..3u64 {
@@ -195,7 +195,7 @@ fn replay_converges_at_every_truncation_prefix() {
         if truncate_len < 8 {
             // Header missing or truncated: recover must return a
             // Format error; no manifest is produced.
-            let err = ManifestLog::recover(&truncated_path).err().unwrap();
+            let err = ManifestLog::recover::<4>(&truncated_path).err().unwrap();
             assert!(
                 matches!(err, LsmError::Format(_)),
                 "truncate_len={truncate_len}: expected Format, got {err:?}"
@@ -206,7 +206,7 @@ fn replay_converges_at_every_truncation_prefix() {
         // truncate_len == 8: valid header, no frames — first Ok case,
         // returns empty manifest. Subsequent iterations accumulate runs
         // as frame boundaries are crossed.
-        let (replayed, _) = ManifestLog::recover(&truncated_path)
+        let (replayed, _) = ManifestLog::recover::<4>(&truncated_path)
             .unwrap_or_else(|e| panic!("recover failed at truncate_len={truncate_len}: {e:?}"));
 
         assert!(
@@ -244,7 +244,7 @@ fn replay_converges_at_every_truncation_prefix() {
 fn replay_truncates_log_on_promote_of_missing_run() {
     let dir = tempfile::tempdir().unwrap();
     let log_path = dir.path().join("manifest.log");
-    let (mut manifest, mut log) = ManifestLog::recover(&log_path).unwrap();
+    let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
     world.spawn((Pos { x: 1.0, y: 0.0 },));
@@ -273,7 +273,7 @@ fn replay_truncates_log_on_promote_of_missing_run() {
     .unwrap();
     drop(log);
 
-    let (recovered, _) = ManifestLog::recover(&log_path).unwrap();
+    let (recovered, _) = ManifestLog::recover::<4>(&log_path).unwrap();
     assert_eq!(
         recovered.total_runs(),
         1,
@@ -293,7 +293,7 @@ fn replay_truncates_log_on_promote_of_missing_run() {
 fn cleanup_removes_orphans_and_tmp() {
     let dir = tempfile::tempdir().unwrap();
     let log_path = dir.path().join("manifest.log");
-    let (mut manifest, mut log) = ManifestLog::recover(&log_path).unwrap();
+    let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
     world.spawn((Pos { x: 1.0, y: 2.0 },));
@@ -331,7 +331,7 @@ fn cleanup_removes_orphans_and_tmp() {
 fn replay_truncates_log_on_unsorted_coverage() {
     let dir = tempfile::tempdir().unwrap();
     let log_path = dir.path().join("manifest.log");
-    let (mut manifest, mut log) = ManifestLog::recover(&log_path).unwrap();
+    let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
     world.spawn((Pos { x: 1.0, y: 0.0 },));
@@ -377,7 +377,7 @@ fn replay_truncates_log_on_unsorted_coverage() {
     drop(f);
 
     // Replay must truncate back to end of first valid frame.
-    let (recovered, _) = ManifestLog::recover(&log_path).unwrap();
+    let (recovered, _) = ManifestLog::recover::<4>(&log_path).unwrap();
     assert_eq!(
         recovered.total_runs(),
         1,
@@ -399,7 +399,7 @@ fn replay_truncates_log_on_unsorted_coverage() {
 fn replay_truncates_log_on_invalid_level_byte() {
     let dir = tempfile::tempdir().unwrap();
     let log_path = dir.path().join("manifest.log");
-    let (mut manifest, mut log) = ManifestLog::recover(&log_path).unwrap();
+    let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
     world.spawn((Pos { x: 1.0, y: 0.0 },));
@@ -432,7 +432,7 @@ fn replay_truncates_log_on_invalid_level_byte() {
     f.sync_all().unwrap();
     drop(f);
 
-    let (recovered, _) = ManifestLog::recover(&log_path).unwrap();
+    let (recovered, _) = ManifestLog::recover::<4>(&log_path).unwrap();
     assert_eq!(
         recovered.total_runs(),
         1,
@@ -454,7 +454,7 @@ fn replay_truncates_log_on_invalid_level_byte() {
 fn replay_truncates_log_on_unknown_tag_byte() {
     let dir = tempfile::tempdir().unwrap();
     let log_path = dir.path().join("manifest.log");
-    let (mut manifest, mut log) = ManifestLog::recover(&log_path).unwrap();
+    let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
     world.spawn((Pos { x: 1.0, y: 0.0 },));
@@ -482,7 +482,7 @@ fn replay_truncates_log_on_unknown_tag_byte() {
     f.sync_all().unwrap();
     drop(f);
 
-    let (recovered, _) = ManifestLog::recover(&log_path).unwrap();
+    let (recovered, _) = ManifestLog::recover::<4>(&log_path).unwrap();
     assert_eq!(
         recovered.total_runs(),
         1,
@@ -505,7 +505,7 @@ fn replay_truncates_log_on_unknown_tag_byte() {
 fn replay_truncates_log_on_inverted_seq_range() {
     let dir = tempfile::tempdir().unwrap();
     let log_path = dir.path().join("manifest.log");
-    let (mut manifest, mut log) = ManifestLog::recover(&log_path).unwrap();
+    let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
     world.spawn((Pos { x: 1.0, y: 0.0 },));
@@ -550,7 +550,7 @@ fn replay_truncates_log_on_inverted_seq_range() {
     drop(f);
 
     // Replay must truncate back to end of first valid frame.
-    let (recovered, _) = ManifestLog::recover(&log_path).unwrap();
+    let (recovered, _) = ManifestLog::recover::<4>(&log_path).unwrap();
     assert_eq!(
         recovered.total_runs(),
         1,
@@ -572,7 +572,7 @@ fn replay_truncates_log_on_inverted_seq_range() {
 fn replay_truncates_log_on_zero_page_count() {
     let dir = tempfile::tempdir().unwrap();
     let log_path = dir.path().join("manifest.log");
-    let (mut manifest, mut log) = ManifestLog::recover(&log_path).unwrap();
+    let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
     world.spawn((Pos { x: 1.0, y: 0.0 },));
@@ -621,7 +621,7 @@ fn replay_truncates_log_on_zero_page_count() {
     drop(f);
 
     // Replay must truncate at the bad frame.
-    let (recovered, _) = ManifestLog::recover(&log_path).unwrap();
+    let (recovered, _) = ManifestLog::recover::<4>(&log_path).unwrap();
     assert_eq!(
         recovered.total_runs(),
         1,
@@ -641,7 +641,7 @@ fn replay_truncates_log_on_zero_page_count() {
 fn replay_truncates_log_on_remove_of_missing_run() {
     let dir = tempfile::tempdir().unwrap();
     let log_path = dir.path().join("manifest.log");
-    let (mut manifest, mut log) = ManifestLog::recover(&log_path).unwrap();
+    let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
     world.spawn((Pos { x: 1.0, y: 0.0 },));
@@ -668,7 +668,7 @@ fn replay_truncates_log_on_remove_of_missing_run() {
     .unwrap();
     drop(log);
 
-    let (recovered, _) = ManifestLog::recover(&log_path).unwrap();
+    let (recovered, _) = ManifestLog::recover::<4>(&log_path).unwrap();
     assert_eq!(
         recovered.total_runs(),
         1,
@@ -693,7 +693,7 @@ fn recover_then_flush_then_recover_roundtrips_state() {
     let log_path = dir.path().join("manifest.log");
 
     // Fresh recover creates the file.
-    let (mut manifest, mut log) = ManifestLog::recover(&log_path).unwrap();
+    let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
     assert_eq!(manifest.total_runs(), 0);
 
     // Two flushes produce two AddRunAndSequence frames.
@@ -720,7 +720,7 @@ fn recover_then_flush_then_recover_roundtrips_state() {
     drop(log);
 
     // Second recover replays both entries.
-    let (recovered, _) = ManifestLog::recover(&log_path).unwrap();
+    let (recovered, _) = ManifestLog::recover::<4>(&log_path).unwrap();
     assert_eq!(recovered.total_runs(), 2);
     assert_eq!(recovered.next_sequence(), SeqNo::from(20u64));
 
@@ -747,7 +747,7 @@ fn recover_rejects_file_without_header() {
     // header) — what a legacy headerless log would look like byte-for-byte.
     fs::write(&log_path, [0x20, 0x00, 0x00, 0x00, 0xAB, 0xCD, 0xEF, 0x12]).unwrap();
 
-    let err = ManifestLog::recover(&log_path).err().unwrap();
+    let err = ManifestLog::recover::<4>(&log_path).err().unwrap();
     assert!(
         matches!(err, LsmError::Format(ref msg) if msg.contains("bad magic")),
         "expected bad-magic Format error, got {err:?}"
@@ -764,7 +764,7 @@ fn recover_rejects_file_with_unsupported_version() {
 
     fs::write(&log_path, b"MKMF\x63\x00\x00\x00").unwrap(); // version 0x63
 
-    let err = ManifestLog::recover(&log_path).err().unwrap();
+    let err = ManifestLog::recover::<4>(&log_path).err().unwrap();
     assert!(
         matches!(err, LsmError::Format(ref msg) if msg.contains("unsupported manifest version")),
         "expected version-mismatch Format error, got {err:?}"
@@ -786,7 +786,7 @@ fn recover_ignores_nonzero_reserved_bytes() {
     fs::write(&log_path, b"MKMF\x01\xFF\xAA\x55").unwrap();
 
     // Recover should succeed on an otherwise-empty log.
-    let (recovered, _) = ManifestLog::recover(&log_path).unwrap();
+    let (recovered, _) = ManifestLog::recover::<4>(&log_path).unwrap();
     assert_eq!(recovered.total_runs(), 0);
     assert_eq!(recovered.next_sequence(), SeqNo::from(0u64));
 }
@@ -806,7 +806,7 @@ fn recover_preserves_reserved_bytes_through_append_cycle() {
     fs::write(&log_path, b"MKMF\x01\xFF\xAA\x55").unwrap();
 
     // Open, append one entry, close.
-    let (_, mut log) = ManifestLog::recover(&log_path).unwrap();
+    let (_, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
     log.append(&ManifestEntry::SetSequence {
         next_sequence: SeqNo::from(42),
     })
@@ -824,7 +824,7 @@ fn recover_preserves_reserved_bytes_through_append_cycle() {
     );
 
     // And the entry must replay.
-    let (m, _) = ManifestLog::recover(&log_path).unwrap();
+    let (m, _) = ManifestLog::recover::<4>(&log_path).unwrap();
     assert_eq!(m.next_sequence(), SeqNo::from(42));
 }
 
@@ -837,12 +837,12 @@ fn recover_is_idempotent_with_no_flushes() {
     let log_path = dir.path().join("idempotent.log");
 
     // First recover creates the file.
-    let (manifest_a, log_a) = ManifestLog::recover(&log_path).unwrap();
+    let (manifest_a, log_a) = ManifestLog::recover::<4>(&log_path).unwrap();
     let bytes_after_first = fs::read(&log_path).unwrap();
     drop(log_a);
 
     // Second recover on the same path — no flushes between.
-    let (manifest_b, log_b) = ManifestLog::recover(&log_path).unwrap();
+    let (manifest_b, log_b) = ManifestLog::recover::<4>(&log_path).unwrap();
     let bytes_after_second = fs::read(&log_path).unwrap();
     drop(log_b);
 
@@ -857,7 +857,7 @@ fn recover_is_idempotent_with_no_flushes() {
 fn flush_and_record_clean_world_no_change() {
     let dir = tempfile::tempdir().unwrap();
     let log_path = dir.path().join("manifest.log");
-    let (mut manifest, mut log) = ManifestLog::recover(&log_path).unwrap();
+    let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
     world.spawn((Pos { x: 1.0, y: 2.0 },));
@@ -876,6 +876,6 @@ fn flush_and_record_clean_world_no_change() {
     assert_eq!(manifest.next_sequence(), SeqNo::from(0u64));
 
     // Log should be empty — recover produces empty manifest.
-    let (replayed, _) = ManifestLog::recover(&log_path).unwrap();
+    let (replayed, _) = ManifestLog::recover::<4>(&log_path).unwrap();
     assert_eq!(replayed.total_runs(), 0);
 }

--- a/crates/minkowski-persist/Cargo.toml
+++ b/crates/minkowski-persist/Cargo.toml
@@ -8,6 +8,7 @@ workspace = true
 
 [dependencies]
 minkowski = { path = "../minkowski" }
+minkowski-lsm = { path = "../minkowski-lsm" }
 rkyv = { version = "0.8", features = ["alloc", "bytecheck"] }
 memmap2 = "0.9"
 parking_lot = "0.12"

--- a/crates/minkowski-persist/src/checkpoint.rs
+++ b/crates/minkowski-persist/src/checkpoint.rs
@@ -4,10 +4,10 @@ use std::sync::Arc;
 use minkowski::World;
 use parking_lot::Mutex;
 
-use crate::codec::CodecRegistry;
 use crate::index::PersistentIndex;
 use crate::snapshot::Snapshot;
 use crate::wal::Wal;
+use minkowski_lsm::codec::CodecRegistry;
 
 /// Callback invoked when the WAL has accumulated more mutation bytes than
 /// the configured `max_bytes_between_checkpoints` threshold without a
@@ -87,9 +87,9 @@ impl CheckpointHandler for AutoCheckpoint {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::codec::CodecRegistry;
     use crate::wal::{Wal, WalConfig};
     use minkowski::World;
+    use minkowski_lsm::codec::CodecRegistry;
     use rkyv::{Archive, Deserialize, Serialize};
 
     #[derive(Clone, Copy, Archive, Serialize, Deserialize)]

--- a/crates/minkowski-persist/src/durable.rs
+++ b/crates/minkowski-persist/src/durable.rs
@@ -3,8 +3,8 @@ use parking_lot::Mutex;
 use minkowski::{Access, EnumChangeSet, Transact, TransactError, Tx, World, WorldMismatch};
 
 use crate::checkpoint::CheckpointHandler;
-use crate::codec::CodecRegistry;
 use crate::wal::Wal;
+use minkowski_lsm::codec::CodecRegistry;
 
 /// Wraps any [`Transact`] strategy to guarantee WAL logging on commit.
 ///
@@ -132,9 +132,9 @@ impl<S: Transact> Transact for Durable<S> {
 mod tests {
     use super::*;
     use crate::checkpoint::CheckpointHandler;
-    use crate::codec::CodecRegistry;
     use crate::wal::{Wal, WalConfig};
     use minkowski::{Optimistic, Pessimistic};
+    use minkowski_lsm::codec::CodecRegistry;
     use rkyv::{Archive, Deserialize, Serialize};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU32, Ordering};

--- a/crates/minkowski-persist/src/index.rs
+++ b/crates/minkowski-persist/src/index.rs
@@ -493,9 +493,9 @@ mod tests {
 
     #[test]
     fn full_recovery_with_persistent_index() {
-        use crate::codec::CodecRegistry;
         use crate::snapshot::Snapshot;
         use crate::wal::{Wal, WalConfig};
+        use minkowski_lsm::codec::CodecRegistry;
 
         let dir = tempfile::tempdir().unwrap();
         let wal_dir = dir.path().join("recovery.wal");

--- a/crates/minkowski-persist/src/lib.rs
+++ b/crates/minkowski-persist/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod blob;
 pub mod checkpoint;
-pub mod codec;
 pub mod durable;
 pub mod index;
 pub mod record;
@@ -10,9 +9,9 @@ pub mod wal;
 
 pub use blob::{BlobRef, BlobStore};
 pub use checkpoint::{AutoCheckpoint, CheckpointHandler};
-pub use codec::{CodecError, CodecRegistry};
 pub use durable::Durable;
 pub use index::{IndexPersistError, PersistentIndex, load_btree_index, load_hash_index};
+pub use minkowski_lsm::codec::{CodecError, CodecRegistry, CrcProof};
 pub use record::*;
 pub use replication::{ReplicationError, apply_batch};
 pub use snapshot::{Snapshot, SnapshotError};

--- a/crates/minkowski-persist/src/record.rs
+++ b/crates/minkowski-persist/src/record.rs
@@ -2,6 +2,8 @@ use rkyv::{Archive, Deserialize, Serialize};
 
 use minkowski::ComponentId;
 
+pub use minkowski_lsm::codec::ComponentSchema;
+
 /// rkyv-friendly mirror of core's Mutation enum.
 /// Entity stored as raw u64 (preserving generation bits).
 /// Component data is pre-serialized through CodecRegistry.
@@ -41,17 +43,6 @@ pub enum SerializedMutation {
 pub struct WalRecord {
     pub seq: u64,
     pub mutations: Vec<SerializedMutation>,
-}
-
-/// Schema entry describing a component type. Used in both snapshot schemas
-/// and WAL preambles. Fields are sender-local: `id` is meaningful only in
-/// the originating World's ID space.
-#[derive(Archive, Serialize, Deserialize, Debug, Clone)]
-pub struct ComponentSchema {
-    pub id: ComponentId,
-    pub name: String,
-    pub size: usize,
-    pub align: usize,
 }
 
 /// Serializable entity allocator state.

--- a/crates/minkowski-persist/src/replication.rs
+++ b/crates/minkowski-persist/src/replication.rs
@@ -13,9 +13,9 @@ use std::collections::HashMap;
 
 use minkowski::{ComponentId, World};
 
-use crate::codec::{CodecError, CodecRegistry};
 use crate::record::ReplicationBatch;
 use crate::wal::{WalError, apply_record};
+use minkowski_lsm::codec::{CodecError, CodecRegistry};
 
 /// Errors from transport-agnostic replication operations.
 ///
@@ -86,10 +86,10 @@ pub fn apply_batch(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::codec::CodecRegistry;
     use crate::record::{ComponentSchema, SerializedMutation, WalRecord, WalSchema};
     use crate::wal::{Wal, WalConfig, WalCursor, WalError};
     use minkowski::{EnumChangeSet, World};
+    use minkowski_lsm::codec::CodecRegistry;
 
     #[derive(Clone, Copy, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize, PartialEq, Debug)]
     struct Pos {

--- a/crates/minkowski-persist/src/snapshot.rs
+++ b/crates/minkowski-persist/src/snapshot.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 
 use minkowski::{ComponentId, Entity, EnumChangeSet, World};
 
-use crate::codec::{CodecError, CodecRegistry, CrcProof};
 use crate::record::*;
+use minkowski_lsm::codec::{CodecError, CodecRegistry, CrcProof};
 
 /// Snapshot file magic identifying the v2 format with CRC32 checksums.
 ///
@@ -479,7 +479,7 @@ impl Default for Snapshot {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::codec::CodecRegistry;
+    use minkowski_lsm::codec::CodecRegistry;
     use rkyv::{Archive, Deserialize, Serialize};
 
     #[derive(Clone, Copy, Archive, Serialize, Deserialize, PartialEq, Debug)]

--- a/crates/minkowski-persist/src/wal.rs
+++ b/crates/minkowski-persist/src/wal.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 
 use minkowski::{ComponentId, Entity, EnumChangeSet, MutationRef, World};
 
-use crate::codec::{CodecError, CodecRegistry, CrcProof};
 use crate::record::{ComponentSchema, SerializedMutation, WalEntry, WalSchema};
+use minkowski_lsm::codec::{CodecError, CodecRegistry, CrcProof};
 
 // WAL segment format (v2):
 //   [segment_magic: 4 bytes "MKW2"]
@@ -1158,7 +1158,7 @@ impl WalCursor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::codec::CodecRegistry;
+    use minkowski_lsm::codec::CodecRegistry;
     use rkyv::{Archive, Deserialize, Serialize};
 
     #[derive(Clone, Copy, Archive, Serialize, Deserialize, PartialEq, Debug)]

--- a/docs/plans/2026-04-18-stage3-phase3-compactor-design.md
+++ b/docs/plans/2026-04-18-stage3-phase3-compactor-design.md
@@ -366,9 +366,59 @@ Phase 2's `replay_converges_at_every_truncation_prefix` currently covers frame-l
 
 ## Rollout
 
-Single squash-merged PR per project convention. CI gates: fmt, clippy, test, tsan, loom, claude-review. `minkowski-lsm` test count expected to grow ~30–40 tests (from 118 current); `minkowski-persist` test count may shrink slightly as snapshot-specific tests are removed.
+Phase 3 lands as **three sequential squash-merged PRs**, each with its own coherent theme. The split avoids a single blast-radius PR that mixes pure refactor, behavioral replacement, and new feature work.
 
-**Post-merge memory updates**:
+**Dependency graph:**
+```
+  PR 1 ──┬─→ PR 2 (LsmCheckpoint + snapshot cut)
+         └─→ PR 3 (compactor)
+```
+
+### PR 1: Infrastructure (no semantics change)
+
+Pure refactor + type-system extension. Zero behavioral changes to existing callers. Estimated ~500–800 lines.
+
+- Move `CrcProof` + `CodecRegistry` + `CodecError` from `minkowski-persist::codec` to `minkowski-lsm::codec`
+- Add `minkowski-lsm` dep to `minkowski-persist`; update all imports
+- Convert `LsmManifest` → `LsmManifest<const N: usize = 4>` with `DefaultManifest` alias
+- Propagate const-generic through `FlushWriter<N>` and manifest_ops call sites
+- Change `SortedRunReader::validate_page_crc` return type to `Result<CrcProof, LsmError>`
+- Add `recover_world_from_lsm` helper (new code, no callers yet; tested standalone)
+- Module-level regime doc on `manifest.rs`
+
+All existing tests pass unchanged. Easy review: if the build and tests pass, it's correct.
+
+### PR 2: LsmCheckpoint + snapshot clean cut
+
+Behavioral replacement. Estimated ~600–1000 lines, heavy deletions. Depends on PR 1.
+
+- Implement `LsmCheckpoint<N>` as new `CheckpointHandler` impl
+- Migrate `Durable<S>` default checkpoint handler from `AutoCheckpoint` to `LsmCheckpoint`
+- Delete `Snapshot`, `SnapshotError`, `AutoCheckpoint`, `save_to_bytes`, `load_from_bytes`
+- Stub `examples/replicate.rs` with a TODO pointing to this design doc
+- Migrate benchmarks (`persist.rs`, `serialize.rs`) to use `LsmCheckpoint`
+
+Public `CheckpointHandler` trait is unchanged; the impl swap is invisible to any external user of `Durable<S>`. (No external users exist; this is belt-and-braces.)
+
+### PR 3: Compactor
+
+Pure feature addition. Estimated ~800–1200 lines. Depends on PR 1, independent of PR 2.
+
+- `ManifestTag::CompactionCommit = 0x06` + `ManifestEntry::CompactionCommit` variant
+- `CompactionCommit` encode/decode with `input_count: u32 LE`
+- `World::compact_one()` + `World::needs_compaction()` API
+- K=4 count-based trigger, stable-iteration picking
+- Tombstone elision at bottom level only
+- `FlushWriter::set_entry_observer` hook (no-op observer for Phase 3; Phase 4 installs a real one)
+- `MAX_COMPACTION_INPUTS = 1024` debug_assert at apply site
+
+PR 2 and PR 3 can land in either order (or in parallel worktrees). PR 1 is the strict prerequisite for both.
+
+**CI gates each PR**: fmt, clippy, test, tsan, loom, claude-review.
+
+### Post-phase memory updates
+
+After PR 3 lands:
 - `project_scaling_roadmap.md`: mark Phase 3 complete, update type-rating table (add `Compactor`, `LsmCheckpoint`), update next-step to Phase 4 (bloom filter).
 - `project_bloom_compaction_coupling.md`: confirm Phase 3's filter hook API landed as designed; Phase 4 can now start.
 

--- a/docs/plans/2026-04-18-stage3-phase3-compactor-design.md
+++ b/docs/plans/2026-04-18-stage3-phase3-compactor-design.md
@@ -376,22 +376,24 @@ Phase 3 lands as **three sequential squash-merged PRs**, each with its own coher
 
 ### PR 1: Infrastructure (no semantics change)
 
-Pure refactor + type-system extension. Zero behavioral changes to existing callers. Estimated ~500–800 lines.
+Pure refactor + type-system extension. Zero behavioral changes to existing callers. Estimated ~400–600 lines.
 
 - Move `CrcProof` + `CodecRegistry` + `CodecError` from `minkowski-persist::codec` to `minkowski-lsm::codec`
 - Add `minkowski-lsm` dep to `minkowski-persist`; update all imports
 - Convert `LsmManifest` → `LsmManifest<const N: usize = 4>` with `DefaultManifest` alias
 - Propagate const-generic through `FlushWriter<N>` and manifest_ops call sites
 - Change `SortedRunReader::validate_page_crc` return type to `Result<CrcProof, LsmError>`
-- Add `recover_world_from_lsm` helper (new code, no callers yet; tested standalone)
 - Module-level regime doc on `manifest.rs`
 
 All existing tests pass unchanged. Easy review: if the build and tests pass, it's correct.
 
+**Deferred to PR 2**: `recover_world_from_lsm` helper. The page-to-archetype plumbing (reconstruct archetype schema from slots, spawn entities from entity-ID pages, fill columns from component pages) is non-trivial and has no value without a caller. PR 2 provides both the helper implementation and its first consumer (`LsmCheckpoint`'s recovery path).
+
 ### PR 2: LsmCheckpoint + snapshot clean cut
 
-Behavioral replacement. Estimated ~600–1000 lines, heavy deletions. Depends on PR 1.
+Behavioral replacement. Estimated ~800–1200 lines, heavy deletions + the recovery helper. Depends on PR 1.
 
+- Implement `recover_world_from_lsm<const N: usize>(run_dir, codecs) -> (World, SeqNo)` helper — reconstructs World by iterating sorted-run pages, using `CrcProof` fast path
 - Implement `LsmCheckpoint<N>` as new `CheckpointHandler` impl
 - Migrate `Durable<S>` default checkpoint handler from `AutoCheckpoint` to `LsmCheckpoint`
 - Delete `Snapshot`, `SnapshotError`, `AutoCheckpoint`, `save_to_bytes`, `load_from_bytes`

--- a/docs/plans/2026-04-18-stage3-phase3-compactor-design.md
+++ b/docs/plans/2026-04-18-stage3-phase3-compactor-design.md
@@ -1,0 +1,370 @@
+# LSM Phase 3: Compactor + Recovery Integration
+
+*Parent document: [Stage 3: LSM Tree Storage](./2026-04-03-stage3-lsm-implementation-plan.md). Follow-up to Phase 2 + B-series + PR #167.*
+*Status: Design. Prerequisites: Phase 1 (SortedRun format), Phase 2 (LsmManifest, ManifestLog, flush_and_record), PR #167 (ManifestTag enum) all merged.*
+
+---
+
+## Summary
+
+Phase 3 implements LSM compaction, replaces the snapshot-based checkpoint/recovery path with LSM-based equivalents, and reorganizes crate layering so that `minkowski-lsm` owns the zero-copy storage primitives and `minkowski-persist` depends on it.
+
+Scope:
+1. **Compactor** — pause-and-compact `World::compact_one()` primitive that merges all of one archetype's runs at L(N) into a new run at L(N+1). Count-based trigger (≥4 runs per archetype per level).
+2. **Atomic commit** — new `CompactionCommit` manifest entry fusing the output-add with input-removes into a single crash-safe frame.
+3. **Recovery** — `SortedRunReader::validate_page_crc` returns `CrcProof`, enabling the existing `raw_copy_size` fast path in `CodecRegistry::decode`. Zero-copy recovery preserved.
+4. **Snapshot cleanup (clean cut)** — remove `Snapshot`, `SnapshotError`, `AutoCheckpoint`, `save_to_bytes`/`load_from_bytes`. Replace with `LsmCheckpoint` impl of `CheckpointHandler`.
+5. **Crate layering shift** — move `CrcProof` and `CodecRegistry` from `minkowski-persist::codec` into `minkowski-lsm::codec`; `minkowski-persist` gains a dep on `minkowski-lsm`.
+6. **Const-generic level count** — `Manifest<const N: usize = 4>` with `DefaultManifest = Manifest<4>` alias. 4 remains the default; the constant now has a workload model behind it.
+
+Non-goals (deferred to later phases):
+- Continuous background compaction (D-mode scheduling). This is a dedicated thread with throttling, back-pressure, and frame-budget awareness. Phase 3 ships the C-mode primitive that D will call in a loop.
+- Schema evolution across levels. Sorted runs at different levels must share the same component schema today.
+- LSM-based replica bootstrap. The `replicate.rs` example's `save_to_bytes` path disappears in the clean cut; replication bootstrap is revisited in a later phase.
+- Concurrency between compaction and flush. C-mode is synchronous; not an issue.
+
+## Motivation
+
+Two shortcomings of the current snapshot-based persistence model:
+
+1. **Full-snapshot cost scales with World size, not delta size.** Every checkpoint rewrites the entire World. For a 10GB world, each checkpoint writes 10GB. The LSM approach writes only dirty pages since the last flush.
+2. **Cold recovery replays the full WAL tail from the last snapshot.** A 10-minute snapshot interval + 9 minutes of WAL can mean seconds of replay on boot. LSM recovery reads the most recent compacted state directly and replays only the WAL tail since the last flush.
+
+Phase 3 is the point where those benefits actually land in the recovery path. Phases 1 and 2 built the storage primitives (sorted runs, manifest log). Phase 3 wires them into `Durable<S>` and removes the old snapshot path.
+
+A secondary motivation surfaced during this brainstorm: the current crate layering (`persist` owns `CrcProof` + `CodecRegistry`) was an accident of snapshot having been the first user. Post-cleanup, LSM is the primary producer of page-level proofs, and WAL's single callsite of `CrcProof` is well-served by depending on `minkowski-lsm`. The layering shift reflects the inversion: `lsm` is the load-bearing storage layer; `persist` is operations over it.
+
+## Design
+
+### 1. Level count model and const generic
+
+The current `NUM_LEVELS = 4` constant in `manifest.rs:7` was an arbitrary choice. Phase 3 replaces it with a const generic parameter on `LsmManifest`, keeping 4 as the default.
+
+**Workload regime: data fits in ~100× RAM, biased low (10–30× typical).** The dominant use case is real-time interactive — games, simulations, collaborative tools. The working set is RAM-bounded because the frame budget can only touch what's in RAM. On-disk data is historical — ledger of what's happened, not a larger active dataset.
+
+**Math**: at size ratio T=10 between levels, with L1 being 1–10% of RAM (a typical flush unit):
+- 4 levels covers ~0.1× to 100× RAM on disk → matches the regime
+- 5 levels extends to ~1000× RAM → overkill for the regime, but harmless to support for archival-style users
+
+**API**:
+```rust
+pub struct LsmManifest<const N: usize = 4> {
+    levels: [Vec<SortedRunMeta>; N],
+}
+
+pub type DefaultManifest = LsmManifest<4>;
+
+impl<const N: usize> LsmManifest<N> { /* ... */ }
+```
+
+The const generic propagates through `FlushWriter<N>`, `Compactor<N>`, and `LsmCheckpoint<N>`. **Merge logic is level-count-agnostic** — merging archetype X's runs at L(i) into L(i+1) is the same operation regardless of total N. Only bounds checks and manifest serialization care about N.
+
+**Documentation**: module-level comment on `manifest.rs` explains the regime model:
+```rust
+//! # Level Count
+//!
+//! Defaults to 4 levels. This fits the expected regime: on-disk data
+//! up to ~100× RAM, with reads served from the in-memory World rather
+//! than from level traversal (the in-memory World IS the merged view).
+//!
+//! At T=10 size ratio: 4 levels covers ~0.1× to 100× RAM on disk.
+//!
+//! For ledger-style workloads (TigerBeetle territory, ever-growing
+//! history), construct `LsmManifest<7>` instead. Merge logic is
+//! level-count-agnostic; only bounds checks and manifest serialization
+//! care about N.
+```
+
+### 2. Compactor design
+
+**Granularity: A (full-archetype-level merge).** A compaction job merges all of archetype X's runs at L(N) — plus any overlapping runs at L(N+1) — into a single new run at L(N+1). For the append-only ledger shape, overlaps at L(N+1) are rare (new runs have timestamps beyond all older runs), so the "plus overlapping" branch is usually empty.
+
+**Trigger: count-based, K=4 runs per archetype per level.** When any archetype has ≥4 runs at L(N), that archetype+level becomes a compaction candidate. Simpler than size-based; adequate when flush sizes are roughly constant (which they are — we control the flush unit). Upgrade path to size-based is straightforward for D-phase if skew becomes a problem.
+
+**Picking: stable iteration, first-over-threshold wins.** No priority queue. `compact_one` iterates archetypes in stable order, picks the first one over threshold at any level, performs one merge, returns.
+
+**API**:
+```rust
+impl World {
+    /// True if any archetype has ≥ COMPACTION_TRIGGER runs at any level.
+    pub fn needs_compaction(&self) -> bool;
+
+    /// Perform one compaction job. Returns Ok(None) if nothing is over threshold.
+    pub fn compact_one(&mut self) -> Result<Option<CompactionReport>, LsmError>;
+}
+
+pub struct CompactionReport {
+    pub archetype: ArchetypeId,
+    pub from_level: Level,
+    pub to_level: Level,
+    pub input_run_count: usize,
+    pub output_bytes: u64,
+}
+
+const COMPACTION_TRIGGER: usize = 4;
+```
+
+The caller drives the loop:
+```rust
+while world.needs_compaction() {
+    world.compact_one()?;
+}
+```
+
+C-mode. D-mode wraps this in a background thread with throttling.
+
+### 3. Atomic compaction commit
+
+Compacting archetype X at L(N) → L(N+1) produces one output run and removes multiple input runs. Serializing these as separate `AddRun` + `RemoveRun` manifest entries creates a window where a crash leaves the manifest with both the output AND some/all inputs still listed. Recovery reads would see double-counted data — a correctness bug.
+
+**Solution**: new atomic manifest entry, following PR B2's `AddRunAndSequence` pattern.
+
+```rust
+#[repr(u8)]
+pub enum ManifestTag {
+    AddRun = 0x01,
+    RemoveRun = 0x02,
+    PromoteRun = 0x03,
+    SetSequence = 0x04,
+    AddRunAndSequence = 0x05,
+    CompactionCommit = 0x06,  // NEW in Phase 3
+}
+
+pub enum ManifestEntry {
+    // ... existing variants ...
+    CompactionCommit {
+        output_level: Level,
+        output: SortedRunMeta,
+        inputs: Vec<(Level, PathBuf)>,  // runs to remove on apply
+    },
+}
+```
+
+**Wire format for `CompactionCommit`**:
+```
+[tag: u8 = 0x06]
+[output_level: u8]
+[output: SortedRunMeta encoded as in AddRun]
+[input_count: u16 LE]
+input_count × {
+    [level: u8]
+    [path_len: u16 LE][path: bytes]
+}
+```
+
+**Apply semantics**: on replay, `apply_entry` atomically adds the output to the manifest and removes all listed inputs. Partial application is impossible — the frame is a single CRC-validated unit; it either applies entirely or gets truncated as tail garbage.
+
+**Input file deletion** happens after the manifest entry is durable, via the existing `cleanup_orphans` mechanism (paths no longer referenced in the manifest get swept on the next clean operation).
+
+### 4. Tombstone elision
+
+**Policy: drop tombstones only when compacting INTO the bottom level (L(N-1) where N is the const-generic level count).** For the default 4-level config, tombstones survive until they reach L3. Rationale: at any level above the bottom, older data may exist at a deeper level that the tombstone is shadowing; dropping the tombstone early would resurrect shadowed data.
+
+This is the standard LSM policy. For the append-only ledger shape, tombstones are rare (history is mostly immutable), so the "tombstone lingers until bottom level" cost is minimal in practice.
+
+**Implementation**: `Level` gains a const-generic-aware accessor:
+```rust
+impl Level {
+    /// The bottom level for an N-level manifest: Level(N - 1).
+    pub const fn bottom<const N: usize>() -> Level {
+        Level(N as u8 - 1)
+    }
+}
+```
+During merge: `if to_level == Level::bottom::<N>() { skip_tombstones() } else { include_tombstones() }`. One branch on the output level at compaction start.
+
+### 5. Filter construction hook (Phase 4 carry-forward)
+
+Phase 3 does not implement the bloom filter, but must leave a clean hook for Phase 4 to slot into. The hook goes on the **output writer side, after merge resolution**. Keys that get dropped during merge (tombstoned, overwritten, deduped across input runs) never reach the hook. This keeps FPR honest — the filter's claimed membership matches exactly what ends up on disk.
+
+**Writer API**:
+```rust
+impl<const N: usize> FlushWriter<N> {
+    /// Install a per-entry observer. Called once per key that passes merge
+    /// resolution and is written to the output run.
+    pub fn set_entry_observer(&mut self, observer: Box<dyn FnMut(&EntryKey)>);
+}
+```
+
+For Phase 3, no observer is installed; the hook is a no-op. Phase 4 installs a `BloomFilterBuilder` observer and extracts the finalized filter after the writer closes.
+
+**Size estimation for the filter (Phase 4 detail, noted here)**: blocked bloom needs block count at construction time. Sum input run key counts as an upper bound; accept slight over-provisioning after tombstones/overwrites reduce the actual output. Alternative (buffer entries, finalize on close) is deferred to Phase 4 if the over-provisioning overhead proves material.
+
+### 6. Zero-copy recovery preservation
+
+The existing snapshot path gets zero-copy recovery via `CrcProof` + `CodecRegistry::decode(..., Some(&proof))` which routes to the `raw_copy_size` fast path (direct memcpy, skipping rkyv bytecheck). Phase 3 preserves this for LSM-based recovery with a small API tweak on `SortedRunReader`:
+
+```rust
+// crates/minkowski-lsm/src/reader.rs (post-cleanup namespace)
+impl SortedRunReader {
+    /// Validate the page CRC and return a proof token on success.
+    ///
+    /// The returned CrcProof is the input to CodecRegistry::decode's
+    /// raw_copy_size fast path, which skips rkyv bytecheck for decoded
+    /// pages. Identical mechanism to the old snapshot v2 format.
+    pub fn validate_page_crc(&self, page: &PageRef<'_>) -> Result<CrcProof, LsmError>;
+}
+```
+
+This is a return-type change on an existing method. Current callers either discard the success value (`let _ = validate_page_crc(...)?;` or `validate_page_crc(...)?;` — both forms keep working since `CrcProof` is `Drop`-only-no-op) or migrate to the new signature to get the proof.
+
+**Recovery path** (new, replacing `Snapshot::load`):
+
+```rust
+pub fn recover_world_from_lsm<const N: usize>(
+    run_dir: &Path,
+    codecs: &CodecRegistry,
+) -> Result<(World, SeqNo), LsmError> {
+    let (manifest, _log) = ManifestLog::recover(&run_dir.join("manifest.log"))?;
+    let mut world = World::new();
+    for level in 0..N {
+        for meta in manifest.runs_at_level(Level::new(level as u8).unwrap()) {
+            let reader = SortedRunReader::open(meta.path(), codecs)?;
+            for page in reader.pages() {
+                let proof = reader.validate_page_crc(&page)?;
+                let bytes = page.data();
+                // raw_copy_size fast path (skips rkyv bytecheck)
+                codecs.decode(page.header().slot, bytes, Some(&proof))?
+                    .apply_to(&mut world);
+            }
+        }
+    }
+    let last_flush_seq = manifest.max_sequence();
+    Ok((world, last_flush_seq))
+}
+```
+
+Then WAL replay from `last_flush_seq` applies any mutations since the last flush, matching the existing `Durable::recover` protocol.
+
+### 7. Snapshot cleanup (clean cut)
+
+Minkowski has no external users. Clean-cut removal is safe.
+
+**Removed**:
+- `Snapshot` struct (save, load, save_to_bytes, load_from_bytes)
+- `SnapshotError` (folded; any residual semantics merge into `LsmError`)
+- `AutoCheckpoint` (replaced by `LsmCheckpoint`)
+
+**Kept (moved)**:
+- `CrcProof` — moves to `minkowski-lsm::codec`
+- `CodecRegistry`, `CodecError` — move to `minkowski-lsm::codec`
+
+**Caller migration**:
+| File | Current | Post |
+|---|---|---|
+| `crates/minkowski-persist/src/checkpoint.rs:68-69` | Calls `Snapshot::save` | Replaced with `LsmCheckpoint` |
+| `crates/minkowski-persist/src/index.rs:535,568` | Tests use `Snapshot::new().save/load` | Rewrite against LSM or delete |
+| `crates/minkowski-persist/src/replication.rs:619` | Test uses `Snapshot::new()` | Rewrite against LSM or delete |
+| `crates/minkowski-persist/benches/persist.rs` | Benchmarks | Rewrite against LSM |
+| `crates/minkowski-bench/benches/serialize.rs` | Benchmarks | Rewrite against LSM |
+| `examples/examples/replicate.rs:69,137` | Uses `save_to_bytes`/`load_from_bytes` for replica bootstrap | Remove or stub; full LSM-based bootstrap in a later phase |
+
+### 8. Crate layering shift
+
+**Post-cleanup stack**:
+```
+minkowski              (ECS core)
+     ↑
+minkowski-lsm          (storage primitives: sorted runs, manifest, codec, CrcProof)
+     ↑
+minkowski-persist      (WAL, replication, orchestration over LSM)
+```
+
+**Moves**:
+- `crates/minkowski-persist/src/codec.rs` → `crates/minkowski-lsm/src/codec.rs`
+  - Exports: `CodecRegistry`, `CodecError`, `CrcProof`
+- `crates/minkowski-persist/Cargo.toml` gains `minkowski-lsm = { path = "../minkowski-lsm" }`
+- `crates/minkowski-lsm/Cargo.toml` does NOT gain a dep on persist (cycle prevention)
+- WAL's import of `CrcProof` updates from `crate::codec::CrcProof` to `minkowski_lsm::codec::CrcProof`
+
+### 9. `LsmCheckpoint` API
+
+```rust
+// In minkowski-persist/src/checkpoint.rs (replaces AutoCheckpoint)
+
+pub struct LsmCheckpoint<const N: usize = 4> {
+    manifest: LsmManifest<N>,
+    log: ManifestLog,
+    run_dir: PathBuf,
+}
+
+impl<const N: usize> LsmCheckpoint<N> {
+    pub fn new(run_dir: PathBuf) -> Result<Self, LsmError> {
+        let log_path = run_dir.join("manifest.log");
+        let (manifest, log) = ManifestLog::recover(&log_path)?;
+        Ok(Self { manifest, log, run_dir })
+    }
+}
+
+impl<const N: usize> CheckpointHandler for LsmCheckpoint<N> {
+    fn checkpoint(&mut self, world: &World, seq: SeqNo) -> Result<(), CheckpointError> {
+        // Lower bound: sequence immediately after the last durable flush.
+        // Upper bound: current WAL sequence (passed in).
+        let lo = self.manifest.max_sequence()
+            .map(SeqNo::next)
+            .unwrap_or(SeqNo::from(0u64));
+        let seq_range = SeqRange::new(lo, seq)
+            .ok_or(CheckpointError::InvalidSeqRange)?;
+        flush_and_record(world, seq_range, &mut self.manifest, &mut self.log, &self.run_dir)
+            .map_err(CheckpointError::from)
+    }
+}
+```
+
+`Durable<S>` is unchanged; it depends on the `CheckpointHandler` trait abstractly.
+
+### 10. Error handling
+
+**Reuses existing atomic primitives** — no new error-handling machinery needed.
+
+| Failure point | Existing mechanism | Behavior |
+|---|---|---|
+| Output run write fails partway | `tmp + rename + fsync dir` atomicity (Phase 1) | Tmp file unlinked on `Drop`; no manifest changes; state unchanged |
+| Manifest `CompactionCommit` write fails (crash mid-frame) | PR B1 truncate-on-error replay | Frame becomes tail garbage; output file becomes orphan |
+| Orphan output file (no manifest ref) | `cleanup_orphans` sweep | Removed on next clean boot or explicit cleanup call |
+| CRC mismatch on recovery page read | `LsmError::Crc { offset, expected, actual }` (Phase 1) | Propagates up; recovery fails hard (not tail-truncate) |
+
+**No silent failures.** Every failure path surfaces as `LsmError::*` with enough context to diagnose.
+
+## Testing strategy
+
+### Unit tests
+
+- **`compact_one` with no candidates**: `Ok(None)`.
+- **`compact_one` single archetype over threshold**: K=4 runs at L0 → 1 run at L1, 0 runs at L0.
+- **Tombstone elision at bottom level**: compact with a tombstone, confirm it's dropped at L(N-1) compaction but preserved at higher levels.
+- **CompactionCommit atomic apply**: write a CompactionCommit frame, apply, verify manifest matches.
+- **CompactionCommit torn frame**: truncate the frame mid-payload, replay, verify truncation to prior frame boundary.
+- **`validate_page_crc` returns CrcProof**: valid page → proof; corrupted page → `LsmError::Crc`.
+- **`LsmCheckpoint::checkpoint` flushes to new sorted run**: call, verify new run appears in manifest at L0.
+
+### Integration tests
+
+- **`recover_world_from_lsm` round-trip**: populate World, flush, drop, recover, verify all entities/components restored.
+- **Recovery replays WAL tail after last_flush_seq**: flush at seq=100, append WAL at seq=100..200, recover, verify state includes post-flush mutations.
+- **Full Durable<S> integration**: replace AutoCheckpoint with LsmCheckpoint in the existing Durable tests; all pass.
+- **`compact_one` idempotence under crash**: mid-compaction crash (simulated by truncating the manifest at various byte offsets), replay, verify correct state or clean "pre-compaction" state, never double-counted.
+- **Cross-level tombstone survival**: insert, delete, flush L0, compact L0→L1, compact L1→L2, verify tombstone still present (not yet at bottom).
+- **Tombstone dropped at bottom level**: continue above test through L(N-1) compaction, verify tombstone now gone.
+
+### Byte-prefix convergence test (extends existing)
+
+Phase 2's `replay_converges_at_every_truncation_prefix` currently covers frame-level truncation. Extend to include a `CompactionCommit` frame with K=4 inputs, verify every prefix 0..=frame_len either produces (a) an error pre-frame with consistent pre-compaction state, or (b) successful apply with post-compaction state. No intermediate "partial compaction" state should be reachable.
+
+## Rollout
+
+Single squash-merged PR per project convention. CI gates: fmt, clippy, test, tsan, loom, claude-review. `minkowski-lsm` test count expected to grow ~30–40 tests (from 118 current); `minkowski-persist` test count may shrink slightly as snapshot-specific tests are removed.
+
+**Post-merge memory updates**:
+- `project_scaling_roadmap.md`: mark Phase 3 complete, update type-rating table (add `Compactor`, `LsmCheckpoint`), update next-step to Phase 4 (bloom filter).
+- `project_bloom_compaction_coupling.md`: confirm Phase 3's filter hook API landed as designed; Phase 4 can now start.
+
+## Risks
+
+- **Zero-copy regression risk**: the `validate_page_crc` return-type change has to be picked up at every recovery-path callsite. Missing one means `CodecRegistry::decode` gets `None` for the proof, falls back to full rkyv bytecheck — silently correct but slow. Mitigate with a benchmark in `minkowski-bench` that asserts recovery throughput within an expected range of the old snapshot recovery path.
+
+- **Crate layering move blast radius**: `CrcProof` + `CodecRegistry` move across crates changes every import. Mechanical but wide. Run it as a separate commit within the PR so review can see the import-rewriting and the feature changes independently.
+
+- **`replicate.rs` example in limbo**: clean cut breaks the example. If the example is the only documentation of how to set up replication, removing it without replacement leaves a doc gap. Decision: stub with a `TODO: LSM-based bootstrap pending` comment and a pointer to this design doc, rather than delete outright.
+
+- **Tombstone elision correctness**: the "drop only at bottom level" rule is right for a system where older data exists at deeper levels. If a future design adds shortcuts (e.g., direct L0 → L3 promotion), the rule needs to be re-examined — the tombstone must survive long enough to shadow all older data that could still exist below it.

--- a/docs/plans/2026-04-18-stage3-phase3-compactor-design.md
+++ b/docs/plans/2026-04-18-stage3-phase3-compactor-design.md
@@ -145,12 +145,25 @@ pub enum ManifestEntry {
 [tag: u8 = 0x06]
 [output_level: u8]
 [output: SortedRunMeta encoded as in AddRun]
-[input_count: u16 LE]
+[input_count: u32 LE]
 input_count × {
     [level: u8]
     [path_len: u16 LE][path: bytes]
 }
 ```
+
+`input_count` is `u32` rather than `u16`. The expected value is <100 even under pathological conditions (bounded by per-level count trigger), but the asymmetry of change cost favors the wider field: u16→u32 later requires a manifest-log format-version bump and dual-decode, while u32→u16 later is trivial. A logical bound check sits at the apply site:
+
+```rust
+const MAX_COMPACTION_INPUTS: usize = 1024;  // orders of magnitude past expected
+
+debug_assert!(
+    inputs.len() <= MAX_COMPACTION_INPUTS,
+    "CompactionCommit with {} inputs — check compaction granularity",
+    inputs.len()
+);
+```
+That preserves the "bounded everything" property at the semantic layer without baking it into the wire format.
 
 **Apply semantics**: on replay, `apply_entry` atomically adds the output to the manifest and removes all listed inputs. Partial application is impossible — the frame is a single CRC-validated unit; it either applies entirely or gets truncated as tail garbage.
 

--- a/docs/plans/2026-04-18-stage3-phase3-compactor-design.md
+++ b/docs/plans/2026-04-18-stage3-phase3-compactor-design.md
@@ -413,6 +413,7 @@ Pure feature addition. Estimated ~800–1200 lines. Depends on PR 1, independent
 - Tombstone elision at bottom level only
 - `FlushWriter::set_entry_observer` hook (no-op observer for Phase 3; Phase 4 installs a real one)
 - `MAX_COMPACTION_INPUTS = 1024` debug_assert at apply site
+- **Manifest-log header `max_level` byte** (repurpose one of PR #164's 3 reserved bytes at offset 5–7): write `N as u8` on create; on `recover::<N>()`, reject mismatches as fatal `LsmError::Format` rather than letting per-frame OOR checks silently truncate valid frames. Closes the cross-`N` portability hazard flagged on PR #168 (Codex review + internal type-design review). Since PR 3 already bumps the on-disk format with `CompactionCommit`, the header byte rides along naturally.
 
 PR 2 and PR 3 can land in either order (or in parallel worktrees). PR 1 is the strict prerequisite for both.
 

--- a/docs/plans/2026-04-18-stage3-phase3-pr1-infrastructure-implementation-plan.md
+++ b/docs/plans/2026-04-18-stage3-phase3-pr1-infrastructure-implementation-plan.md
@@ -1,0 +1,1099 @@
+# Phase 3 PR 1: Infrastructure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land Phase 3's pure-infrastructure prerequisites as a single squash-merged PR. No behavioral changes to existing callers; enables PR 2 (LsmCheckpoint + snapshot cut) and PR 3 (compactor).
+
+**Architecture:** Three tightly coupled type-system / module changes: (a) move zero-copy primitives from `minkowski-persist::codec` into `minkowski-lsm::codec` and flip the crate dependency direction; (b) convert `LsmManifest` to a const-generic `LsmManifest<const N: usize = 4>` with `DefaultManifest` alias; (c) change `SortedRunReader::validate_page_crc` to return `Result<CrcProof, LsmError>`, enabling the existing `raw_copy_size` fast path in recovery. Plus a regime-model module doc on `manifest.rs`.
+
+**Scope note:** `recover_world_from_lsm` (the helper that reconstructs a `World` by iterating sorted-run pages) is **deferred to PR 2**, where it pairs naturally with `LsmCheckpoint`'s first real use. PR 1 only lands the `CrcProof`-returning signature change on `validate_page_crc`; PR 2 lands the helper that consumes it. Rationale: the page-to-archetype plumbing (reconstruct archetype schema from slots, spawn entities from entity-ID pages, fill columns from component pages) is non-trivial and has no value without a caller — PR 2 provides both.
+
+**Tech Stack:** Rust edition 2024; `rkyv` 0.8 (moved into lsm with codec); `thiserror` 2 (already in lsm via error.rs); `crc32fast` 1 (already in lsm); clippy::pedantic workspace-wide.
+
+---
+
+## File Structure
+
+### Files moved
+- `crates/minkowski-persist/src/codec.rs` → `crates/minkowski-lsm/src/codec.rs` (681 lines, unchanged content except visibility of `CrcProof`)
+
+### Files created
+- `docs/plans/2026-04-18-stage3-phase3-pr1-infrastructure-implementation-plan.md` (this file)
+
+### Files modified
+- `crates/minkowski-lsm/Cargo.toml` — add `rkyv`, `thiserror` deps
+- `crates/minkowski-persist/Cargo.toml` — add `minkowski-lsm` dep
+- `crates/minkowski-lsm/src/lib.rs` — add `pub mod codec;` + re-exports
+- `crates/minkowski-persist/src/lib.rs` — remove `pub mod codec;`, add re-exports from `minkowski_lsm::codec`
+- `crates/minkowski-persist/src/wal.rs` — rewrite `use crate::codec::*` → `use minkowski_lsm::codec::*`
+- `crates/minkowski-persist/src/checkpoint.rs` — same import rewrite
+- `crates/minkowski-persist/src/durable.rs` — same
+- `crates/minkowski-persist/src/replication.rs` — same
+- `crates/minkowski-persist/src/snapshot.rs` — same (will be deleted in PR 2, but must compile here)
+- `crates/minkowski-persist/src/index.rs` — test-only import rewrite
+- `crates/minkowski-persist/src/record.rs` — no direct codec import, but may need `minkowski_lsm::codec::CodecError` if it references it
+- `crates/minkowski-persist/src/blob.rs` — check for any codec imports (rkyv usage unrelated)
+- `crates/minkowski-lsm/src/manifest.rs` — const-generic `LsmManifest<const N: usize = 4>`, regime-model module doc, `DefaultManifest` alias, `NUM_LEVELS` removed
+- `crates/minkowski-lsm/src/types.rs` — add `MAX_LEVELS = 32` constant; `Level::new` checks against `MAX_LEVELS` (not `NUM_LEVELS` which no longer exists)
+- `crates/minkowski-lsm/src/manifest_log.rs` — propagate const generic through `ManifestLog::recover`, `apply_entry`, bounds checks
+- `crates/minkowski-lsm/src/manifest_ops.rs` — propagate const generic through `flush_and_record`
+- `crates/minkowski-lsm/src/writer.rs` — `FlushWriter<const N: usize = 4>`, propagation
+- `crates/minkowski-lsm/src/reader.rs` — `SortedRunReader::validate_page_crc` returns `Result<CrcProof, LsmError>`; import `CrcProof` from the new `crate::codec`
+
+### Tests
+- `crates/minkowski-lsm/src/manifest.rs` (inline) — new test: `lsm_manifest_alternate_level_count_compiles_and_works`
+- `crates/minkowski-lsm/src/reader.rs` (inline) — new test: `validate_page_crc_returns_proof_token`
+- `crates/minkowski-persist/*` tests — unchanged, must continue to pass
+
+---
+
+## Task 1: Add rkyv + thiserror deps to minkowski-lsm
+
+**Files:**
+- Modify: `crates/minkowski-lsm/Cargo.toml`
+
+- [ ] **Step 1: Edit Cargo.toml to add dependencies**
+
+Replace the `[dependencies]` section with:
+
+```toml
+[dependencies]
+minkowski = { path = "../minkowski" }
+crc32fast = "1"
+memmap2 = "0.9"
+rkyv = { version = "0.8", features = ["alloc", "bytecheck"] }
+thiserror = "2"
+```
+
+- [ ] **Step 2: Verify lsm still builds standalone**
+
+Run: `cargo check -p minkowski-lsm`
+Expected: clean build, no warnings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/minkowski-lsm/Cargo.toml
+git commit -m "chore(lsm): add rkyv + thiserror deps for codec module move"
+```
+
+---
+
+## Task 2: Move codec.rs from persist to lsm
+
+**Files:**
+- Move: `crates/minkowski-persist/src/codec.rs` → `crates/minkowski-lsm/src/codec.rs`
+- Modify: `crates/minkowski-lsm/src/lib.rs` (add `pub mod codec;`)
+- Modify: `crates/minkowski-lsm/src/codec.rs` (widen `CrcProof` visibility)
+
+- [ ] **Step 1: Move the file with git**
+
+Run:
+```bash
+git mv crates/minkowski-persist/src/codec.rs crates/minkowski-lsm/src/codec.rs
+```
+
+- [ ] **Step 2: Add `pub mod codec;` to lsm/lib.rs**
+
+Open `crates/minkowski-lsm/src/lib.rs`. Add near the top, after existing `pub mod` declarations:
+
+```rust
+pub mod codec;
+```
+
+- [ ] **Step 3: Widen CrcProof visibility from `pub(crate)` to `pub`**
+
+Open `crates/minkowski-lsm/src/codec.rs`. Find the line:
+
+```rust
+pub(crate) struct CrcProof(());
+```
+
+Replace with:
+
+```rust
+/// A proof token returned by [`CrcProof::verify`] after successful CRC32
+/// validation of a byte payload. Unforgeable: the only public constructor
+/// is [`CrcProof::verify`], which runs the actual checksum.
+///
+/// Used by [`CodecRegistry::decode`] to gate the `raw_copy_size` fast path
+/// (direct memcpy, skipping rkyv bytecheck). Producers: WAL frame reader
+/// ([`minkowski_persist::wal::read_next_frame`]), LSM page validator
+/// ([`SortedRunReader::validate_page_crc`]).
+pub struct CrcProof(());
+```
+
+- [ ] **Step 4: Verify lsm still builds**
+
+Run: `cargo check -p minkowski-lsm`
+Expected: compiles cleanly. `cargo check` for persist will fail at this point — that is expected and fixed in Task 3.
+
+- [ ] **Step 5: Commit (broken intermediate state acknowledged)**
+
+```bash
+git add crates/minkowski-lsm/src/codec.rs \
+        crates/minkowski-lsm/src/lib.rs \
+        crates/minkowski-persist/src/codec.rs
+git commit -m "refactor(lsm): move codec module from persist to lsm
+
+Move CrcProof, CodecRegistry, CodecError into minkowski-lsm::codec.
+CrcProof visibility widens from pub(crate) to pub since it now crosses
+the crate boundary. minkowski-persist does not build after this commit;
+Task 3 restores it by flipping the dep direction."
+```
+
+---
+
+## Task 3: Update persist to depend on lsm; rewrite imports
+
+**Files:**
+- Modify: `crates/minkowski-persist/Cargo.toml`
+- Modify: `crates/minkowski-persist/src/lib.rs`
+- Modify: `crates/minkowski-persist/src/wal.rs`
+- Modify: `crates/minkowski-persist/src/checkpoint.rs`
+- Modify: `crates/minkowski-persist/src/durable.rs`
+- Modify: `crates/minkowski-persist/src/replication.rs`
+- Modify: `crates/minkowski-persist/src/snapshot.rs` (will die in PR 2 but must compile now)
+- Modify: `crates/minkowski-persist/src/index.rs` (test imports)
+
+- [ ] **Step 1: Add minkowski-lsm dep to persist**
+
+Open `crates/minkowski-persist/Cargo.toml`. In `[dependencies]`, add after `minkowski = { path = "../minkowski" }`:
+
+```toml
+minkowski-lsm = { path = "../minkowski-lsm" }
+```
+
+- [ ] **Step 2: Rewrite lib.rs re-exports**
+
+Open `crates/minkowski-persist/src/lib.rs`. Find:
+
+```rust
+pub mod codec;
+```
+
+Delete that line. Find:
+
+```rust
+pub use codec::{CodecError, CodecRegistry};
+```
+
+Replace with:
+
+```rust
+pub use minkowski_lsm::codec::{CodecError, CodecRegistry, CrcProof};
+```
+
+- [ ] **Step 3: Rewrite imports in wal.rs**
+
+Open `crates/minkowski-persist/src/wal.rs`. Find line 9:
+
+```rust
+use crate::codec::{CodecError, CodecRegistry, CrcProof};
+```
+
+Replace with:
+
+```rust
+use minkowski_lsm::codec::{CodecError, CodecRegistry, CrcProof};
+```
+
+Find line 1161 (inside `#[cfg(test)] mod tests`):
+
+```rust
+use crate::codec::CodecRegistry;
+```
+
+Replace with:
+
+```rust
+use minkowski_lsm::codec::CodecRegistry;
+```
+
+- [ ] **Step 4: Rewrite imports in checkpoint.rs**
+
+Open `crates/minkowski-persist/src/checkpoint.rs`. Find line 7:
+
+```rust
+use crate::codec::CodecRegistry;
+```
+
+Replace with:
+
+```rust
+use minkowski_lsm::codec::CodecRegistry;
+```
+
+Find line 90 (test scope):
+
+```rust
+use crate::codec::CodecRegistry;
+```
+
+Replace with:
+
+```rust
+use minkowski_lsm::codec::CodecRegistry;
+```
+
+- [ ] **Step 5: Rewrite imports in durable.rs**
+
+Open `crates/minkowski-persist/src/durable.rs`. Find line 6:
+
+```rust
+use crate::codec::CodecRegistry;
+```
+
+Replace with:
+
+```rust
+use minkowski_lsm::codec::CodecRegistry;
+```
+
+Find line 135 (test scope):
+
+```rust
+use crate::codec::CodecRegistry;
+```
+
+Replace with:
+
+```rust
+use minkowski_lsm::codec::CodecRegistry;
+```
+
+- [ ] **Step 6: Rewrite imports in replication.rs**
+
+Open `crates/minkowski-persist/src/replication.rs`. Find line 16:
+
+```rust
+use crate::codec::{CodecError, CodecRegistry};
+```
+
+Replace with:
+
+```rust
+use minkowski_lsm::codec::{CodecError, CodecRegistry};
+```
+
+Find line 89 (test scope):
+
+```rust
+use crate::codec::CodecRegistry;
+```
+
+Replace with:
+
+```rust
+use minkowski_lsm::codec::CodecRegistry;
+```
+
+- [ ] **Step 7: Rewrite imports in snapshot.rs**
+
+Open `crates/minkowski-persist/src/snapshot.rs`. Find line 8:
+
+```rust
+use crate::codec::{CodecError, CodecRegistry, CrcProof};
+```
+
+Replace with:
+
+```rust
+use minkowski_lsm::codec::{CodecError, CodecRegistry, CrcProof};
+```
+
+Find line 482 (test scope):
+
+```rust
+use crate::codec::CodecRegistry;
+```
+
+Replace with:
+
+```rust
+use minkowski_lsm::codec::CodecRegistry;
+```
+
+- [ ] **Step 8: Rewrite test imports in index.rs**
+
+Open `crates/minkowski-persist/src/index.rs`. Find line 496 (test scope):
+
+```rust
+use crate::codec::CodecRegistry;
+```
+
+Replace with:
+
+```rust
+use minkowski_lsm::codec::CodecRegistry;
+```
+
+- [ ] **Step 9: Check for any other `crate::codec` references**
+
+Run:
+
+```bash
+grep -rn "crate::codec\|use codec::\|self::codec" crates/minkowski-persist/src/ 2>/dev/null
+```
+
+Expected output: none. If any remain, rewrite them following the pattern from Steps 3–8.
+
+- [ ] **Step 10: Build the full workspace**
+
+Run: `cargo check --workspace`
+Expected: clean build across all crates.
+
+- [ ] **Step 11: Run full workspace test suite**
+
+Run: `cargo test --workspace`
+Expected: all tests pass. No new failures from the move; same test count as before.
+
+- [ ] **Step 12: Clippy check**
+
+Run: `cargo clippy --workspace --all-targets -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add crates/minkowski-persist/
+git commit -m "refactor(persist): migrate codec imports to minkowski-lsm
+
+Add minkowski-lsm as a dependency of minkowski-persist. Rewrite all
+use crate::codec::* as use minkowski_lsm::codec::*. Re-export from
+persist::lib for downstream convenience. No behavioral changes;
+pure import rewrite."
+```
+
+---
+
+## Task 4: Const-generic LsmManifest — failing test
+
+**Files:**
+- Modify: `crates/minkowski-lsm/src/manifest.rs` (add test)
+
+- [ ] **Step 1: Add failing test at the bottom of the existing `mod tests`**
+
+Open `crates/minkowski-lsm/src/manifest.rs`. Find the existing `#[cfg(test)] mod tests { ... }` block. Add this test before the closing `}` of the mod:
+
+```rust
+    #[test]
+    fn lsm_manifest_alternate_level_count_compiles_and_works() {
+        // Default N=4 path still works.
+        let m4: LsmManifest<4> = LsmManifest::new();
+        assert_eq!(m4.total_runs(), 0);
+
+        // Alternate N=7 manifest constructs and is distinct at the type level.
+        let m7: LsmManifest<7> = LsmManifest::new();
+        assert_eq!(m7.total_runs(), 0);
+
+        // DefaultManifest alias resolves to N=4.
+        let md: DefaultManifest = LsmManifest::new();
+        assert_eq!(md.total_runs(), 0);
+    }
+```
+
+- [ ] **Step 2: Run the test, confirm it fails to compile**
+
+Run: `cargo test -p minkowski-lsm lsm_manifest_alternate_level_count_compiles_and_works 2>&1 | head -40`
+Expected: compilation errors pointing at `LsmManifest<4>`, `LsmManifest<7>`, `DefaultManifest` — none of these types exist yet.
+
+---
+
+## Task 5: Const-generic LsmManifest — introduce parameter
+
+**Files:**
+- Modify: `crates/minkowski-lsm/src/manifest.rs`
+- Modify: `crates/minkowski-lsm/src/types.rs`
+
+- [ ] **Step 1: Replace NUM_LEVELS constant with MAX_LEVELS sanity bound**
+
+Open `crates/minkowski-lsm/src/types.rs`. Find:
+
+```rust
+use crate::manifest::NUM_LEVELS;
+```
+
+Replace with:
+
+```rust
+/// Maximum level count accepted by [`Level::new`]. A generous upper bound:
+/// the default manifest uses 4 levels, TigerBeetle-style configurations
+/// use 7. `Level::new` rejects anything ≥ `MAX_LEVELS`; per-manifest
+/// bounds are enforced at the manifest boundary.
+pub const MAX_LEVELS: usize = 32;
+```
+
+Find `Level::new`:
+
+```rust
+pub fn new(level: u8) -> Option<Self> {
+    if (level as usize) < NUM_LEVELS {
+        Some(Self(level))
+    } else {
+        None
+    }
+}
+```
+
+Replace with:
+
+```rust
+pub fn new(level: u8) -> Option<Self> {
+    if (level as usize) < MAX_LEVELS {
+        Some(Self(level))
+    } else {
+        None
+    }
+}
+```
+
+- [ ] **Step 2: Update manifest.rs with const generic + regime doc**
+
+Open `crates/minkowski-lsm/src/manifest.rs`. Replace the entire file content starting from the top through the `impl LsmManifest { pub fn new() ...` definition. Be precise:
+
+Find:
+
+```rust
+use std::path::{Path, PathBuf};
+
+use crate::error::LsmError;
+use crate::types::{Level, PageCount, SeqNo, SeqRange, SizeBytes};
+
+/// Number of LSM levels (L0 through L3).
+pub const NUM_LEVELS: usize = 4;
+
+/// In-memory manifest tracking all sorted runs across levels.
+pub struct LsmManifest {
+    levels: [Vec<SortedRunMeta>; NUM_LEVELS],
+    next_sequence: u64,
+}
+```
+
+Replace with:
+
+```rust
+//! # LsmManifest
+//!
+//! In-memory index of sorted runs across LSM levels.
+//!
+//! ## Level Count
+//!
+//! Defaults to 4 levels. This fits the expected minkowski regime:
+//! on-disk data up to ~100× RAM, with reads served from the in-memory
+//! World rather than from level traversal (the in-memory World IS the
+//! merged view).
+//!
+//! At T=10 size ratio: 4 levels covers ~0.1× to 100× RAM on disk.
+//!
+//! For ledger-style workloads (TigerBeetle territory, ever-growing
+//! history), construct [`LsmManifest<7>`] instead. Merge logic is
+//! level-count-agnostic; only bounds checks and manifest serialization
+//! care about `N`.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::LsmError;
+use crate::types::{Level, PageCount, SeqNo, SeqRange, SizeBytes};
+
+/// In-memory manifest tracking all sorted runs across `N` levels.
+///
+/// `N` is a const generic with default 4. Use [`DefaultManifest`] as
+/// the conventional alias.
+pub struct LsmManifest<const N: usize = 4> {
+    levels: [Vec<SortedRunMeta>; N],
+    next_sequence: u64,
+}
+
+/// Conventional alias for the default 4-level manifest.
+pub type DefaultManifest = LsmManifest<4>;
+```
+
+- [ ] **Step 3: Update impl block**
+
+In `manifest.rs`, find:
+
+```rust
+impl LsmManifest {
+    /// Create an empty manifest.
+    pub fn new() -> Self {
+        Self {
+            levels: std::array::from_fn(|_| Vec::new()),
+            next_sequence: 0,
+        }
+    }
+```
+
+Replace the `impl LsmManifest {` line and (only that line) with:
+
+```rust
+impl<const N: usize> LsmManifest<N> {
+    /// Create an empty manifest.
+    pub fn new() -> Self {
+        Self {
+            levels: std::array::from_fn(|_| Vec::new()),
+            next_sequence: 0,
+        }
+    }
+```
+
+- [ ] **Step 4: Fix `add_run` / `remove_run` / `promote_run` / `runs_at_level` bounds handling**
+
+Any method that uses `level.as_index()` as an array index into `self.levels` must guard against `level.as_index() >= N` since `Level::new` now accepts up to `MAX_LEVELS = 32`.
+
+In `manifest.rs`, find `add_run`:
+
+```rust
+pub fn add_run(&mut self, level: Level, meta: SortedRunMeta) {
+    self.levels[level.as_index()].push(meta);
+}
+```
+
+Replace with:
+
+```rust
+pub fn add_run(&mut self, level: Level, meta: SortedRunMeta) -> Result<(), LsmError> {
+    if level.as_index() >= N {
+        return Err(LsmError::Format(format!(
+            "level {} out of range for {}-level manifest",
+            level,
+            N
+        )));
+    }
+    self.levels[level.as_index()].push(meta);
+    Ok(())
+}
+```
+
+Similarly update `remove_run` (returns `Option<SortedRunMeta>` currently) to return `Option<SortedRunMeta>` with an early `None` if out of range:
+
+Find:
+
+```rust
+pub fn remove_run(&mut self, level: Level, path: &Path) -> Option<SortedRunMeta> {
+    let runs = &mut self.levels[level.as_index()];
+    // ...
+}
+```
+
+Change the first two lines to:
+
+```rust
+pub fn remove_run(&mut self, level: Level, path: &Path) -> Option<SortedRunMeta> {
+    if level.as_index() >= N {
+        return None;
+    }
+    let runs = &mut self.levels[level.as_index()];
+    // ...
+}
+```
+
+For `promote_run`:
+
+```rust
+pub fn promote_run(&mut self, from: Level, to: Level, path: &Path) -> Result<(), LsmError> {
+    // existing body
+}
+```
+
+Add at the top of the body:
+
+```rust
+if from.as_index() >= N || to.as_index() >= N {
+    return Err(LsmError::Format(format!(
+        "level out of range for {}-level manifest: from={}, to={}",
+        N, from, to
+    )));
+}
+```
+
+For `runs_at_level`:
+
+```rust
+pub fn runs_at_level(&self, level: Level) -> &[SortedRunMeta] {
+    &self.levels[level.as_index()]
+}
+```
+
+Replace with:
+
+```rust
+pub fn runs_at_level(&self, level: Level) -> &[SortedRunMeta] {
+    if level.as_index() >= N {
+        return &[];
+    }
+    &self.levels[level.as_index()]
+}
+```
+
+- [ ] **Step 5: Fix existing tests that expect `add_run` to not return Result**
+
+In `manifest.rs` `mod tests`, find all `m.add_run(Level::Lx, ...)` calls and change them to `m.add_run(Level::Lx, ...).unwrap()`.
+
+- [ ] **Step 6: Fix `for lvl in 0..NUM_LEVELS` loop**
+
+In `manifest.rs` `mod tests`, find:
+
+```rust
+for lvl in 0..NUM_LEVELS {
+    assert!(m.runs_at_level(Level::new(lvl as u8).unwrap()).is_empty());
+}
+```
+
+Replace with:
+
+```rust
+for lvl in 0..4 {
+    assert!(m.runs_at_level(Level::new(lvl as u8).unwrap()).is_empty());
+}
+```
+
+(The test is checking the default `LsmManifest<4>`, so hardcoding 4 here matches intent.)
+
+- [ ] **Step 7: Run the previously failing test**
+
+Run: `cargo test -p minkowski-lsm lsm_manifest_alternate_level_count_compiles_and_works`
+Expected: PASS.
+
+- [ ] **Step 8: Do NOT commit yet** — Task 6 finishes the propagation.
+
+---
+
+## Task 6: Propagate const generic through ManifestLog, flush_and_record, FlushWriter
+
+**Files:**
+- Modify: `crates/minkowski-lsm/src/manifest_log.rs`
+- Modify: `crates/minkowski-lsm/src/manifest_ops.rs`
+- Modify: `crates/minkowski-lsm/src/writer.rs`
+- Modify all call sites referencing `LsmManifest` without a type parameter
+
+- [ ] **Step 1: Grep for all `LsmManifest` call sites**
+
+Run:
+
+```bash
+grep -rn "LsmManifest" crates/minkowski-lsm/ crates/minkowski-persist/ 2>/dev/null
+```
+
+Expected output: a list of ~15–25 lines. Each will either (a) already work as `LsmManifest<4>` (if inference happens) or (b) need an explicit `<const N: usize>` parameter added to a surrounding signature.
+
+- [ ] **Step 2: Update `ManifestLog::recover` signature**
+
+Open `crates/minkowski-lsm/src/manifest_log.rs`. Find the `recover` signature:
+
+```rust
+pub fn recover(path: &Path) -> Result<(LsmManifest, Self), LsmError> {
+```
+
+Replace with:
+
+```rust
+pub fn recover<const N: usize>(path: &Path) -> Result<(LsmManifest<N>, Self), LsmError> {
+```
+
+- [ ] **Step 3: Update `apply_entry` to take `&mut LsmManifest<N>`**
+
+In `manifest_log.rs`, find `fn apply_entry(manifest: &mut LsmManifest, entry: &ManifestEntry)`. Change to:
+
+```rust
+fn apply_entry<const N: usize>(
+    manifest: &mut LsmManifest<N>,
+    entry: &ManifestEntry,
+) -> Result<(), LsmError> {
+    // existing body, with these changes:
+    //   - manifest.add_run(level, meta.clone()) becomes manifest.add_run(level, meta.clone())? (propagate error)
+    //   - manifest.promote_run(...)? stays as-is (already Result)
+```
+
+Specifically in the `AddRun`, `AddRunAndSequence` arms, change:
+
+```rust
+manifest.add_run(*level, meta.clone());
+```
+
+To:
+
+```rust
+manifest.add_run(*level, meta.clone())?;
+```
+
+- [ ] **Step 4: Update `replay_frames` helper**
+
+In `manifest_log.rs`, find `replay_frames` and add the const generic propagation:
+
+```rust
+fn replay_frames<const N: usize>(
+    file: &File,
+    path: &Path,
+    manifest: &mut LsmManifest<N>,
+    start_pos: u64,
+) -> Result<u64, LsmError> {
+```
+
+- [ ] **Step 5: Update `flush_and_record` signature**
+
+Open `crates/minkowski-lsm/src/manifest_ops.rs`. Find `flush_and_record`:
+
+```rust
+pub fn flush_and_record(
+    world: &World,
+    seq_range: SeqRange,
+    manifest: &mut LsmManifest,
+    log: &mut ManifestLog,
+    run_dir: &Path,
+) -> Result<(), LsmError> {
+```
+
+Replace with:
+
+```rust
+pub fn flush_and_record<const N: usize>(
+    world: &World,
+    seq_range: SeqRange,
+    manifest: &mut LsmManifest<N>,
+    log: &mut ManifestLog,
+    run_dir: &Path,
+) -> Result<(), LsmError> {
+```
+
+Inside the body, find `manifest.add_run(Level::L0, meta);` (or similar) and add `?`:
+
+```rust
+manifest.add_run(Level::L0, meta)?;
+```
+
+- [ ] **Step 6: Update FlushWriter (if it holds LsmManifest)**
+
+Open `crates/minkowski-lsm/src/writer.rs`. Check whether `FlushWriter` references `LsmManifest` in any field or method. If yes, propagate `const N: usize` through its definition. If `FlushWriter` does NOT hold `LsmManifest` (it likely doesn't — it writes pages, not manifests), no change is needed here. Verify by running:
+
+```bash
+grep -n "LsmManifest" crates/minkowski-lsm/src/writer.rs
+```
+
+If no matches, skip this step.
+
+- [ ] **Step 7: Update tests in manifest_log.rs to use explicit type params**
+
+In `manifest_log.rs`, tests call `ManifestLog::recover(...)`. After the generic is introduced, Rust inference will pick N=4 only if the binding is typed. If the test binds as `let (mut manifest, ...)`, inference uses the default `N=4`. That's usually fine. If any test needs to be explicit, write `ManifestLog::recover::<4>(...)`.
+
+Run tests after every change (see Step 10) to catch missing annotations.
+
+- [ ] **Step 8: Update tests in manifest_ops.rs**
+
+Similarly, `flush_and_record(...)` calls should infer `N=4` from the `LsmManifest<4>` (default) type of the `manifest` argument. If any callsite fails inference, add `flush_and_record::<4>(...)`.
+
+- [ ] **Step 9: Update manifest_integration.rs**
+
+Open `crates/minkowski-lsm/tests/manifest_integration.rs`. Bindings like `let (mut manifest, mut log) = ManifestLog::recover(&log_path).unwrap();` should infer `N=4` and keep working. Verify by running (Step 10).
+
+- [ ] **Step 10: Build and test**
+
+```bash
+cargo check -p minkowski-lsm
+cargo check --workspace
+cargo test -p minkowski-lsm
+cargo test --workspace
+```
+
+Expected: all pass. 118 tests in minkowski-lsm + one new (`lsm_manifest_alternate_level_count_compiles_and_works`) = 119.
+
+- [ ] **Step 11: Clippy**
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Expected: clean.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add crates/minkowski-lsm/src/manifest.rs \
+        crates/minkowski-lsm/src/types.rs \
+        crates/minkowski-lsm/src/manifest_log.rs \
+        crates/minkowski-lsm/src/manifest_ops.rs \
+        crates/minkowski-lsm/src/writer.rs \
+        crates/minkowski-lsm/tests/manifest_integration.rs
+git commit -m "feat(lsm): LsmManifest<const N: usize = 4> with DefaultManifest alias
+
+Convert LsmManifest into a const-generic type parameterized by level
+count. Default N=4 remains the conventional choice; N=7 (TigerBeetle
+regime) is available via LsmManifest<7>. Merge logic is N-agnostic;
+only bounds checks and serialization care about N. Level::new checks
+against a generous MAX_LEVELS=32 sanity bound; per-manifest bounds
+are enforced at add_run/remove_run/promote_run/runs_at_level.
+
+Add module-level regime-model documentation on manifest.rs explaining
+why N=4 fits the expected minkowski workload (on-disk up to ~100× RAM,
+reads served from the in-memory World, not from level traversal)."
+```
+
+---
+
+## Task 7: `validate_page_crc` returns `CrcProof` — failing test
+
+**Files:**
+- Modify: `crates/minkowski-lsm/src/reader.rs`
+
+- [ ] **Step 1: Add failing test**
+
+Open `crates/minkowski-lsm/src/reader.rs`. Inside the existing `#[cfg(test)] mod tests` block, add:
+
+```rust
+    #[test]
+    fn validate_page_crc_returns_proof_token() {
+        // This test fails to compile until validate_page_crc returns
+        // Result<CrcProof, LsmError> instead of Result<(), LsmError>.
+        use crate::codec::CrcProof;
+
+        let (reader, _td) = build_single_page_reader();
+        let page = reader.pages().next().unwrap();
+        let proof: CrcProof = reader.validate_page_crc(&page).unwrap();
+        // Consume the proof: no-op Drop, but ensures type is correct.
+        let _ = proof;
+    }
+```
+
+If `build_single_page_reader` doesn't already exist, add this helper inside `mod tests`:
+
+```rust
+    fn build_single_page_reader() -> (SortedRunReader, tempfile::TempDir) {
+        // Reuses the same setup pattern as validate_page_crc_succeeds.
+        // Copy the body of validate_page_crc_succeeds up to the point
+        // of constructing the reader.
+        todo!("copy from validate_page_crc_succeeds setup")
+    }
+```
+
+Actually, don't use `todo!` — the plan forbids placeholders. Instead, inline the setup in the new test by copying the pattern from the existing `validate_page_crc_succeeds` test (around `reader.rs:437-447`). If the existing test body is short, duplicate it. If long, factor it out into a helper.
+
+Open `reader.rs` and read `validate_page_crc_succeeds` starting at line ~437. Copy the setup (everything before the existing `reader.validate_page_crc(&page).unwrap();` call). Use that setup in the new test.
+
+- [ ] **Step 2: Run test, confirm it fails**
+
+```bash
+cargo test -p minkowski-lsm validate_page_crc_returns_proof_token 2>&1 | head -20
+```
+
+Expected: compile error — either "cannot find type `CrcProof` in this scope" (if the import line is missing), or "mismatched types" where `()` is returned but `CrcProof` is annotated. Either is a valid fail for TDD purposes.
+
+---
+
+## Task 8: `validate_page_crc` — implement change
+
+**Files:**
+- Modify: `crates/minkowski-lsm/src/reader.rs`
+
+- [ ] **Step 1: Import CrcProof**
+
+At the top of `crates/minkowski-lsm/src/reader.rs`, add:
+
+```rust
+use crate::codec::CrcProof;
+```
+
+- [ ] **Step 2: Change `validate_page_crc` signature and body**
+
+Find the current `validate_page_crc` (around line 278):
+
+```rust
+pub fn validate_page_crc(&self, page: &PageRef<'_>) -> Result<(), LsmError> {
+    let item_size = self.item_size_for_slot(page.header().slot)?;
+    let actual_len = page.header().row_count as usize * item_size;
+    let computed = crc32fast::hash(&page.data()[..actual_len]);
+
+    if computed != page.header().page_crc32 {
+        return Err(LsmError::Crc {
+            offset: page.file_offset(),
+            expected: page.header().page_crc32,
+            actual: computed,
+        });
+    }
+    Ok(())
+}
+```
+
+Replace with:
+
+```rust
+/// Validate the CRC of a specific page and return a [`CrcProof`] on success.
+///
+/// The returned token feeds into [`CodecRegistry::decode`]'s `raw_copy_size`
+/// fast path (direct memcpy, skipping rkyv bytecheck). The CRC covers
+/// `row_count * item_size` bytes — the actual data, not zero-padding.
+pub fn validate_page_crc(&self, page: &PageRef<'_>) -> Result<CrcProof, LsmError> {
+    let item_size = self.item_size_for_slot(page.header().slot)?;
+    let actual_len = page.header().row_count as usize * item_size;
+    let payload = &page.data()[..actual_len];
+
+    CrcProof::verify(payload, page.header().page_crc32).ok_or_else(|| LsmError::Crc {
+        offset: page.file_offset(),
+        expected: page.header().page_crc32,
+        actual: crc32fast::hash(payload),
+    })
+}
+```
+
+This reuses `CrcProof::verify` rather than computing the CRC twice on the success path. On the error path, we recompute to populate the `actual` field (same cost as the old code).
+
+- [ ] **Step 3: Update existing caller in the same test module**
+
+Find `validate_page_crc_succeeds` and any other tests that call `validate_page_crc(...).unwrap()` and discard the result. They continue to work because the returned `CrcProof` is ignored. No changes needed unless a test asserts on `Ok(())` explicitly — in that case, change `Ok(())` to `Ok(_)` or extract the proof.
+
+Grep to audit:
+
+```bash
+grep -n "validate_page_crc" crates/minkowski-lsm/src/reader.rs
+```
+
+Expected: 3 existing test callsites + 1 new one. Verify each still compiles in Step 5.
+
+- [ ] **Step 4: Update any external callers**
+
+Grep the workspace:
+
+```bash
+grep -rn "validate_page_crc" crates/ 2>/dev/null
+```
+
+Expected: only in `reader.rs` and the PR 1 test. No external callers today. If any appear, adjust as needed.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cargo test -p minkowski-lsm
+```
+
+Expected: `validate_page_crc_returns_proof_token` now PASSES. All existing tests still pass. 120 tests total.
+
+- [ ] **Step 6: Clippy**
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/minkowski-lsm/src/reader.rs
+git commit -m "feat(lsm): validate_page_crc returns CrcProof on success
+
+SortedRunReader::validate_page_crc now returns Result<CrcProof, LsmError>.
+The returned proof token feeds CodecRegistry::decode's raw_copy_size
+fast path during recovery, preserving zero-copy page restoration.
+
+No callers today consume the proof — this prepares the API for
+recover_world_from_lsm in a subsequent commit."
+```
+
+---
+
+## Task 9: Final verification + push
+
+**Files:** none modified; verification only
+
+- [ ] **Step 1: Full workspace build**
+
+```bash
+cargo check --workspace
+```
+
+Expected: clean.
+
+- [ ] **Step 2: Full workspace test**
+
+```bash
+cargo test --workspace
+```
+
+Expected: all tests pass. `minkowski-lsm` has 120 tests (118 prior + `lsm_manifest_alternate_level_count_compiles_and_works` + `validate_page_crc_returns_proof_token`). `minkowski-persist` test count unchanged.
+
+- [ ] **Step 3: Clippy pedantic**
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Format check**
+
+```bash
+cargo fmt --all --check
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Create branch and push**
+
+Start a new branch based on main:
+
+```bash
+git checkout -b lsm/phase3-pr1-infrastructure main
+# Cherry-pick commits from the working branch if needed, OR
+# if the commits were already on a transient branch, rebase them.
+```
+
+If the PR 1 commits were made on an existing branch (e.g., still on `lsm/phase3-prep-enum-tags` which has PR #167 squashed into main), cherry-pick the new commits onto a fresh branch off main:
+
+```bash
+git log --oneline main..HEAD | tail -n +1  # see commits to pick
+git checkout -b lsm/phase3-pr1-infrastructure main
+git cherry-pick <each-sha>
+```
+
+Then push:
+
+```bash
+git push -u origin lsm/phase3-pr1-infrastructure
+```
+
+- [ ] **Step 6: Open PR**
+
+```bash
+gh pr create --title "refactor(lsm): Phase 3 PR 1 — infrastructure" --body "$(cat <<'EOF'
+## Summary
+
+Phase 3 infrastructure PR — prerequisite for PR 2 (LsmCheckpoint + snapshot cut) and PR 3 (compactor). No behavioral changes; pure refactor + type-system extension.
+
+Design: `docs/plans/2026-04-18-stage3-phase3-compactor-design.md` §PR 1.
+
+### Changes
+
+- Move `CrcProof` + `CodecRegistry` + `CodecError` from `minkowski-persist::codec` → `minkowski-lsm::codec`
+- Flip crate layering: `minkowski-persist` now depends on `minkowski-lsm`
+- Convert `LsmManifest` → `LsmManifest<const N: usize = 4>` with `DefaultManifest` alias
+- Propagate const generic through `ManifestLog::recover`, `flush_and_record`, `apply_entry`, `replay_frames`
+- `SortedRunReader::validate_page_crc` returns `Result<CrcProof, LsmError>` (was `Result<(), LsmError>`)
+- Module-level regime-model documentation on `manifest.rs`
+
+Note: `recover_world_from_lsm` helper is deferred to PR 2, where it lands alongside `LsmCheckpoint`'s first use.
+
+## Test Plan
+- [x] `cargo test --workspace` — all tests pass (120 in lsm, persist unchanged)
+- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
+- [x] `cargo fmt --all --check` — clean
+- [x] New tests: const-generic manifest alternate-N compiles and works; validate_page_crc returns proof token
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 7: Wait for CI to go green (7/7)**
+
+Monitor via `gh pr checks`. All gates must pass: Format, Clippy, Test, ThreadSanitizer, Loom, CI, Claude Code Review.
+
+- [ ] **Step 8: User squash-merges**
+
+This is an explicit user action; the plan ends here. Post-merge cleanup (branch deletion, memory updates, etc.) is handled outside this plan.
+
+---
+
+## Known Risks
+
+- **Zero-copy regression risk**: `validate_page_crc`'s return-type change is mechanical. In PR 1 there are no production callers of `validate_page_crc` that consume the proof — the only post-change consumers are tests. PR 2 is where the zero-copy path is actually exercised end-to-end (via `recover_world_from_lsm`), and that's where regression becomes possible. Plan-level mitigation for PR 1: the signature change compiles and tests demonstrate the proof is producible. End-to-end zero-copy verification lives in PR 2.
+
+- **const generic inference failures in tests**: introducing `LsmManifest<const N: usize = 4>` may cause inference failures in test bindings that previously worked without annotations. The plan's test-update steps assume inference picks N=4 from the default; if a specific test requires `LsmManifest<4>` to be explicit, the task steps flag it.
+
+- **`replicate.rs` example**: PR 1 does not touch `examples/replicate.rs`. Snapshot-based APIs are still in use there. PR 1 compiles as-is; PR 2 stubs or rewrites the example.


### PR DESCRIPTION
## Summary

Phase 3 infrastructure PR — prerequisite for PR 2 (LsmCheckpoint + snapshot cut) and PR 3 (compactor). No behavioral changes; pure refactor + type-system extension.

Design: [`docs/plans/2026-04-18-stage3-phase3-compactor-design.md`](./docs/plans/2026-04-18-stage3-phase3-compactor-design.md) §PR 1.
Plan: [`docs/plans/2026-04-18-stage3-phase3-pr1-infrastructure-implementation-plan.md`](./docs/plans/2026-04-18-stage3-phase3-pr1-infrastructure-implementation-plan.md).

### Changes

- **Crate layering flipped**: `CrcProof`, `CodecRegistry`, `CodecError`, `ComponentSchema` move from `minkowski-persist::codec` → `minkowski-lsm::codec`. `minkowski-persist` now depends on `minkowski-lsm`. Reflects the post-Phase-3 conceptual stack: `lsm` is the load-bearing storage layer, `persist` is operations over it.
- **`LsmManifest<const N: usize = 4>`**: const-generic level count with `DefaultManifest` alias. Workload regime documented at module level — 4 levels fit minkowski's expected ~100× RAM ceiling; `LsmManifest<7>` available for TigerBeetle-style ledger workloads. Level bounds checks moved from `Level::new` (now checks a generous `MAX_LEVELS = 32` sanity bound) to `LsmManifest<N>` method boundaries (`add_run`, `remove_run`, `promote_run`, `runs_at_level`).
- **`SortedRunReader::validate_page_crc`** returns `Result<CrcProof, LsmError>` (was `Result<(), LsmError>`). The proof token is the input to `CodecRegistry::decode`'s `raw_copy_size` fast path. PR 2's `recover_world_from_lsm` will consume it to preserve the zero-copy recovery path that the old snapshot restore had.

### Scope discipline

- `recover_world_from_lsm` helper is **deferred to PR 2** — the page-to-archetype plumbing pairs naturally with `LsmCheckpoint`'s first consumer. PR 1 lands the signature change that makes PR 2's zero-copy route mechanical.
- `Snapshot` / `AutoCheckpoint` / `save_to_bytes` removals are PR 2.
- `CompactionCommit` manifest entry + `World::compact_one()` are PR 3.

## Test Plan

- [x] `cargo test --workspace` — all pass. `minkowski-lsm` goes 133 → 135 tests (+2 new: const-generic alternate-N compiles/works, validate_page_crc returns proof token). Pre-existing `minkowski-observe` failures on `main` are unchanged.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Manual: verified `LsmManifest::<7>::new()` constructs and `DefaultManifest = LsmManifest<4>` alias resolves correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)