### PR TITLE
fix(observe): repair stale tests + gate full workspace in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: stable
-      - run: cargo test -p minkowski
+      # Whole workspace, not just -p minkowski: minkowski-persist,
+      # minkowski-lsm, and minkowski-observe each have substantial test
+      # suites that previously never ran in CI and silently rotted.
+      # minkowski-py is excluded — its tests link against libpython and
+      # need a maturin/Python toolchain this job doesn't set up.
+      - run: cargo test --workspace --exclude minkowski-py
 
   tsan:
     name: ThreadSanitizer

--- a/crates/minkowski-observe/src/diff.rs
+++ b/crates/minkowski-observe/src/diff.rs
@@ -240,10 +240,15 @@ mod tests {
 
     #[test]
     fn diff_no_pool_omits_delta() {
+        // Every World carries a default SlabPool, so null out pool stats to
+        // exercise the no-pool diff branch: with either side lacking pool_used,
+        // the delta is absent and the line is omitted.
         let mut world = World::new();
-        let before = MetricsSnapshot::capture(&world, None);
+        let mut before = MetricsSnapshot::capture(&world, None);
         world.spawn((Pos { x: 1.0, y: 2.0 },));
-        let after = MetricsSnapshot::capture(&world, None);
+        let mut after = MetricsSnapshot::capture(&world, None);
+        before.world.pool_used = None;
+        after.world.pool_used = None;
 
         let diff = MetricsDiff::compute(&before, &after);
         assert!(diff.pool_used_delta.is_none());

--- a/crates/minkowski-observe/src/prometheus.rs
+++ b/crates/minkowski-observe/src/prometheus.rs
@@ -230,10 +230,13 @@ mod tests {
     fn new_renders_default_zeros() {
         let exporter = PrometheusExporter::new();
         let output = exporter.render();
+        // Unlabeled gauges always render, even at zero.
         assert!(output.contains("minkowski_entity_count"));
         assert!(output.contains("minkowski_tick"));
         assert!(output.contains("minkowski_wal_seq"));
-        assert!(output.contains("minkowski_archetype_entity_count"));
+        // Labeled families (e.g. minkowski_archetype_entity_count) only emit
+        // once they have at least one series — covered by
+        // `update_sets_archetype_labels`, not here.
     }
 
     #[test]

--- a/crates/minkowski-observe/src/snapshot.rs
+++ b/crates/minkowski-observe/src/snapshot.rs
@@ -217,8 +217,12 @@ mod tests {
 
     #[test]
     fn snapshot_without_pool_omits_pool_line() {
+        // Every World carries a default SlabPool, so drive the omit-branch
+        // directly: when pool stats are absent, the pool line is omitted.
         let world = World::new();
-        let snap = MetricsSnapshot::capture(&world, None);
+        let mut snap = MetricsSnapshot::capture(&world, None);
+        snap.world.pool_capacity = None;
+        snap.world.pool_used = None;
         let output = format!("{snap}");
         assert!(!output.contains("pool:"));
     }


### PR DESCRIPTION
## Summary

Two problems, one root cause: three `minkowski-observe` tests had been failing on `main`, but nobody noticed because **CI's Test job only ran `cargo test -p minkowski`** — the `minkowski-observe`, `minkowski-persist`, and `minkowski-lsm` suites never ran in CI.

### Test fixes

- **`snapshot_without_pool_omits_pool_line`** and **`diff_no_pool_omits_delta`** assumed a default `World` has no pool. But every `World` now carries a default `SlabPool` (asserted by minkowski's own `world_new_uses_slab_pool`). The tests' premise was an unreachable state. Fixed to drive the no-pool render/diff branch with controlled `None` pool stats — which also makes them deterministic across environments instead of depending on whether a 256 MiB pool mmap succeeds.
- **`new_renders_default_zeros`** asserted the labeled family `minkowski_archetype_entity_count` renders for an empty world, but `prometheus-client` emits a family only once it has at least one series. Now asserts the always-present unlabeled gauges; the populated case is already covered by `update_sets_archetype_labels`.

### CI gap fix

The `Test` job now runs `cargo test --workspace --exclude minkowski-py` instead of `cargo test -p minkowski`. This gates the persist / lsm / observe suites (~1200 tests total vs ~900) so they can't silently rot again — directly applying the project's "mechanical enforcement > discipline" rule.

`minkowski-py` is excluded because its tests link against `libpython` and need a maturin/Python toolchain this job doesn't provision. Adding a Python-enabled test job for it is a reasonable future follow-up.

## Test plan
- [x] `cargo test --workspace --exclude minkowski-py` — all pass (was 3 failing in observe)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

Note: this is the first PR whose CI run will actually exercise the persist/lsm/observe suites — a good smoke test of the gate itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)