### PR TITLE
feat(lsm): Phase 4 — BlockedBloomFilter for sorted-run page lookups

### DIFF
--- a/crates/minkowski-lsm/src/bloom.rs
+++ b/crates/minkowski-lsm/src/bloom.rs
@@ -1,0 +1,360 @@
+//! Cache-line-blocked bloom filter for sorted-run page membership.
+//!
+//! One `BlockedBloomFilter` per sorted run. Each 64-byte block holds 8 u64
+//! words; each key sets 1 bit per word (8 bits total). Probing touches
+//! exactly one cache line regardless of the number of hash functions.
+
+use crate::error::LsmError;
+use std::io::Write;
+
+const BITS_PER_KEY: usize = 10;
+const BLOCK_BITS: usize = 512;
+const BLOCK_BYTES: usize = 64;
+const WORDS_PER_BLOCK: usize = 8;
+const NUM_HASHES: usize = 8;
+
+#[repr(C, align(64))]
+#[derive(Clone)]
+struct Block {
+    words: [u64; WORDS_PER_BLOCK],
+}
+
+impl Block {
+    const ZERO: Block = Block {
+        words: [0u64; WORDS_PER_BLOCK],
+    };
+}
+
+#[repr(C)]
+struct BloomHeader {
+    num_blocks: [u8; 4],
+    seed: [u8; 8],
+    _padding: [u8; 4],
+}
+
+impl BloomHeader {
+    fn to_bytes(&self) -> &[u8; 16] {
+        unsafe { &*(self as *const Self as *const [u8; 16]) }
+    }
+
+    fn from_bytes(bytes: &[u8; 16]) -> Self {
+        unsafe { std::ptr::read_unaligned(bytes.as_ptr() as *const Self) }
+    }
+}
+
+pub struct BlockedBloomFilter {
+    blocks: Vec<Block>,
+    num_blocks: u32,
+    seed: u64,
+}
+
+fn splitmix64(state: u64) -> u64 {
+    let mut z = state.wrapping_add(0x9e3779b97f4a7c15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94d049bb13311177);
+    z ^ (z >> 31)
+}
+
+pub fn pack_page_key(arch_id: u16, slot: u16, page_index: u16) -> u64 {
+    ((arch_id as u64) << 32) | ((slot as u64) << 16) | (page_index as u64)
+}
+
+impl BlockedBloomFilter {
+    pub fn new(expected_keys: usize, seed: u64) -> Self {
+        if expected_keys == 0 {
+            return Self {
+                blocks: Vec::new(),
+                num_blocks: 0,
+                seed,
+            };
+        }
+        let num_blocks = (expected_keys * BITS_PER_KEY).div_ceil(BLOCK_BITS);
+        let num_blocks = num_blocks.max(1) as u32;
+        let blocks = vec![Block::ZERO; num_blocks as usize];
+        Self {
+            blocks,
+            num_blocks,
+            seed,
+        }
+    }
+
+    pub fn insert(&mut self, key: u64) {
+        if self.num_blocks == 0 {
+            return;
+        }
+        let h1 = splitmix64(key ^ self.seed);
+        let block_idx = (h1 % self.num_blocks as u64) as usize;
+        let h2 = splitmix64(h1);
+        let h3 = splitmix64(h2);
+
+        let block = &mut self.blocks[block_idx];
+        for i in 0..NUM_HASHES {
+            let bit = ((h2 >> (i * 6)) ^ (h3 >> ((7 - i) * 6))) & 0x3F;
+            block.words[i] |= 1u64 << bit;
+        }
+    }
+
+    pub fn contains(&self, key: u64) -> bool {
+        if self.num_blocks == 0 {
+            return true;
+        }
+        let h1 = splitmix64(key ^ self.seed);
+        let block_idx = (h1 % self.num_blocks as u64) as usize;
+        let h2 = splitmix64(h1);
+        let h3 = splitmix64(h2);
+
+        let block = &self.blocks[block_idx];
+        for i in 0..NUM_HASHES {
+            let bit = ((h2 >> (i * 6)) ^ (h3 >> ((7 - i) * 6))) & 0x3F;
+            if block.words[i] & (1u64 << bit) == 0 {
+                return false;
+            }
+        }
+        true
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.num_blocks == 0
+    }
+
+    pub fn byte_size(&self) -> usize {
+        if self.num_blocks == 0 {
+            return 0;
+        }
+        16 + (self.num_blocks as usize) * BLOCK_BYTES
+    }
+
+    pub fn num_blocks(&self) -> u32 {
+        self.num_blocks
+    }
+
+    pub fn seed(&self) -> u64 {
+        self.seed
+    }
+
+    pub fn write_to(&self, w: &mut impl Write) -> Result<(), LsmError> {
+        assert!(self.num_blocks > 0, "should not serialize empty filter");
+        let header = BloomHeader {
+            num_blocks: self.num_blocks.to_le_bytes(),
+            seed: self.seed.to_le_bytes(),
+            _padding: [0u8; 4],
+        };
+        w.write_all(header.to_bytes())?;
+        for block in &self.blocks {
+            for &word in &block.words {
+                w.write_all(&word.to_le_bytes())?;
+            }
+        }
+        Ok(())
+    }
+}
+
+pub struct BloomView {
+    blocks_ptr: *const Block,
+    num_blocks: u32,
+    seed: u64,
+    _owned: Option<Vec<Block>>,
+}
+
+// SAFETY: BloomView holds a raw pointer into either the mmap (immutable after
+// open, thread-safe like the rest of SortedRunReader) or an owned Vec<Block>
+// (also thread-safe for reads). No &mut access exists after construction.
+unsafe impl Send for BloomView {}
+unsafe impl Sync for BloomView {}
+
+impl BloomView {
+    pub fn from_bytes(buf: &[u8], offset: usize) -> Result<Self, LsmError> {
+        let header_size = 16;
+        let header_end = offset
+            .checked_add(header_size)
+            .ok_or_else(|| LsmError::Format("bloom header offset overflow".to_owned()))?;
+        if header_end > buf.len() {
+            return Err(LsmError::Format(
+                "bloom header extends beyond file".to_owned(),
+            ));
+        }
+        let header_bytes: &[u8; 16] = buf[offset..header_end].try_into().expect("16 bytes");
+        let header = BloomHeader::from_bytes(header_bytes);
+
+        let num_blocks = u32::from_le_bytes(header.num_blocks);
+        let seed = u64::from_le_bytes(header.seed);
+
+        if num_blocks == 0 {
+            return Ok(Self {
+                blocks_ptr: std::ptr::null(),
+                num_blocks: 0,
+                seed,
+                _owned: None,
+            });
+        }
+
+        let blocks_offset = header_end;
+        let blocks_len = (num_blocks as usize) * BLOCK_BYTES;
+        let blocks_end = blocks_offset
+            .checked_add(blocks_len)
+            .ok_or_else(|| LsmError::Format("bloom blocks offset overflow".to_owned()))?;
+        if blocks_end > buf.len() {
+            return Err(LsmError::Format(
+                "bloom blocks extend beyond file".to_owned(),
+            ));
+        }
+
+        let blocks_ptr = buf[blocks_offset..].as_ptr() as *const Block;
+        let aligned = (blocks_ptr as usize).is_multiple_of(64);
+
+        if aligned {
+            Ok(Self {
+                blocks_ptr,
+                num_blocks,
+                seed,
+                _owned: None,
+            })
+        } else {
+            let owned: Vec<Block> = buf[blocks_offset..blocks_end]
+                .chunks_exact(BLOCK_BYTES)
+                .map(|chunk| {
+                    let mut block = Block::ZERO;
+                    for i in 0..WORDS_PER_BLOCK {
+                        let start = i * 8;
+                        block.words[i] = u64::from_le_bytes(
+                            chunk[start..start + 8].try_into().expect("8 bytes"),
+                        );
+                    }
+                    block
+                })
+                .collect();
+            let ptr = owned.as_ptr();
+            Ok(Self {
+                blocks_ptr: ptr,
+                num_blocks,
+                seed,
+                _owned: Some(owned),
+            })
+        }
+    }
+
+    pub fn contains(&self, key: u64) -> bool {
+        if self.num_blocks == 0 {
+            return true;
+        }
+        let h1 = splitmix64(key ^ self.seed);
+        let block_idx = (h1 % self.num_blocks as u64) as usize;
+        let h2 = splitmix64(h1);
+        let h3 = splitmix64(h2);
+
+        unsafe {
+            let block = &*self.blocks_ptr.add(block_idx);
+            for i in 0..NUM_HASHES {
+                let bit = ((h2 >> (i * 6)) ^ (h3 >> ((7 - i) * 6))) & 0x3F;
+                if block.words[i] & (1u64 << bit) == 0 {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn insert_and_contains_zero_false_negatives() {
+        let mut filter = BlockedBloomFilter::new(1000, 42);
+        let mut keys = HashSet::new();
+        for i in 0..1000u64 {
+            filter.insert(i);
+            keys.insert(i);
+        }
+        for key in &keys {
+            assert!(filter.contains(*key), "false negative for key {key}");
+        }
+    }
+
+    #[test]
+    fn empty_filter_returns_true_for_all_probes() {
+        let filter = BlockedBloomFilter::new(0, 42);
+        assert!(filter.is_empty());
+        assert!(filter.contains(0), "empty filter must return true");
+        assert!(filter.contains(u64::MAX), "empty filter must return true");
+    }
+
+    #[test]
+    fn seed_determinism() {
+        let mut a = BlockedBloomFilter::new(100, 99);
+        let mut b = BlockedBloomFilter::new(100, 99);
+        for i in 0..100u64 {
+            a.insert(i);
+            b.insert(i);
+        }
+        for i in 0..200u64 {
+            assert_eq!(a.contains(i), b.contains(i), "mismatch at key {i}");
+        }
+    }
+
+    #[test]
+    fn pack_page_key_layout() {
+        let key = pack_page_key(1, 2, 3);
+        assert_eq!((key >> 32) as u16, 1, "arch_id");
+        assert_eq!(((key >> 16) & 0xFFFF) as u16, 2, "slot");
+        assert_eq!((key & 0xFFFF) as u16, 3, "page_index");
+    }
+
+    #[test]
+    fn pack_page_key_distinguishes_slots() {
+        let a = pack_page_key(0, 1, 5);
+        let b = pack_page_key(0, 2, 5);
+        assert_ne!(a, b, "different slots must produce different keys");
+    }
+
+    #[test]
+    fn false_positive_rate_within_bounds() {
+        let n = 10_000usize;
+        let mut filter = BlockedBloomFilter::new(n, 12345);
+        let inserted: HashSet<u64> = (0..n as u64).collect();
+        for &k in &inserted {
+            filter.insert(k);
+        }
+
+        let mut fp = 0usize;
+        let probes = 100_000u64;
+        for p in (n as u64)..((n as u64) + probes) {
+            if filter.contains(p) {
+                fp += 1;
+            }
+        }
+        let fpr = fp as f64 / probes as f64;
+        assert!(fpr < 0.02, "FPR {fpr:.4} exceeds 2% threshold");
+    }
+
+    #[test]
+    fn serialization_round_trip() {
+        let mut filter = BlockedBloomFilter::new(500, 77);
+        let keys: Vec<u64> = (0..500).collect();
+        for &k in &keys {
+            filter.insert(k);
+        }
+
+        let mut buf = Vec::new();
+        filter.write_to(&mut buf).unwrap();
+
+        let view = BloomView::from_bytes(&buf, 0).unwrap();
+        for &k in &keys {
+            assert!(
+                view.contains(k),
+                "false negative for key {k} after round-trip"
+            );
+        }
+
+        let mut fp = 0;
+        for p in 500..1500u64 {
+            if view.contains(p) {
+                fp += 1;
+            }
+        }
+        let fpr = fp as f64 / 1000.0;
+        assert!(fpr < 0.02, "FPR after round-trip {fpr:.4} exceeds 2%");
+    }
+}

--- a/crates/minkowski-lsm/src/bloom.rs
+++ b/crates/minkowski-lsm/src/bloom.rs
@@ -5,7 +5,8 @@
 //! exactly one cache line regardless of the number of hash functions.
 
 use crate::error::LsmError;
-use std::io::Write;
+use crate::format::IndexEntry;
+use std::io::{Seek, Write};
 
 const BITS_PER_KEY: usize = 10;
 const BLOCK_BITS: usize = 512;
@@ -133,7 +134,11 @@ impl BlockedBloomFilter {
     }
 
     pub fn write_to(&self, w: &mut impl Write) -> Result<(), LsmError> {
-        assert!(self.num_blocks > 0, "should not serialize empty filter");
+        if self.num_blocks == 0 {
+            return Err(LsmError::Format(
+                "cannot serialize empty bloom filter".to_owned(),
+            ));
+        }
         let header = BloomHeader {
             num_blocks: self.num_blocks.to_le_bytes(),
             seed: self.seed.to_le_bytes(),
@@ -149,7 +154,7 @@ impl BlockedBloomFilter {
     }
 }
 
-pub struct BloomView {
+pub(crate) struct BloomView {
     blocks_ptr: *const Block,
     num_blocks: u32,
     seed: u64,
@@ -163,7 +168,7 @@ unsafe impl Send for BloomView {}
 unsafe impl Sync for BloomView {}
 
 impl BloomView {
-    pub fn from_bytes(buf: &[u8], offset: usize) -> Result<Self, LsmError> {
+    pub(crate) fn from_bytes(buf: &[u8], offset: usize) -> Result<Self, LsmError> {
         let header_size = 16;
         let header_end = offset
             .checked_add(header_size)
@@ -189,7 +194,9 @@ impl BloomView {
         }
 
         let blocks_offset = header_end;
-        let blocks_len = (num_blocks as usize) * BLOCK_BYTES;
+        let blocks_len = (num_blocks as usize)
+            .checked_mul(BLOCK_BYTES)
+            .ok_or_else(|| LsmError::Format("bloom blocks length overflow".to_owned()))?;
         let blocks_end = blocks_offset
             .checked_add(blocks_len)
             .ok_or_else(|| LsmError::Format("bloom blocks offset overflow".to_owned()))?;
@@ -203,6 +210,10 @@ impl BloomView {
         let aligned = (blocks_ptr as usize).is_multiple_of(64);
 
         if aligned {
+            // NOTE: zero-copy path reads Block words as native-endian u64.
+            // `write_to` serializes words in little-endian, so this is
+            // correct only on LE targets (x86-64, AArch64 in LE mode).
+            // The unaligned fallback below does explicit LE decoding.
             Ok(Self {
                 blocks_ptr,
                 num_blocks,
@@ -253,6 +264,33 @@ impl BloomView {
         }
         true
     }
+}
+
+pub(crate) fn write_bloom_section(
+    w: &mut (impl Write + Seek),
+    index_entries: &[IndexEntry],
+    seed: u64,
+) -> Result<u64, LsmError> {
+    if index_entries.is_empty() {
+        return Ok(0);
+    }
+    let mut bloom = BlockedBloomFilter::new(index_entries.len(), seed);
+    for entry in index_entries {
+        bloom.insert(pack_page_key(entry.arch_id, entry.slot, entry.page_index));
+    }
+    let mut offset = w.stream_position()?;
+    if offset % 64 != 0 {
+        let pad = 64 - (offset as usize % 64);
+        const ZEROS: [u8; 64] = [0u8; 64];
+        w.write_all(&ZEROS[..pad])?;
+        offset = w.stream_position()?;
+    }
+    assert!(
+        offset % 64 == 0,
+        "bloom filter section must be 64-byte aligned"
+    );
+    bloom.write_to(w)?;
+    Ok(offset)
 }
 
 #[cfg(test)]

--- a/crates/minkowski-lsm/src/compaction_writer.rs
+++ b/crates/minkowski-lsm/src/compaction_writer.rs
@@ -28,7 +28,7 @@ use std::fs;
 use std::io::{BufWriter, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
-use crate::bloom::{BlockedBloomFilter, pack_page_key};
+use crate::bloom;
 use crate::error::LsmError;
 use crate::format::{
     ENTITY_SLOT, Footer, Header, IndexEntry, MAGIC, PAGE_SIZE, PageHeader, VERSION,
@@ -512,26 +512,7 @@ impl<'a> CompactionWriter<'a> {
         }
 
         // ── 9b. Bloom filter — built from all page keys in the index.
-        let bloom_filter_offset = if index_entries.is_empty() {
-            0u64
-        } else {
-            let bloom_seed = seq_lo;
-            let mut bloom = BlockedBloomFilter::new(index_entries.len(), bloom_seed);
-            for entry in &index_entries {
-                bloom.insert(pack_page_key(entry.arch_id, entry.slot, entry.page_index));
-            }
-            let mut offset = w.stream_position()?;
-            if offset % 64 != 0 {
-                write_zeros(&mut w, 64 - (offset as usize % 64))?;
-                offset = w.stream_position()?;
-            }
-            assert!(
-                offset % 64 == 0,
-                "bloom filter section must be 64-byte aligned"
-            );
-            bloom.write_to(&mut w)?;
-            offset
-        };
+        let bloom_filter_offset = bloom::write_bloom_section(&mut w, &index_entries, seq_lo)?;
 
         // ── 10. Write footer (CRCs patched later) ─────────────────────────────
         let footer = Footer {

--- a/crates/minkowski-lsm/src/compaction_writer.rs
+++ b/crates/minkowski-lsm/src/compaction_writer.rs
@@ -28,6 +28,7 @@ use std::fs;
 use std::io::{BufWriter, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
+use crate::bloom::{BlockedBloomFilter, pack_page_key};
 use crate::error::LsmError;
 use crate::format::{
     ENTITY_SLOT, Footer, Header, IndexEntry, MAGIC, PAGE_SIZE, PageHeader, VERSION,
@@ -510,12 +511,34 @@ impl<'a> CompactionWriter<'a> {
             w.write_all(entry.as_bytes())?;
         }
 
+        // ── 9b. Bloom filter — built from all page keys in the index.
+        let bloom_filter_offset = if index_entries.is_empty() {
+            0u64
+        } else {
+            let bloom_seed = seq_lo;
+            let mut bloom = BlockedBloomFilter::new(index_entries.len(), bloom_seed);
+            for entry in &index_entries {
+                bloom.insert(pack_page_key(entry.arch_id, entry.slot, entry.page_index));
+            }
+            let mut offset = w.stream_position()?;
+            if offset % 64 != 0 {
+                write_zeros(&mut w, 64 - (offset as usize % 64))?;
+                offset = w.stream_position()?;
+            }
+            assert!(
+                offset % 64 == 0,
+                "bloom filter section must be 64-byte aligned"
+            );
+            bloom.write_to(&mut w)?;
+            offset
+        };
+
         // ── 10. Write footer (CRCs patched later) ─────────────────────────────
         let footer = Footer {
             sparse_index_offset,
             sparse_index_count: index_entries.len() as u64,
             schema_offset,
-            bloom_filter_offset: 0,
+            bloom_filter_offset,
             total_crc32: 0,
             reserved: [0u8; 28],
         };
@@ -1163,6 +1186,49 @@ mod tests {
         assert!(
             (x - 2.0_f32).abs() < f32::EPSILON,
             "expected Pos.x == 2.0 from newer run, got {x}"
+        );
+    }
+
+    // ── Task 4 test: compaction rebuilds bloom filter ─────────────────────────
+
+    #[test]
+    fn compaction_rebuilds_bloom_filter() {
+        let mut world = World::new();
+        let _e1 = world.spawn((Pos { x: 1.0, y: 0.0 },));
+        let _e2 = world.spawn((Pos { x: 2.0, y: 0.0 },));
+
+        let (_dir_a, reader_a) = flush_to_reader(&world, 1, 5);
+        let (_dir_b, reader_b) = flush_to_reader(&world, 6, 10);
+
+        let arch_info = arch_component_names(&reader_a);
+        assert_eq!(arch_info.len(), 1);
+        let (arch_a, comp_names) = &arch_info[0];
+        let arch_b = find_archetype_by_components(&reader_b, &[comp_names[0].as_str()])
+            .expect("run B must have the Pos archetype");
+
+        let out_dir = tempfile::tempdir().unwrap();
+        let out_path = out_dir.path().join("1-10.compact.run");
+        let seq_range = SeqRange::new(SeqNo::from(1u64), SeqNo::from(10u64)).unwrap();
+
+        let writer = CompactionWriter::new(
+            vec![&reader_b, &reader_a],
+            vec![vec![Some(arch_b), Some(*arch_a)]],
+            vec![comp_names.clone()],
+            out_path.clone(),
+            seq_range,
+        )
+        .unwrap();
+
+        writer.write().unwrap();
+
+        let data = std::fs::read(&out_path).unwrap();
+        let footer_start = data.len() - 64;
+        let footer = crate::format::Footer::from_bytes(
+            data[footer_start..footer_start + 64].try_into().unwrap(),
+        );
+        assert!(
+            footer.bloom_filter_offset > 0,
+            "compacted run must have a bloom filter"
         );
     }
 }

--- a/crates/minkowski-lsm/src/lib.rs
+++ b/crates/minkowski-lsm/src/lib.rs
@@ -13,4 +13,5 @@ pub(crate) mod schema_match;
 pub mod types;
 pub mod writer;
 
+pub use bloom::{BlockedBloomFilter, BloomView, pack_page_key};
 pub use compactor::{COMPACTION_TRIGGER, CompactionReport, compact_one, compact_one_observed};

--- a/crates/minkowski-lsm/src/lib.rs
+++ b/crates/minkowski-lsm/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod bloom;
 pub mod codec;
 pub(crate) mod compaction_writer;
 pub mod compactor;

--- a/crates/minkowski-lsm/src/lib.rs
+++ b/crates/minkowski-lsm/src/lib.rs
@@ -13,5 +13,5 @@ pub(crate) mod schema_match;
 pub mod types;
 pub mod writer;
 
-pub use bloom::{BlockedBloomFilter, BloomView, pack_page_key};
+pub use bloom::{BlockedBloomFilter, pack_page_key};
 pub use compactor::{COMPACTION_TRIGGER, CompactionReport, compact_one, compact_one_observed};

--- a/crates/minkowski-lsm/src/reader.rs
+++ b/crates/minkowski-lsm/src/reader.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::Path;
 
+use crate::bloom::BloomView;
 use crate::codec::CrcProof;
 use crate::error::LsmError;
 use crate::format::*;
@@ -59,6 +60,7 @@ pub struct SortedRunReader {
     data: MappedData,
     schema: SchemaSection,
     index: Vec<IndexEntry>,
+    bloom: Option<BloomView>,
     sequence_range: SeqRange,
     page_count: u64,
 }
@@ -70,6 +72,7 @@ const MIN_FILE_SIZE: usize = 128;
 struct ParsedMetadata {
     schema: SchemaSection,
     index: Vec<IndexEntry>,
+    bloom: Option<BloomView>,
     sequence_range: SeqRange,
     page_count: u64,
 }
@@ -180,9 +183,17 @@ fn validate_and_parse(buf: &[u8]) -> Result<ParsedMetadata, LsmError> {
         index.push(IndexEntry::from_bytes(entry_bytes));
     }
 
+    let bloom = if footer.bloom_filter_offset != 0 {
+        let offset = footer.bloom_filter_offset as usize;
+        Some(BloomView::from_bytes(buf, offset)?)
+    } else {
+        None
+    };
+
     Ok(ParsedMetadata {
         schema,
         index,
+        bloom,
         sequence_range,
         page_count,
     })
@@ -198,6 +209,7 @@ impl SortedRunReader {
             data,
             schema: parsed.schema,
             index: parsed.index,
+            bloom: parsed.bloom,
             sequence_range: parsed.sequence_range,
             page_count: parsed.page_count,
         })
@@ -385,6 +397,21 @@ impl SortedRunReader {
     /// Number of entries in the sparse index.
     pub fn index_len(&self) -> usize {
         self.index.len()
+    }
+
+    /// Check if a page *might* be present in this sorted run.
+    ///
+    /// Returns `true` if the page might exist (could be a false positive).
+    /// Returns `false` if the page is definitely not present (no false negatives).
+    ///
+    /// When no bloom filter exists (old files without one), returns `true`
+    /// conservatively — the caller should fall through to `get_page` or
+    /// binary search.
+    pub fn contains_page(&self, arch_id: u16, slot: u16, page_index: u16) -> bool {
+        match &self.bloom {
+            Some(view) => view.contains(crate::bloom::pack_page_key(arch_id, slot, page_index)),
+            None => true,
+        }
     }
 
     /// Returns the sorted, deduplicated list of archetype IDs present in this sorted run.
@@ -921,6 +948,57 @@ mod tests {
             found_via_entity_pages,
             &[100, 200, 300, 400],
             "entity_pages must find all entities across sparse pages"
+        );
+    }
+
+    #[test]
+    fn bloom_filter_matches_index() {
+        let (_dir, path, _world) = flush_world_with_pos(10);
+        let reader = SortedRunReader::open(&path).unwrap();
+
+        for entry in &reader.index {
+            assert!(
+                reader.contains_page(entry.arch_id, entry.slot, entry.page_index),
+                "bloom filter must return true for indexed page ({}, {}, {})",
+                entry.arch_id,
+                entry.slot,
+                entry.page_index
+            );
+        }
+    }
+
+    #[test]
+    fn bloom_filter_rejects_absent_pages() {
+        let (_dir, path, _world) = flush_world_with_pos(5);
+        let reader = SortedRunReader::open(&path).unwrap();
+
+        let mut rejected = 0;
+        for arch_id in 200u16..210 {
+            for page_index in 0u16..10 {
+                if !reader.contains_page(arch_id, 0, page_index) {
+                    rejected += 1;
+                }
+            }
+        }
+        assert!(
+            rejected > 0,
+            "bloom filter must reject some absent page keys"
+        );
+    }
+
+    #[test]
+    fn old_run_without_bloom_falls_through() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = build_sparse_entity_page_file(dir.path());
+        let reader = SortedRunReader::open(&path).unwrap();
+
+        assert!(
+            reader.contains_page(0, ENTITY_SLOT, 0),
+            "contains_page must return true when no bloom filter is present"
+        );
+        assert!(
+            reader.contains_page(255, 255, 255),
+            "contains_page must return true when no bloom filter is present"
         );
     }
 }

--- a/crates/minkowski-lsm/src/writer.rs
+++ b/crates/minkowski-lsm/src/writer.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 use minkowski::World;
 
+use crate::bloom::{BlockedBloomFilter, pack_page_key};
 use crate::error::LsmError;
 use crate::format::*;
 use crate::schema::SchemaSection;
@@ -336,12 +337,34 @@ pub fn flush_observed(
         w.write_all(entry.as_bytes())?;
     }
 
+    // (e2) Bloom filter — built from all page keys in the index.
+    let bloom_filter_offset = if index_entries.is_empty() {
+        0u64
+    } else {
+        let bloom_seed = seq_lo;
+        let mut bloom = BlockedBloomFilter::new(index_entries.len(), bloom_seed);
+        for entry in &index_entries {
+            bloom.insert(pack_page_key(entry.arch_id, entry.slot, entry.page_index));
+        }
+        let mut offset = w.stream_position()?;
+        if offset % 64 != 0 {
+            write_zeros(&mut w, 64 - (offset as usize % 64))?;
+            offset = w.stream_position()?;
+        }
+        assert!(
+            offset % 64 == 0,
+            "bloom filter section must be 64-byte aligned"
+        );
+        bloom.write_to(&mut w)?;
+        offset
+    };
+
     // (f) Footer
     let footer = Footer {
         sparse_index_offset,
         sparse_index_count: index_entries.len() as u64,
         schema_offset,
-        bloom_filter_offset: 0,
+        bloom_filter_offset,
         total_crc32: 0,
         reserved: [0u8; 28],
     };
@@ -565,5 +588,32 @@ mod tests {
         assert!(seen.contains(&e1.to_bits()), "e1 not observed");
         assert!(seen.contains(&e2.to_bits()), "e2 not observed");
         assert!(seen.contains(&e3.to_bits()), "e3 not observed");
+    }
+
+    #[test]
+    fn flush_produces_run_with_bloom_filter() {
+        let mut world = World::new();
+        world.spawn((Pos { x: 1.0, y: 2.0 },));
+        world.spawn((Pos { x: 3.0, y: 4.0 },));
+        world.spawn((Pos { x: 5.0, y: 6.0 },));
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = flush(
+            &world,
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(0u64)).unwrap(),
+            dir.path(),
+        )
+        .unwrap()
+        .unwrap();
+
+        let data = std::fs::read(&path).unwrap();
+        let footer_start = data.len() - 64;
+        let footer = crate::format::Footer::from_bytes(
+            data[footer_start..footer_start + 64].try_into().unwrap(),
+        );
+        assert!(
+            footer.bloom_filter_offset > 0,
+            "bloom_filter_offset must be non-zero for dirty flush"
+        );
     }
 }

--- a/crates/minkowski-lsm/src/writer.rs
+++ b/crates/minkowski-lsm/src/writer.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use minkowski::World;
 
-use crate::bloom::{BlockedBloomFilter, pack_page_key};
+use crate::bloom;
 use crate::error::LsmError;
 use crate::format::*;
 use crate::schema::SchemaSection;
@@ -338,26 +338,7 @@ pub fn flush_observed(
     }
 
     // (e2) Bloom filter — built from all page keys in the index.
-    let bloom_filter_offset = if index_entries.is_empty() {
-        0u64
-    } else {
-        let bloom_seed = seq_lo;
-        let mut bloom = BlockedBloomFilter::new(index_entries.len(), bloom_seed);
-        for entry in &index_entries {
-            bloom.insert(pack_page_key(entry.arch_id, entry.slot, entry.page_index));
-        }
-        let mut offset = w.stream_position()?;
-        if offset % 64 != 0 {
-            write_zeros(&mut w, 64 - (offset as usize % 64))?;
-            offset = w.stream_position()?;
-        }
-        assert!(
-            offset % 64 == 0,
-            "bloom filter section must be 64-byte aligned"
-        );
-        bloom.write_to(&mut w)?;
-        offset
-    };
+    let bloom_filter_offset = bloom::write_bloom_section(&mut w, &index_entries, seq_lo)?;
 
     // (f) Footer
     let footer = Footer {


### PR DESCRIPTION
## Summary

- Add `BlockedBloomFilter` core: cache-line-blocked (64-byte aligned blocks), enhanced double-hashing with per-word entropy via `splitmix64`, ~0.84% FPR at 10 bits/key
- Serialize bloom filters in sorted-run files between the sparse index and footer, using the existing `Footer.bloom_filter_offset` field (backward-compatible — old files with offset 0 fall through to binary search)
- Flush writer and compaction writer build filters from completed `index_entries` (page keys packed as `(arch_id, slot, page_index)` → u64), serialize with 64-byte alignment padding
- Reader parses bloom filter zero-copy from the mmap via `BloomView` (falls back to heap copy if mmap alignment insufficient), exposes `contains_page(arch_id, slot, page_index) -> bool`
- 7 bloom unit tests (zero false negatives, FPR < 2%, round-trip, empty filter, seed determinism, key packing) + 5 integration tests (flush produces bloom, bloom matches index, bloom rejects absent pages, old-file fallback, compaction rebuilds bloom)

## Design doc

`docs/plans/2026-05-03-stage3-phase4-blocked-bloom-filter-design.md`

## Test plan

- `cargo test -p minkowski-lsm` — 159 unit + 38 integration tests all pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean