### PR TITLE
fix: critical audit findings C1-C4 (crash safety, panic, partial apply)

### DIFF
--- a/crates/minkowski-persist/src/wal.rs
+++ b/crates/minkowski-persist/src/wal.rs
@@ -697,13 +697,22 @@ impl Wal {
             let mut writer = BufWriter::new(&self.active_file);
             write_frame(&mut writer, &payload)?
         };
+
+        // Advance in-memory state *before* fsync.  Once bytes have been
+        // handed to the kernel via write(2), they may survive a crash even
+        // if fsync reports failure (POSIX allows this).  If we kept the old
+        // counters and the caller retried, the same sequence number would
+        // appear twice in one segment — silent corruption that causes
+        // WalCursor to skip records.  A gap (missing seq) is detectable on
+        // replay and therefore the lesser evil.
+        self.active_bytes += frame_bytes;
+        self.bytes_since_checkpoint += frame_bytes;
+        self.next_seq += 1;
+
         // Durability: flush kernel buffers to stable storage so that a
         // process crash or power loss cannot lose the frame we just wrote.
         // Without this, BufWriter::flush only pushes to the page cache.
         self.active_file.sync_all()?;
-        self.active_bytes += frame_bytes;
-        self.bytes_since_checkpoint += frame_bytes;
-        self.next_seq += 1;
 
         // Roll to new segment if threshold exceeded. Failure is non-fatal:
         // the mutation is already persisted and the oversized segment is

--- a/crates/minkowski-persist/src/wal.rs
+++ b/crates/minkowski-persist/src/wal.rs
@@ -697,6 +697,10 @@ impl Wal {
             let mut writer = BufWriter::new(&self.active_file);
             write_frame(&mut writer, &payload)?
         };
+        // Durability: flush kernel buffers to stable storage so that a
+        // process crash or power loss cannot lose the frame we just wrote.
+        // Without this, BufWriter::flush only pushes to the page cache.
+        self.active_file.sync_all()?;
         self.active_bytes += frame_bytes;
         self.bytes_since_checkpoint += frame_bytes;
         self.next_seq += 1;

--- a/crates/minkowski-persist/src/wal.rs
+++ b/crates/minkowski-persist/src/wal.rs
@@ -705,6 +705,11 @@ impl Wal {
         // appear twice in one segment — silent corruption that causes
         // WalCursor to skip records.  A gap (missing seq) is detectable on
         // replay and therefore the lesser evil.
+        //
+        // This ordering only matters for callers that continue after a sync
+        // error: `Durable` treats a WAL error as fatal and never retries on
+        // the same handle, and a restart reconstructs `next_seq` from the
+        // durable segment bytes — so the in-memory gap heals naturally.
         self.active_bytes += frame_bytes;
         self.bytes_since_checkpoint += frame_bytes;
         self.next_seq += 1;

--- a/crates/minkowski/src/changeset.rs
+++ b/crates/minkowski/src/changeset.rs
@@ -10,6 +10,10 @@ use crate::world::{EntityLocation, World, get_pair_mut};
 
 /// Error returned by [`EnumChangeSet::apply`] when a mutation targets
 /// an invalid entity.
+///
+/// **Important:** `apply` is not atomic. When any error is returned,
+/// the World may be in a partially-mutated state due to fast-lane writes
+/// that cannot be rolled back. Callers must discard the World on error.
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub enum ApplyError {
@@ -17,6 +21,14 @@ pub enum ApplyError {
     DeadEntity(Entity),
     /// Spawn targeted an entity already placed in an archetype.
     AlreadyPlaced(Entity),
+    /// Fast-lane writes were already committed when a later mutation failed.
+    /// The World is in a partially-mutated state and must be discarded.
+    PartialApply {
+        /// The index of the mutation that failed.
+        failed_index: usize,
+        /// The error that caused the failure.
+        source: Box<ApplyError>,
+    },
 }
 
 impl std::fmt::Display for ApplyError {
@@ -24,6 +36,9 @@ impl std::fmt::Display for ApplyError {
         match self {
             Self::DeadEntity(e) => write!(f, "entity {:?} is not alive", e),
             Self::AlreadyPlaced(e) => write!(f, "entity {:?} is already placed", e),
+            Self::PartialApply { failed_index, source } => {
+                write!(f, "partial apply at mutation {}: {}", failed_index, source)
+            }
         }
     }
 }
@@ -740,6 +755,19 @@ impl EnumChangeSet {
     ///
     /// Returns `Ok(())` on success or `Err(ApplyError)` if a mutation targets
     /// an invalid entity. A single tick is allocated for the entire batch.
+    ///
+    /// # Partial application
+    ///
+    /// `apply` is **not atomic**. Internally, "fast-lane" overwrites (mutations
+    /// whose target archetype and column are already known) are applied *before*
+    /// the sequential mutation loop. If a later mutation fails, those fast-lane
+    /// writes are already committed to `world` and cannot be rolled back.
+    ///
+    /// After a failed `apply`, the World is in a **partially-mutated** state:
+    /// some columns have been overwritten with new values while the failing
+    /// mutation (and all subsequent ones) were never applied. Callers must
+    /// **discard** the World on error — there is no way to determine exactly
+    /// which fast-lane writes took effect.
     pub fn apply(mut self, world: &mut World) -> Result<(), ApplyError> {
         let tick = world.next_tick();
 
@@ -760,7 +788,17 @@ impl EnumChangeSet {
                 self.drop_entries.retain(|entry| {
                     entry.mutation_idx >= failed_idx && entry.mutation_idx != usize::MAX
                 });
-                Err(err)
+                // If fast-lane batches were applied before the failure, the World
+                // is partially mutated — wrap in PartialApply so callers know.
+                let had_fast_lane = !self.archetype_batches.is_empty();
+                if had_fast_lane {
+                    Err(ApplyError::PartialApply {
+                        failed_index: failed_idx,
+                        source: Box::new(err),
+                    })
+                } else {
+                    Err(err)
+                }
             }
         }
     }
@@ -1083,7 +1121,10 @@ fn changeset_insert_raw(
         return Err(ApplyError::DeadEntity(entity));
     }
     let index = entity.index() as usize;
-    let location = world.entity_locations[index].unwrap();
+    let Some(location) = world.entity_locations[index] else {
+        // Alive but unplaced (alloc_entity without spawn) — treat as dead.
+        return Err(ApplyError::DeadEntity(entity));
+    };
 
     let src_arch = &world.archetypes.archetypes[location.archetype_id.0];
 
@@ -1182,7 +1223,10 @@ fn changeset_remove_raw(
         return Err(ApplyError::DeadEntity(entity));
     }
     let index = entity.index() as usize;
-    let location = world.entity_locations[index].unwrap();
+    let Some(location) = world.entity_locations[index] else {
+        // Alive but unplaced (alloc_entity without spawn) — treat as dead.
+        return Err(ApplyError::DeadEntity(entity));
+    };
     let src_arch = &world.archetypes.archetypes[location.archetype_id.0];
 
     if !src_arch.component_ids.contains(comp_id) {

--- a/crates/minkowski/src/changeset.rs
+++ b/crates/minkowski/src/changeset.rs
@@ -11,22 +11,37 @@ use crate::world::{EntityLocation, World, get_pair_mut};
 /// Error returned by [`EnumChangeSet::apply`] when a mutation targets
 /// an invalid entity.
 ///
-/// **Important:** `apply` is not atomic. When any error is returned,
-/// the World may be in a partially-mutated state due to fast-lane writes
-/// that cannot be rolled back. Callers must discard the World on error.
+/// **Important:** `apply` is not atomic. When any error is returned, the
+/// World may be in a partially-mutated state and must be discarded. The
+/// [`PartialApply`](ApplyError::PartialApply) variant marks the cases
+/// where mutations were already committed before the failure; see
+/// [`EnumChangeSet::apply`] for the full contract.
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub enum ApplyError {
     /// Mutation targeted an entity that is no longer alive.
     DeadEntity(Entity),
+    /// Mutation targeted an entity that is alive but not placed in any
+    /// archetype — e.g. one obtained from [`World::alloc_entity`] without
+    /// a subsequent spawn.
+    ///
+    /// [`World::alloc_entity`]: crate::world::World::alloc_entity
+    Unplaced(Entity),
     /// Spawn targeted an entity already placed in an archetype.
     AlreadyPlaced(Entity),
-    /// Fast-lane writes were already committed when a later mutation failed.
-    /// The World is in a partially-mutated state and must be discarded.
+    /// A mutation failed after one or more earlier mutations had already
+    /// been committed to the World. The World is partially mutated and
+    /// must be discarded.
+    ///
+    /// The variant is `#[non_exhaustive]` so it can only be constructed by
+    /// the engine, which guarantees `source` is never itself a
+    /// `PartialApply`.
+    #[non_exhaustive]
     PartialApply {
-        /// The index of the mutation that failed.
+        /// Position of the failing mutation in the changeset's sequential
+        /// mutation log.
         failed_index: usize,
-        /// The error that caused the failure.
+        /// The leaf error that caused the failure (never `PartialApply`).
         source: Box<ApplyError>,
     },
 }
@@ -34,16 +49,27 @@ pub enum ApplyError {
 impl std::fmt::Display for ApplyError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::DeadEntity(e) => write!(f, "entity {:?} is not alive", e),
-            Self::AlreadyPlaced(e) => write!(f, "entity {:?} is already placed", e),
-            Self::PartialApply { failed_index, source } => {
-                write!(f, "partial apply at mutation {}: {}", failed_index, source)
+            Self::DeadEntity(e) => write!(f, "entity {e:?} is not alive"),
+            Self::Unplaced(e) => write!(f, "entity {e:?} is alive but not placed in an archetype"),
+            Self::AlreadyPlaced(e) => write!(f, "entity {e:?} is already placed"),
+            Self::PartialApply {
+                failed_index,
+                source,
+            } => {
+                write!(f, "partial apply at mutation {failed_index}: {source}")
             }
         }
     }
 }
 
-impl std::error::Error for ApplyError {}
+impl std::error::Error for ApplyError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::PartialApply { source, .. } => Some(&**source),
+            Self::DeadEntity(_) | Self::Unplaced(_) | Self::AlreadyPlaced(_) => None,
+        }
+    }
+}
 
 const ARENA_ALIGN: usize = 16;
 
@@ -758,16 +784,18 @@ impl EnumChangeSet {
     ///
     /// # Partial application
     ///
-    /// `apply` is **not atomic**. Internally, "fast-lane" overwrites (mutations
-    /// whose target archetype and column are already known) are applied *before*
-    /// the sequential mutation loop. If a later mutation fails, those fast-lane
-    /// writes are already committed to `world` and cannot be rolled back.
+    /// `apply` is **not atomic**. Mutations are committed incrementally and
+    /// there is no rollback: a mutation that succeeds stays applied even if a
+    /// later one fails. (Internally, "fast-lane" overwrites are also flushed
+    /// ahead of the per-mutation pass, so committed writes can precede the
+    /// first reported mutation index.)
     ///
-    /// After a failed `apply`, the World is in a **partially-mutated** state:
-    /// some columns have been overwritten with new values while the failing
-    /// mutation (and all subsequent ones) were never applied. Callers must
-    /// **discard** the World on error — there is no way to determine exactly
-    /// which fast-lane writes took effect.
+    /// When a failure leaves committed writes behind, the error is
+    /// [`ApplyError::PartialApply`], carrying the index of the failing
+    /// mutation. The only error that guarantees an untouched World is a
+    /// non-`PartialApply` variant. Either way, callers must **discard** the
+    /// World on error — there is no way to determine exactly which writes
+    /// took effect.
     pub fn apply(mut self, world: &mut World) -> Result<(), ApplyError> {
         let tick = world.next_tick();
 
@@ -788,10 +816,19 @@ impl EnumChangeSet {
                 self.drop_entries.retain(|entry| {
                     entry.mutation_idx >= failed_idx && entry.mutation_idx != usize::MAX
                 });
-                // If fast-lane batches were applied before the failure, the World
-                // is partially mutated — wrap in PartialApply so callers know.
-                let had_fast_lane = !self.archetype_batches.is_empty();
-                if had_fast_lane {
+                // The World is partially mutated whenever something committed
+                // before the failure: either fast-lane batches (applied ahead
+                // of the sequential loop) or any earlier sequential mutation
+                // (indices 0..failed_idx). Only a first-mutation failure with no
+                // fast-lane batches leaves the World untouched.
+                let partially_applied = !self.archetype_batches.is_empty() || failed_idx > 0;
+                if partially_applied {
+                    // `err` originates from a per-mutation failure and is always a
+                    // leaf variant — apply_mutations never produces PartialApply.
+                    debug_assert!(
+                        !matches!(err, ApplyError::PartialApply { .. }),
+                        "PartialApply must wrap a leaf error, never another PartialApply"
+                    );
                     Err(ApplyError::PartialApply {
                         failed_index: failed_idx,
                         source: Box::new(err),
@@ -878,9 +915,9 @@ impl EnumChangeSet {
                 // this (archetype, component), skip contains + column_index +
                 // info lookup — all invariant within a batch run.
                 let Some(location) = location else {
-                    // Alive but unplaced (from alloc_entity) — treat as dead.
+                    // Alive but unplaced (from alloc_entity without spawn).
                     flush_insert_batch(&mut world.archetypes.archetypes, &mut batch, tick);
-                    return Err(map_err(ApplyError::DeadEntity(*entity)));
+                    return Err(map_err(ApplyError::Unplaced(*entity)));
                 };
                 let key_matches = batch.as_ref().is_some_and(|b| {
                     b.arch_idx == location.archetype_id.0 && b.comp_id == *component_id
@@ -1121,9 +1158,9 @@ fn changeset_insert_raw(
         return Err(ApplyError::DeadEntity(entity));
     }
     let index = entity.index() as usize;
-    let Some(location) = world.entity_locations[index] else {
-        // Alive but unplaced (alloc_entity without spawn) — treat as dead.
-        return Err(ApplyError::DeadEntity(entity));
+    let Some(location) = world.entity_locations.get(index).copied().flatten() else {
+        // Alive but unplaced (alloc_entity without spawn).
+        return Err(ApplyError::Unplaced(entity));
     };
 
     let src_arch = &world.archetypes.archetypes[location.archetype_id.0];
@@ -1223,9 +1260,9 @@ fn changeset_remove_raw(
         return Err(ApplyError::DeadEntity(entity));
     }
     let index = entity.index() as usize;
-    let Some(location) = world.entity_locations[index] else {
-        // Alive but unplaced (alloc_entity without spawn) — treat as dead.
-        return Err(ApplyError::DeadEntity(entity));
+    let Some(location) = world.entity_locations.get(index).copied().flatten() else {
+        // Alive but unplaced (alloc_entity without spawn).
+        return Err(ApplyError::Unplaced(entity));
     };
     let src_arch = &world.archetypes.archetypes[location.archetype_id.0];
 
@@ -2204,7 +2241,10 @@ mod tests {
 
     #[test]
     fn batch_apply_dead_entity_returns_error() {
-        // A dead entity mid-batch should flush the batch and return an error.
+        // A dead entity mid-batch flushes the pending batch (committing the
+        // earlier mutation) and then fails. Because an earlier mutation was
+        // already committed, the failure is reported as PartialApply wrapping
+        // the DeadEntity leaf — the World is partially mutated.
         let mut world = World::new();
         let alive = world.spawn((Pos { x: 1.0, y: 1.0 },));
         let dead = world.spawn((Pos { x: 2.0, y: 2.0 },));
@@ -2214,11 +2254,16 @@ mod tests {
         cs.insert::<Pos>(&mut world, alive, Pos { x: 99.0, y: 99.0 });
         cs.insert::<Pos>(&mut world, dead, Pos { x: 0.0, y: 0.0 });
 
-        let result = cs.apply(&mut world);
-        assert!(
-            matches!(result, Err(ApplyError::DeadEntity(_))),
-            "should return DeadEntity error"
-        );
+        match cs.apply(&mut world) {
+            Err(ApplyError::PartialApply {
+                failed_index,
+                source,
+            }) => {
+                assert_eq!(failed_index, 1);
+                assert_eq!(*source, ApplyError::DeadEntity(dead));
+            }
+            other => panic!("expected PartialApply wrapping DeadEntity, got {other:?}"),
+        }
 
         // The first mutation (on alive entity) should have been flushed
         // and applied before the error.
@@ -2592,7 +2637,26 @@ mod tests {
         });
 
         let result = cs.apply(&mut world);
-        assert!(result.is_err());
+
+        // Fast-lane batches were committed before the failure, so the error
+        // is wrapped in PartialApply marking the partially-mutated World.
+        // The failing mutation is index 0 and its leaf cause is DeadEntity.
+        let err = result.expect_err("dead entity must fail the apply");
+        // The error chain must surface the leaf via `source()`.
+        assert!(
+            std::error::Error::source(&err).is_some(),
+            "PartialApply must expose its source"
+        );
+        match err {
+            ApplyError::PartialApply {
+                failed_index,
+                source,
+            } => {
+                assert_eq!(failed_index, 0);
+                assert_eq!(*source, ApplyError::DeadEntity(dead));
+            }
+            other => panic!("expected PartialApply, got {other:?}"),
+        }
 
         // Fast-lane Pos was applied (it runs before the regular mutations).
         assert_eq!(world.get::<Pos>(e), Some(&Pos { x: 99.0, y: 99.0 }));
@@ -2603,6 +2667,52 @@ mod tests {
             1,
             "failed mutation's value must be dropped once"
         );
+    }
+
+    #[test]
+    fn clean_failure_first_mutation_not_wrapped_in_partial_apply() {
+        // No fast-lane batches and the first mutation fails: nothing was
+        // committed, so the error must be a bare leaf variant, not
+        // PartialApply.
+        let mut world = World::new();
+        let dead = world.spawn((Pos { x: 1.0, y: 1.0 },));
+        world.despawn(dead);
+
+        let mut cs = EnumChangeSet::new();
+        cs.insert::<Pos>(&mut world, dead, Pos { x: 9.0, y: 9.0 });
+
+        match cs.apply(&mut world) {
+            Err(ApplyError::DeadEntity(e)) => assert_eq!(e, dead),
+            other => panic!("expected bare DeadEntity, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn changeset_insert_on_unplaced_entity_returns_unplaced() {
+        // Alive-but-unplaced entity (alloc_entity without spawn). Inserting a
+        // component triggers the migration path (changeset_insert_raw), which
+        // must report Unplaced — not DeadEntity, not a panic.
+        let mut world = World::new();
+        let unplaced = world.alloc_entity();
+        assert!(world.is_alive(unplaced));
+        assert!(!world.is_placed(unplaced));
+
+        let mut cs = EnumChangeSet::new();
+        cs.insert::<Pos>(&mut world, unplaced, Pos { x: 1.0, y: 2.0 });
+
+        assert_eq!(cs.apply(&mut world), Err(ApplyError::Unplaced(unplaced)));
+    }
+
+    #[test]
+    fn changeset_remove_on_unplaced_entity_returns_unplaced() {
+        // Alive-but-unplaced entity routed through changeset_remove_raw.
+        let mut world = World::new();
+        let unplaced = world.alloc_entity();
+
+        let mut cs = EnumChangeSet::new();
+        cs.remove::<Pos>(&mut world, unplaced);
+
+        assert_eq!(cs.apply(&mut world), Err(ApplyError::Unplaced(unplaced)));
     }
 
     #[test]

--- a/crates/minkowski/src/world.rs
+++ b/crates/minkowski/src/world.rs
@@ -31,10 +31,14 @@ impl fmt::Display for DeadEntity {
 impl std::error::Error for DeadEntity {}
 
 /// Error returned by [`World::try_insert`].
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub enum InsertError {
     /// The entity is not alive.
     DeadEntity(DeadEntity),
+    /// The entity is alive but not placed in any archetype — e.g. one
+    /// obtained from [`World::alloc_entity`] without a subsequent spawn.
+    Unplaced(Entity),
     /// The memory pool is exhausted.
     PoolExhausted(PoolExhausted),
 }
@@ -43,6 +47,9 @@ impl fmt::Display for InsertError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             InsertError::DeadEntity(e) => write!(f, "{e}"),
+            InsertError::Unplaced(e) => {
+                write!(f, "entity {e:?} is alive but not placed in an archetype")
+            }
             InsertError::PoolExhausted(e) => write!(f, "{e}"),
         }
     }
@@ -53,6 +60,7 @@ impl std::error::Error for InsertError {
         match self {
             InsertError::DeadEntity(e) => Some(e),
             InsertError::PoolExhausted(e) => Some(e),
+            InsertError::Unplaced(_) => None,
         }
     }
 }
@@ -1178,13 +1186,28 @@ impl World {
         }
     }
 
+    /// Insert a bundle's components into an existing, placed entity.
+    ///
+    /// Returns `Err(DeadEntity)` if the entity is not alive, or if it is
+    /// alive but not yet placed in an archetype (e.g. from
+    /// [`alloc_entity`](Self::alloc_entity) without a subsequent spawn) —
+    /// this method's error type does not distinguish the two. Use
+    /// [`try_insert`](Self::try_insert) (which reports
+    /// [`InsertError::Unplaced`]) when the distinction matters.
+    ///
+    /// Panics if the memory pool is exhausted; use
+    /// [`try_insert`](Self::try_insert) to handle that as an error instead.
     pub fn insert<B: Bundle>(&mut self, entity: Entity, bundle: B) -> Result<(), DeadEntity> {
         self.drain_orphans();
         if !self.is_alive(entity) {
             return Err(DeadEntity { entity });
         }
         let index = entity.index() as usize;
-        let location = self.entity_locations[index].unwrap();
+        // Alive but unplaced (alloc_entity without spawn) surfaces as
+        // DeadEntity here — see the doc note above.
+        let Some(location) = self.entity_locations.get(index).copied().flatten() else {
+            return Err(DeadEntity { entity });
+        };
         debug_assert!(
             location.row < self.archetypes.archetypes[location.archetype_id.0].len(),
             "stale EntityLocation: row {} >= archetype len {}",
@@ -1324,7 +1347,9 @@ impl World {
     /// Like [`insert`](Self::insert) but additionally handles pool exhaustion
     /// as an error instead of panicking. Returns
     /// `Err(InsertError::PoolExhausted(_))` when the slab pool cannot allocate,
-    /// and `Err(InsertError::DeadEntity(_))` when the entity is not alive.
+    /// `Err(InsertError::DeadEntity(_))` when the entity is not alive, and
+    /// `Err(InsertError::Unplaced(_))` when the entity is alive but not placed
+    /// in an archetype.
     ///
     /// If this method returns `Err`, the world state is unchanged — no partial
     /// migration occurs and the entity remains in its original archetype.
@@ -1334,7 +1359,9 @@ impl World {
             return Err(DeadEntity { entity }.into());
         }
         let index = entity.index() as usize;
-        let location = self.entity_locations[index].unwrap();
+        let Some(location) = self.entity_locations.get(index).copied().flatten() else {
+            return Err(InsertError::Unplaced(entity));
+        };
         debug_assert!(
             location.row < self.archetypes.archetypes[location.archetype_id.0].len(),
             "stale EntityLocation: row {} >= archetype len {}",
@@ -2578,6 +2605,31 @@ mod tests {
         // Allocated but not yet placed in any archetype
         assert!(world.is_alive(e)); // allocator considers it alive
         assert!(!world.is_placed(e)); // but no archetype row yet
+    }
+
+    #[test]
+    fn insert_on_unplaced_entity_returns_err_not_panic() {
+        // Regression: insert on an alive-but-unplaced entity (alloc_entity
+        // without spawn) must return Err, not panic on a None location.
+        let mut world = World::new();
+        let unplaced = world.alloc_entity();
+        let result = world.insert(unplaced, (Pos { x: 1.0, y: 2.0 },));
+        assert_eq!(result, Err(DeadEntity { entity: unplaced }));
+        // The unplaced entity is untouched.
+        assert!(!world.is_placed(unplaced));
+    }
+
+    #[test]
+    fn try_insert_on_unplaced_entity_returns_unplaced() {
+        // Regression: try_insert on an alive-but-unplaced entity must return
+        // the distinct InsertError::Unplaced, not panic and not DeadEntity.
+        let mut world = World::new();
+        let unplaced = world.alloc_entity();
+        match world.try_insert(unplaced, (Pos { x: 1.0, y: 2.0 },)) {
+            Err(InsertError::Unplaced(e)) => assert_eq!(e, unplaced),
+            other => panic!("expected InsertError::Unplaced, got {other:?}"),
+        }
+        assert!(!world.is_placed(unplaced));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes four critical issues identified during the security/correctness audit (#176, #177, #178).

### C1: WAL append missing fsync (#176)
`Wal::append()` called `BufWriter::flush()` but not `sync_all()`. On crash or power loss, all WAL frames written since the last OS buffer flush were lost — breaking the WAL durability contract.

**Fix:** Added `self.active_file.sync_all()?` after the BufWriter flush. Matches `ManifestLog::append()` behavior.

### C2+C3: Panic on unplaced entity (#177)
`changeset_insert_raw` and `changeset_remove_raw` called `.unwrap()` on `entity_locations[index]`, panicking for alive-but-unplaced entities (from `alloc_entity()` without spawn). The Insert fast-path handled this correctly with a `None` check.

**Fix:** Replaced both `unwrap()` calls with `let Some(location) = ... else { return Err(ApplyError::DeadEntity(entity)) }`.

### C4: Fast-lane writes non-atomic on apply failure (#178)
The fast-lane path in `apply_mutations` writes component data directly into archetype columns before the regular mutation loop. If a later mutation fails, those writes are already committed with no rollback.

**Fix:**
- Documented the non-atomic contract on `apply()` with a `# Partial application` section
- Added `ApplyError::PartialApply { failed_index, source }` variant that wraps errors when fast-lane batches were present
- Added warning doc comment on `ApplyError` enum itself

## Test plan
- [x] `cargo test -p minkowski` — 903/903 passed
- [x] `cargo test -p minkowski-persist` — 117/117 passed  
- [x] `cargo test -p minkowski-lsm` — 19/19 passed
- [x] `cargo check --workspace` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean