### PR TITLE
Group C: sparse durability via sparse-in-baseline

### DIFF
--- a/crates/minkowski-bench/benches/serialize.rs
+++ b/crates/minkowski-bench/benches/serialize.rs
@@ -27,6 +27,7 @@ fn serialize(c: &mut Criterion) {
                 &mut manifest,
                 &mut log,
                 &lsm_dir,
+                &codecs,
             )
             .unwrap();
         });
@@ -48,6 +49,7 @@ fn serialize(c: &mut Criterion) {
             &mut manifest,
             &mut log,
             &lsm_dir,
+            &codecs,
         )
         .unwrap()
         .expect("flush");
@@ -99,6 +101,7 @@ fn serialize(c: &mut Criterion) {
             &mut manifest,
             &mut log,
             &lsm_dir,
+            &codecs,
         )
         .unwrap()
         .expect("flush");

--- a/crates/minkowski-lsm/src/compaction_writer.rs
+++ b/crates/minkowski-lsm/src/compaction_writer.rs
@@ -32,7 +32,7 @@ use crate::bloom;
 use crate::error::LsmError;
 use crate::format::{
     ALLOCATOR_SLOT, ENTITY_SLOT, Footer, Header, IndexEntry, MAGIC, META_ARCH_ID, PAGE_SIZE,
-    PageHeader, VERSION,
+    PageHeader, SPARSE_ARCH_ID, VERSION,
 };
 use crate::manifest::SortedRunMeta;
 use crate::reader::SortedRunReader;
@@ -256,7 +256,44 @@ impl<'a> CompactionWriter<'a> {
         }
 
         // ── 2. Build output schema (union of all components) ─────────────────
-        let all_components = self.collect_all_components();
+
+        // Sparse baseline pages: carry forward from the newest input run
+        // (newest-wins, same as the allocator). Resolve each page's component
+        // NAME from the newest input's schema so it can be re-slotted into the
+        // output schema (slots are not stable across runs).
+        let sparse_carry: Vec<(String, u16, Vec<u8>)> =
+            match self.inputs.iter().max_by_key(|r| r.sequence_range().hi()) {
+                Some(newest) => {
+                    let mut out = Vec::new();
+                    for slot in newest.component_slots_for_arch(SPARSE_ARCH_ID) {
+                        let name = newest
+                            .schema()
+                            .entry_for_slot(slot)
+                            .ok_or_else(|| {
+                                LsmError::Format(format!(
+                                    "sparse slot {slot} missing from input schema"
+                                ))
+                            })?
+                            .name()
+                            .to_owned();
+                        for result in newest.slot_pages(SPARSE_ARCH_ID, slot) {
+                            let (page_index, page) = result?;
+                            newest.validate_page_crc(&page)?;
+                            let len = page.header().row_count as usize;
+                            out.push((name.clone(), page_index, page.data()[..len].to_vec()));
+                        }
+                    }
+                    out
+                }
+                None => Vec::new(),
+            };
+
+        let mut all_components = self.collect_all_components();
+        for (name, _, _) in &sparse_carry {
+            if !all_components.contains(name) {
+                all_components.push(name.clone());
+            }
+        }
         let output_schema = self.build_output_schema(&all_components)?;
 
         // ── 3. Build per-archetype slot translation tables ───────────────────
@@ -306,6 +343,7 @@ impl<'a> CompactionWriter<'a> {
                 None => Vec::new(),
             };
         total_pages += allocator_pages.len();
+        total_pages += sparse_carry.len();
 
         // ── 5. Open temp file ─────────────────────────────────────────────────
         let seq_lo = self.output_seq_range.lo().get();
@@ -546,6 +584,34 @@ impl<'a> CompactionWriter<'a> {
                 arch_id: META_ARCH_ID,
                 slot: ALLOCATOR_SLOT,
                 page_index,
+                _pad: 0,
+                file_offset,
+            });
+        }
+
+        // ── 8c. Carry forward sparse baseline pages (re-slotted to output schema) ──
+        for (name, page_index, payload) in &sparse_carry {
+            let output_slot = output_schema.slot_for(name).ok_or_else(|| {
+                LsmError::Format(format!(
+                    "sparse component {name} missing from output schema"
+                ))
+            })?;
+            let page_crc = crc32fast::hash(payload);
+            let file_offset = w.stream_position()?;
+            let ph = PageHeader {
+                arch_id: SPARSE_ARCH_ID,
+                slot: output_slot,
+                page_index: *page_index,
+                row_count: payload.len() as u16,
+                page_crc32: page_crc,
+                _padding: 0,
+            };
+            w.write_all(ph.as_bytes())?;
+            w.write_all(payload)?;
+            index_entries.push(IndexEntry {
+                arch_id: SPARSE_ARCH_ID,
+                slot: output_slot,
+                page_index: *page_index,
                 _pad: 0,
                 file_offset,
             });

--- a/crates/minkowski-lsm/src/compaction_writer.rs
+++ b/crates/minkowski-lsm/src/compaction_writer.rs
@@ -258,29 +258,21 @@ impl<'a> CompactionWriter<'a> {
         // ── 2. Build output schema (union of all components) ─────────────────
 
         // Sparse baseline pages: carry forward from the newest input run
-        // (newest-wins, same as the allocator). Resolve each page's component
-        // NAME from the newest input's schema so it can be re-slotted into the
-        // output schema (slots are not stable across runs).
-        let sparse_carry: Vec<(String, u16, Vec<u8>)> =
+        // (newest-wins, same as the allocator), preserving each page's
+        // (slot, page_index) VERBATIM. Sparse pages are self-describing (the
+        // component name lives in the blob) and use a separate SPARSE_ARCH_ID
+        // page space, so they need no schema entry and no re-slotting — carrying
+        // them forward byte-for-byte from the newest input is sufficient.
+        let sparse_carry: Vec<(u16, u16, Vec<u8>)> =
             match self.inputs.iter().max_by_key(|r| r.sequence_range().hi()) {
                 Some(newest) => {
                     let mut out = Vec::new();
                     for slot in newest.component_slots_for_arch(SPARSE_ARCH_ID) {
-                        let name = newest
-                            .schema()
-                            .entry_for_slot(slot)
-                            .ok_or_else(|| {
-                                LsmError::Format(format!(
-                                    "sparse slot {slot} missing from input schema"
-                                ))
-                            })?
-                            .name()
-                            .to_owned();
                         for result in newest.slot_pages(SPARSE_ARCH_ID, slot) {
                             let (page_index, page) = result?;
                             newest.validate_page_crc(&page)?;
                             let len = page.header().row_count as usize;
-                            out.push((name.clone(), page_index, page.data()[..len].to_vec()));
+                            out.push((slot, page_index, page.data()[..len].to_vec()));
                         }
                     }
                     out
@@ -288,12 +280,7 @@ impl<'a> CompactionWriter<'a> {
                 None => Vec::new(),
             };
 
-        let mut all_components = self.collect_all_components();
-        for (name, _, _) in &sparse_carry {
-            if !all_components.contains(name) {
-                all_components.push(name.clone());
-            }
-        }
+        let all_components = self.collect_all_components();
         let output_schema = self.build_output_schema(&all_components)?;
 
         // ── 3. Build per-archetype slot translation tables ───────────────────
@@ -589,18 +576,13 @@ impl<'a> CompactionWriter<'a> {
             });
         }
 
-        // ── 8c. Carry forward sparse baseline pages (re-slotted to output schema) ──
-        for (name, page_index, payload) in &sparse_carry {
-            let output_slot = output_schema.slot_for(name).ok_or_else(|| {
-                LsmError::Format(format!(
-                    "sparse component {name} missing from output schema"
-                ))
-            })?;
+        // ── 8c. Carry forward sparse baseline pages (verbatim) ───────────────
+        for (slot, page_index, payload) in &sparse_carry {
             let page_crc = crc32fast::hash(payload);
             let file_offset = w.stream_position()?;
             let ph = PageHeader {
                 arch_id: SPARSE_ARCH_ID,
-                slot: output_slot,
+                slot: *slot,
                 page_index: *page_index,
                 row_count: payload.len() as u16,
                 page_crc32: page_crc,
@@ -610,7 +592,7 @@ impl<'a> CompactionWriter<'a> {
             w.write_all(payload)?;
             index_entries.push(IndexEntry {
                 arch_id: SPARSE_ARCH_ID,
-                slot: output_slot,
+                slot: *slot,
                 page_index: *page_index,
                 _pad: 0,
                 file_offset,

--- a/crates/minkowski-lsm/src/compaction_writer.rs
+++ b/crates/minkowski-lsm/src/compaction_writer.rs
@@ -792,10 +792,12 @@ mod tests {
         seq_hi: u64,
     ) -> (tempfile::TempDir, SortedRunReader) {
         let dir = tempfile::tempdir().unwrap();
+        let codecs = crate::codec::CodecRegistry::new();
         let path = flush(
             world,
             SeqRange::new(SeqNo::from(seq_lo), SeqNo::from(seq_hi)).unwrap(),
             dir.path(),
+            &codecs,
         )
         .unwrap()
         .unwrap();

--- a/crates/minkowski-lsm/src/compaction_writer.rs
+++ b/crates/minkowski-lsm/src/compaction_writer.rs
@@ -578,6 +578,13 @@ impl<'a> CompactionWriter<'a> {
 
         // ── 8c. Carry forward sparse baseline pages (verbatim) ───────────────
         for (slot, page_index, payload) in &sparse_carry {
+            // Each payload came from a source page whose row_count is a u16, so
+            // it is ≤ u16::MAX; assert it before the narrowing cast below.
+            debug_assert!(
+                u16::try_from(payload.len()).is_ok(),
+                "sparse carry payload {} exceeds u16::MAX",
+                payload.len()
+            );
             let page_crc = crc32fast::hash(payload);
             let file_offset = w.stream_position()?;
             let ph = PageHeader {

--- a/crates/minkowski-lsm/src/compactor.rs
+++ b/crates/minkowski-lsm/src/compactor.rs
@@ -464,7 +464,8 @@ mod tests {
             },));
         }
         let seq_range = SeqRange::new(SeqNo::from(seq_lo), SeqNo::from(seq_hi)).unwrap();
-        flush_and_record(&world, seq_range, manifest, log, run_dir)
+        let codecs = crate::codec::CodecRegistry::new();
+        flush_and_record(&world, seq_range, manifest, log, run_dir, &codecs)
             .unwrap()
             .expect("world is dirty, flush must return Some")
     }
@@ -634,9 +635,17 @@ mod tests {
             let lo = (run_i as u64) * 10;
             let hi = lo + 9;
             let seq_range = SeqRange::new(SeqNo::from(lo), SeqNo::from(hi)).unwrap();
-            flush_and_record(&world, seq_range, &mut manifest, &mut log, dir.path())
-                .unwrap()
-                .expect("world is dirty");
+            let codecs = crate::codec::CodecRegistry::new();
+            flush_and_record(
+                &world,
+                seq_range,
+                &mut manifest,
+                &mut log,
+                dir.path(),
+                &codecs,
+            )
+            .unwrap()
+            .expect("world is dirty");
         }
 
         assert_eq!(manifest.runs_at_level(Level::L0).len(), n_runs);
@@ -798,9 +807,17 @@ mod tests {
                 },));
             }
             let seq_range = SeqRange::new(SeqNo::from(i * 10), SeqNo::from(i * 10 + 9)).unwrap();
-            flush_and_record(&world, seq_range, &mut manifest, &mut log, dir.path())
-                .unwrap()
-                .expect("world is dirty");
+            let codecs = crate::codec::CodecRegistry::new();
+            flush_and_record(
+                &world,
+                seq_range,
+                &mut manifest,
+                &mut log,
+                dir.path(),
+                &codecs,
+            )
+            .unwrap()
+            .expect("world is dirty");
         }
 
         assert_eq!(manifest.runs_at_level(Level::L0).len(), 8);
@@ -908,9 +925,17 @@ mod tests {
             let lo = (run_i as u64) * 10;
             let hi = lo + 9;
             let seq_range = SeqRange::new(SeqNo::from(lo), SeqNo::from(hi)).unwrap();
-            flush_and_record(&world, seq_range, &mut manifest, &mut log, dir.path())
-                .unwrap()
-                .expect("world is dirty");
+            let codecs = crate::codec::CodecRegistry::new();
+            flush_and_record(
+                &world,
+                seq_range,
+                &mut manifest,
+                &mut log,
+                dir.path(),
+                &codecs,
+            )
+            .unwrap()
+            .expect("world is dirty");
         }
 
         assert_eq!(
@@ -1009,9 +1034,17 @@ mod tests {
             let lo = (run_i as u64) * 10;
             let hi = lo + 9;
             let seq_range = SeqRange::new(SeqNo::from(lo), SeqNo::from(hi)).unwrap();
-            flush_and_record(&world, seq_range, &mut manifest, &mut log, dir.path())
-                .unwrap()
-                .expect("world is dirty");
+            let codecs = crate::codec::CodecRegistry::new();
+            flush_and_record(
+                &world,
+                seq_range,
+                &mut manifest,
+                &mut log,
+                dir.path(),
+                &codecs,
+            )
+            .unwrap()
+            .expect("world is dirty");
         }
 
         // All 4 runs at L0
@@ -1121,9 +1154,17 @@ mod tests {
             let lo = (run_i as u64) * 10;
             let hi = lo + 9;
             let seq_range = SeqRange::new(SeqNo::from(lo), SeqNo::from(hi)).unwrap();
-            flush_and_record(&world, seq_range, &mut manifest, &mut log, dir.path())
-                .unwrap()
-                .expect("world is dirty");
+            let codecs = crate::codec::CodecRegistry::new();
+            flush_and_record(
+                &world,
+                seq_range,
+                &mut manifest,
+                &mut log,
+                dir.path(),
+                &codecs,
+            )
+            .unwrap()
+            .expect("world is dirty");
         }
 
         // Runs 2, 3: both (Pos,) and (Pos, Vel)
@@ -1159,9 +1200,17 @@ mod tests {
             let lo = (run_i as u64) * 10;
             let hi = lo + 9;
             let seq_range = SeqRange::new(SeqNo::from(lo), SeqNo::from(hi)).unwrap();
-            flush_and_record(&world, seq_range, &mut manifest, &mut log, dir.path())
-                .unwrap()
-                .expect("world is dirty");
+            let codecs = crate::codec::CodecRegistry::new();
+            flush_and_record(
+                &world,
+                seq_range,
+                &mut manifest,
+                &mut log,
+                dir.path(),
+                &codecs,
+            )
+            .unwrap()
+            .expect("world is dirty");
         }
 
         assert_eq!(manifest.runs_at_level(Level::L0).len(), 4);

--- a/crates/minkowski-lsm/src/format.rs
+++ b/crates/minkowski-lsm/src/format.rs
@@ -14,6 +14,12 @@ pub const META_ARCH_ID: u16 = 0xFFFF;
 /// Special `slot` for entity-allocator state pages (`generations` + `free_list`).
 pub const ALLOCATOR_SLOT: u16 = 0xFFFE;
 
+/// Special `arch_id` for sparse-component baseline pages. Pages keyed
+/// `(SPARSE_ARCH_ID, component_schema_slot, page_index)` hold a chunk of a
+/// length-prefixed sparse blob (see `sparse_page`). Distinct from
+/// `META_ARCH_ID` (0xFFFF) and the allocator (which lives under META_ARCH_ID).
+pub const SPARSE_ARCH_ID: u16 = 0xFFFD;
+
 /// Number of rows per page — re-exported from the minkowski crate for
 /// convenience so callers do not need to depend on both crates.
 pub const PAGE_SIZE: usize = minkowski::PAGE_SIZE;

--- a/crates/minkowski-lsm/src/format.rs
+++ b/crates/minkowski-lsm/src/format.rs
@@ -15,9 +15,12 @@ pub const META_ARCH_ID: u16 = 0xFFFF;
 pub const ALLOCATOR_SLOT: u16 = 0xFFFE;
 
 /// Special `arch_id` for sparse-component baseline pages. Pages keyed
-/// `(SPARSE_ARCH_ID, component_schema_slot, page_index)` hold a chunk of a
-/// length-prefixed sparse blob (see `sparse_page`). Distinct from
-/// `META_ARCH_ID` (0xFFFF) and the allocator (which lives under META_ARCH_ID).
+/// `(SPARSE_ARCH_ID, grouping_slot, page_index)` hold a chunk of a
+/// length-prefixed, self-describing sparse blob (see `sparse_page`). The
+/// `grouping_slot` is the blob's position in name-sorted order within a single
+/// run — it is NOT a schema slot and has no cross-run meaning; the component
+/// name lives in the blob. Distinct from `META_ARCH_ID` (0xFFFF) and the
+/// allocator (which lives under META_ARCH_ID).
 pub const SPARSE_ARCH_ID: u16 = 0xFFFD;
 
 /// Number of rows per page — re-exported from the minkowski crate for
@@ -86,7 +89,10 @@ impl Header {
 pub struct PageHeader {
     /// Archetype index within this run.
     pub arch_id: u16,
-    /// Component slot within the archetype, or [`ENTITY_SLOT`].
+    /// Component slot within the archetype, or [`ENTITY_SLOT`]. When
+    /// `arch_id == SPARSE_ARCH_ID` this is a per-run grouping index (the
+    /// name-sort rank of the sparse component), not a schema slot; when
+    /// `slot == ALLOCATOR_SLOT` the page holds allocator metadata bytes.
     pub slot: u16,
     /// Which page of the column (0-based).
     pub page_index: u16,

--- a/crates/minkowski-lsm/src/lib.rs
+++ b/crates/minkowski-lsm/src/lib.rs
@@ -12,6 +12,7 @@ pub mod reader;
 pub mod recovery;
 pub mod schema;
 pub(crate) mod schema_match;
+pub mod sparse_page;
 pub mod types;
 pub mod writer;
 

--- a/crates/minkowski-lsm/src/manifest_ops.rs
+++ b/crates/minkowski-lsm/src/manifest_ops.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 
 use minkowski::World;
 
+use crate::codec::CodecRegistry;
 use crate::error::LsmError;
 use crate::manifest::{LsmManifest, SortedRunMeta};
 use crate::manifest_log::{ManifestEntry, ManifestLog};
@@ -22,8 +23,9 @@ pub fn flush_and_record<const N: usize>(
     manifest: &mut LsmManifest<N>,
     log: &mut ManifestLog,
     output_dir: &Path,
+    codecs: &CodecRegistry,
 ) -> Result<Option<PathBuf>, LsmError> {
-    let Some(path) = flush(world, sequence_range, output_dir)? else {
+    let Some(path) = flush(world, sequence_range, output_dir, codecs)? else {
         return Ok(None);
     };
 
@@ -103,6 +105,7 @@ pub fn cleanup_orphans<const N: usize>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codec::CodecRegistry;
     use crate::types::{Level, PageCount, SeqNo, SeqRange, SizeBytes};
 
     #[derive(Clone, Copy)]
@@ -125,12 +128,14 @@ mod tests {
         let log_path = dir.path().join("manifest.log");
         let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
+        let codecs = CodecRegistry::new();
         let result = flush_and_record(
             &world,
             SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
             &mut manifest,
             &mut log,
             dir.path(),
+            &codecs,
         )
         .unwrap();
         assert!(result.is_some());
@@ -149,12 +154,14 @@ mod tests {
         let log_path = dir.path().join("manifest.log");
         let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
+        let codecs = CodecRegistry::new();
         let result = flush_and_record(
             &world,
             SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
             &mut manifest,
             &mut log,
             dir.path(),
+            &codecs,
         )
         .unwrap();
         assert!(result.is_none());

--- a/crates/minkowski-lsm/src/reader.rs
+++ b/crates/minkowski-lsm/src/reader.rs
@@ -254,11 +254,14 @@ impl SortedRunReader {
         let header = PageHeader::from_bytes(header_bytes);
 
         // Compute and bounds-check data.
-        let item_size = self.item_size_for_slot(slot)?;
         let data_len =
             if slot == crate::format::ALLOCATOR_SLOT || arch_id == crate::format::SPARSE_ARCH_ID {
+                // Sparse/allocator pages store a raw byte chunk in `row_count`;
+                // their `slot` is a grouping index, not a schema slot, so do
+                // NOT resolve it via `item_size_for_slot`.
                 header.row_count as usize
             } else {
+                let item_size = self.item_size_for_slot(slot)?;
                 PAGE_SIZE.checked_mul(item_size).ok_or_else(|| {
                     LsmError::Format(format!(
                         "page ({arch_id}, {slot}, {page_index}): data length overflow"
@@ -387,11 +390,14 @@ impl SortedRunReader {
         let header_bytes: &[u8; 16] = buf[offset..header_end].try_into().expect("16 bytes");
         let header = PageHeader::from_bytes(header_bytes);
 
-        let item_size = self.item_size_for_slot(slot)?;
         let data_len =
             if slot == crate::format::ALLOCATOR_SLOT || arch_id == crate::format::SPARSE_ARCH_ID {
+                // Sparse/allocator pages store a raw byte chunk in `row_count`;
+                // their `slot` is a grouping index, not a schema slot, so do
+                // NOT resolve it via `item_size_for_slot`.
                 header.row_count as usize
             } else {
+                let item_size = self.item_size_for_slot(slot)?;
                 PAGE_SIZE.checked_mul(item_size).ok_or_else(|| {
                     LsmError::Format(format!(
                         "page ({arch_id}, {slot}, {page_index}): data length overflow"

--- a/crates/minkowski-lsm/src/reader.rs
+++ b/crates/minkowski-lsm/src/reader.rs
@@ -538,10 +538,12 @@ mod tests {
             },));
         }
         let dir = tempfile::tempdir().unwrap();
+        let codecs = crate::codec::CodecRegistry::new();
         let path = flush(
             &world,
             SeqRange::new(SeqNo::from(10u64), SeqNo::from(20u64)).unwrap(),
             dir.path(),
+            &codecs,
         )
         .unwrap()
         .unwrap();
@@ -628,10 +630,12 @@ mod tests {
         world.spawn((Vel { dx: 1.0, dy: 0.0 },));
 
         let dir = tempfile::tempdir().unwrap();
+        let codecs = crate::codec::CodecRegistry::new();
         let path = flush(
             &world,
             SeqRange::new(SeqNo::from(0u64), SeqNo::from(0u64)).unwrap(),
             dir.path(),
+            &codecs,
         )
         .unwrap()
         .unwrap();
@@ -709,10 +713,12 @@ mod tests {
         }
 
         let dir = tempfile::tempdir().unwrap();
+        let codecs = crate::codec::CodecRegistry::new();
         let path = flush(
             &world,
             SeqRange::new(SeqNo::from(0u64), SeqNo::from(100u64)).unwrap(),
             dir.path(),
+            &codecs,
         )
         .unwrap()
         .unwrap();

--- a/crates/minkowski-lsm/src/reader.rs
+++ b/crates/minkowski-lsm/src/reader.rs
@@ -295,7 +295,14 @@ impl SortedRunReader {
     /// fast path (direct memcpy, skipping rkyv bytecheck). The CRC covers
     /// `row_count * item_size` bytes — the actual data, not zero-padding.
     pub fn validate_page_crc(&self, page: &PageRef<'_>) -> Result<CrcProof, LsmError> {
-        let item_size = self.item_size_for_slot(page.header().slot)?;
+        // Sparse pages store `chunk.len()` in `row_count` (byte count, not row
+        // count), so item_size is always 1. This mirrors `page_ref_at`'s
+        // `data_len` special-case for `SPARSE_ARCH_ID`.
+        let item_size = if page.header().arch_id == crate::format::SPARSE_ARCH_ID {
+            1
+        } else {
+            self.item_size_for_slot(page.header().slot)?
+        };
         let actual_len = page.header().row_count as usize * item_size;
         let payload = &page.data()[..actual_len];
 

--- a/crates/minkowski-lsm/src/reader.rs
+++ b/crates/minkowski-lsm/src/reader.rs
@@ -255,15 +255,16 @@ impl SortedRunReader {
 
         // Compute and bounds-check data.
         let item_size = self.item_size_for_slot(slot)?;
-        let data_len = if slot == crate::format::ALLOCATOR_SLOT {
-            header.row_count as usize
-        } else {
-            PAGE_SIZE.checked_mul(item_size).ok_or_else(|| {
-                LsmError::Format(format!(
-                    "page ({arch_id}, {slot}, {page_index}): data length overflow"
-                ))
-            })?
-        };
+        let data_len =
+            if slot == crate::format::ALLOCATOR_SLOT || arch_id == crate::format::SPARSE_ARCH_ID {
+                header.row_count as usize
+            } else {
+                PAGE_SIZE.checked_mul(item_size).ok_or_else(|| {
+                    LsmError::Format(format!(
+                        "page ({arch_id}, {slot}, {page_index}): data length overflow"
+                    ))
+                })?
+            };
         let data_start = offset.checked_add(header_size).ok_or_else(|| {
             LsmError::Format(format!(
                 "page ({arch_id}, {slot}, {page_index}): data start overflow"
@@ -380,15 +381,16 @@ impl SortedRunReader {
         let header = PageHeader::from_bytes(header_bytes);
 
         let item_size = self.item_size_for_slot(slot)?;
-        let data_len = if slot == crate::format::ALLOCATOR_SLOT {
-            header.row_count as usize
-        } else {
-            PAGE_SIZE.checked_mul(item_size).ok_or_else(|| {
-                LsmError::Format(format!(
-                    "page ({arch_id}, {slot}, {page_index}): data length overflow"
-                ))
-            })?
-        };
+        let data_len =
+            if slot == crate::format::ALLOCATOR_SLOT || arch_id == crate::format::SPARSE_ARCH_ID {
+                header.row_count as usize
+            } else {
+                PAGE_SIZE.checked_mul(item_size).ok_or_else(|| {
+                    LsmError::Format(format!(
+                        "page ({arch_id}, {slot}, {page_index}): data length overflow"
+                    ))
+                })?
+            };
         let data_start = offset.checked_add(header_size).ok_or_else(|| {
             LsmError::Format(format!(
                 "page ({arch_id}, {slot}, {page_index}): data start overflow"
@@ -441,7 +443,7 @@ impl SortedRunReader {
             .index
             .iter()
             .map(|e| e.arch_id)
-            .filter(|&id| id != crate::format::META_ARCH_ID)
+            .filter(|&id| id != crate::format::META_ARCH_ID && id != crate::format::SPARSE_ARCH_ID)
             .collect();
         ids.sort_unstable();
         ids.dedup();

--- a/crates/minkowski-lsm/src/recovery.rs
+++ b/crates/minkowski-lsm/src/recovery.rs
@@ -127,15 +127,9 @@ impl LsmRecovery {
                     if blob.is_empty() {
                         continue;
                     }
-                    let entries = sparse_page::decode(&blob)?;
-                    let name = reader
-                        .schema()
-                        .entry_for_slot(slot)
-                        .ok_or_else(|| {
-                            LsmError::Format(format!("sparse slot {slot} missing from schema"))
-                        })?
-                        .name()
-                        .to_owned();
+                    // The blob is self-describing: it carries the component's
+                    // stable name. The page `slot` is only a grouping index.
+                    let (name, entries) = sparse_page::decode(&blob)?;
                     components.push((name, entries));
                 }
                 if !components.is_empty() {
@@ -749,6 +743,294 @@ mod tests {
             gen_after,
             gen_before.as_slice(),
             "generations must survive compaction"
+        );
+    }
+
+    // ── Group-C Task-7 tests ──────────────────────────────────────────────
+
+    /// (a) A despawned entity's sparse component must NOT resurface after
+    /// flush+recover. The flush captures net state: despawn erases sparse
+    /// storage before the snapshot is written.
+    #[test]
+    fn sparse_despawn_before_checkpoint_leaves_nothing() {
+        #[derive(Clone, Copy, Archive, Serialize, Deserialize)]
+        #[repr(C)]
+        struct Pos7a {
+            x: f32,
+            y: f32,
+        }
+
+        #[derive(Clone, Copy, PartialEq, Debug, Archive, Serialize, Deserialize)]
+        #[repr(C)]
+        struct Tag7a(u32);
+
+        let dir = tempfile::tempdir().unwrap();
+        let lsm_dir = dir.path().join("lsm");
+        let log_path = lsm_dir.join("manifest.log");
+        std::fs::create_dir_all(&lsm_dir).unwrap();
+
+        let mut world = World::new();
+        let mut codecs = CodecRegistry::new();
+        codecs.register_as::<Pos7a>("pos7a", &mut world).unwrap();
+        codecs.register_as::<Tag7a>("tag7a", &mut world).unwrap();
+
+        // Spawn entity, attach sparse, then despawn — all before flush.
+        let e = world.spawn((Pos7a { x: 1.0, y: 2.0 },));
+        world.insert_sparse::<Tag7a>(e, Tag7a(5));
+        world.despawn(e);
+
+        let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
+        // Spawn a second entity so the world is non-empty and flush actually runs.
+        world.spawn((Pos7a { x: 9.0, y: 9.0 },));
+        flush_and_record(
+            &world,
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(1u64)).unwrap(),
+            &mut manifest,
+            &mut log,
+            &lsm_dir,
+            &codecs,
+        )
+        .unwrap()
+        .expect("flush");
+
+        let (result, _, _) = LsmRecovery::recover::<4>(&lsm_dir, &log_path, &codecs).unwrap();
+        let recovered = result.world;
+
+        // Entity is dead: not alive, sparse must not resurrect.
+        assert!(
+            !recovered.is_alive(e),
+            "despawned entity must not be alive after recovery"
+        );
+        assert!(
+            recovered.get::<Tag7a>(e).is_none(),
+            "sparse component of despawned entity must not appear after recovery"
+        );
+    }
+
+    /// (b) More than u16::MAX bytes of sparse data forces ≥2 pages per
+    /// component. Recovery must concatenate them and return every entry.
+    #[test]
+    fn sparse_multipage_round_trips() {
+        #[derive(Clone, Copy, Archive, Serialize, Deserialize)]
+        #[repr(C)]
+        struct Pos7b {
+            x: f32,
+            y: f32,
+        }
+
+        // Each sparse entry encodes to 8 (entity_bits) + 4 (value_len) + 4 (u32) = 16 bytes.
+        // 5000 entries → 4 (header) + 5000 * 16 = 80_004 bytes > u16::MAX (65_535).
+        #[derive(Clone, Copy, PartialEq, Debug, Archive, Serialize, Deserialize)]
+        #[repr(C)]
+        struct Tag7b(u32);
+
+        let dir = tempfile::tempdir().unwrap();
+        let lsm_dir = dir.path().join("lsm");
+        let log_path = lsm_dir.join("manifest.log");
+        std::fs::create_dir_all(&lsm_dir).unwrap();
+
+        let mut world = World::new();
+        let mut codecs = CodecRegistry::new();
+        codecs.register_as::<Pos7b>("pos7b", &mut world).unwrap();
+        codecs.register_as::<Tag7b>("tag7b", &mut world).unwrap();
+
+        let n: u32 = 5_000;
+        let entities: Vec<_> = (0..n)
+            .map(|i| {
+                let e = world.spawn((Pos7b {
+                    x: i as f32,
+                    y: 0.0,
+                },));
+                world.insert_sparse::<Tag7b>(e, Tag7b(i));
+                e
+            })
+            .collect();
+
+        let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
+        flush_and_record(
+            &world,
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(1u64)).unwrap(),
+            &mut manifest,
+            &mut log,
+            &lsm_dir,
+            &codecs,
+        )
+        .unwrap()
+        .expect("flush");
+
+        let (result, _, _) = LsmRecovery::recover::<4>(&lsm_dir, &log_path, &codecs).unwrap();
+        let recovered = result.world;
+
+        // Check count via iter_sparse.
+        let comp_id = recovered
+            .component_id::<Tag7b>()
+            .expect("Tag7b must be registered");
+        let count = recovered
+            .iter_sparse::<Tag7b>(comp_id)
+            .map_or(0, std::iter::Iterator::count);
+        assert_eq!(count, n as usize, "all {n} sparse entries must survive");
+
+        // Spot-check a sample of values.
+        for &i in &[0u32, 1, 99, 999, 2500, 4999] {
+            let e = entities[i as usize];
+            assert_eq!(
+                recovered.get::<Tag7b>(e).copied(),
+                Some(Tag7b(i)),
+                "entity {i} sparse value mismatch"
+            );
+        }
+    }
+
+    /// (c) An index reused by a new entity after despawn must carry the new
+    /// entity's sparse value, not the old one. Recovery must honour the entity
+    /// generation embedded in sparse entries.
+    #[test]
+    fn sparse_generation_reuse_round_trips() {
+        #[derive(Clone, Copy, Archive, Serialize, Deserialize)]
+        #[repr(C)]
+        struct Pos7c {
+            x: f32,
+            y: f32,
+        }
+
+        #[derive(Clone, Copy, PartialEq, Debug, Archive, Serialize, Deserialize)]
+        #[repr(C)]
+        struct Tag7c(u32);
+
+        let dir = tempfile::tempdir().unwrap();
+        let lsm_dir = dir.path().join("lsm");
+        let log_path = lsm_dir.join("manifest.log");
+        std::fs::create_dir_all(&lsm_dir).unwrap();
+
+        let mut world = World::new();
+        let mut codecs = CodecRegistry::new();
+        codecs.register_as::<Pos7c>("pos7c", &mut world).unwrap();
+        codecs.register_as::<Tag7c>("tag7c", &mut world).unwrap();
+
+        // Spawn `a`, attach sparse, then despawn to free the index.
+        let a = world.spawn((Pos7c { x: 1.0, y: 0.0 },));
+        world.insert_sparse::<Tag7c>(a, Tag7c(1));
+        world.despawn(a);
+
+        // Spawn enough entities to force reuse of `a`'s index. The allocator
+        // returns freed indices from a free-list (LIFO), so the first spawn
+        // after a single despawn reuses the same index with a bumped generation.
+        let b = world.spawn((Pos7c { x: 2.0, y: 0.0 },));
+
+        // If the allocator didn't reuse immediately, spawn more until reuse.
+        let b = if b.index() == a.index() {
+            b
+        } else {
+            // Pad until the recycled slot shows up.
+            let mut found = b;
+            for _ in 0..32 {
+                let e = world.spawn((Pos7c { x: 3.0, y: 0.0 },));
+                if e.index() == a.index() {
+                    found = e;
+                    break;
+                }
+            }
+            found
+        };
+
+        // Whatever happened, b must have a different generation than a.
+        assert_ne!(
+            b.generation(),
+            a.generation(),
+            "recycled entity must have bumped generation"
+        );
+
+        world.insert_sparse::<Tag7c>(b, Tag7c(2));
+
+        let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
+        flush_and_record(
+            &world,
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(1u64)).unwrap(),
+            &mut manifest,
+            &mut log,
+            &lsm_dir,
+            &codecs,
+        )
+        .unwrap()
+        .expect("flush");
+
+        let (result, _, _) = LsmRecovery::recover::<4>(&lsm_dir, &log_path, &codecs).unwrap();
+        let recovered = result.world;
+
+        assert_eq!(
+            recovered.get::<Tag7c>(b).copied(),
+            Some(Tag7c(2)),
+            "new entity's sparse must survive"
+        );
+        assert!(
+            recovered.get::<Tag7c>(a).is_none(),
+            "old (stale generation) entity's sparse must not appear"
+        );
+    }
+
+    /// (d) When two flushes cover the same entity's sparse component, the
+    /// newer run's value must win over the older run's value.
+    #[test]
+    fn sparse_newest_run_wins() {
+        #[derive(Clone, Copy, Archive, Serialize, Deserialize)]
+        #[repr(C)]
+        struct Pos7d {
+            x: f32,
+            y: f32,
+        }
+
+        #[derive(Clone, Copy, PartialEq, Debug, Archive, Serialize, Deserialize)]
+        #[repr(C)]
+        struct Tag7d(u32);
+
+        let dir = tempfile::tempdir().unwrap();
+        let lsm_dir = dir.path().join("lsm");
+        let log_path = lsm_dir.join("manifest.log");
+        std::fs::create_dir_all(&lsm_dir).unwrap();
+
+        let mut world = World::new();
+        let mut codecs = CodecRegistry::new();
+        codecs.register_as::<Pos7d>("pos7d", &mut world).unwrap();
+        codecs.register_as::<Tag7d>("tag7d", &mut world).unwrap();
+
+        // First flush: entity e has Tag7d(1).
+        let e = world.spawn((Pos7d { x: 1.0, y: 2.0 },));
+        world.insert_sparse::<Tag7d>(e, Tag7d(1));
+
+        let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
+        flush_and_record(
+            &world,
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(1u64)).unwrap(),
+            &mut manifest,
+            &mut log,
+            &lsm_dir,
+            &codecs,
+        )
+        .unwrap()
+        .expect("first flush");
+
+        // Second flush: overwrite sparse to Tag7d(2). Spawn an extra archetype
+        // entity so the second flush is non-trivially dirty.
+        world.insert_sparse::<Tag7d>(e, Tag7d(2));
+        world.spawn((Pos7d { x: 99.0, y: 99.0 },));
+        flush_and_record(
+            &world,
+            SeqRange::new(SeqNo::from(1u64), SeqNo::from(2u64)).unwrap(),
+            &mut manifest,
+            &mut log,
+            &lsm_dir,
+            &codecs,
+        )
+        .unwrap()
+        .expect("second flush");
+
+        let (result, _, _) = LsmRecovery::recover::<4>(&lsm_dir, &log_path, &codecs).unwrap();
+        let recovered = result.world;
+
+        assert_eq!(
+            recovered.get::<Tag7d>(e).copied(),
+            Some(Tag7d(2)),
+            "newer run's sparse value must win"
         );
     }
 

--- a/crates/minkowski-lsm/src/recovery.rs
+++ b/crates/minkowski-lsm/src/recovery.rs
@@ -49,7 +49,8 @@ struct StoredAllocator {
 
 struct StoredSparse {
     seq_hi: u64,
-    /// (component stable name, entries) resolved against the winning run's schema.
+    /// (component stable name, entries). The name is decoded directly from each
+    /// self-describing blob — the run's schema is never consulted for sparse.
     components: Vec<(String, SparseEntries)>,
 }
 
@@ -395,8 +396,18 @@ fn apply_sparse(
             ))
         })?;
         for (entity_bits, value) in entries {
+            let entity = Entity::from_bits(*entity_bits);
+            // Defense-in-depth: only restore sparse for entities that are alive
+            // in the materialized world. A blob entry was live at flush time, so
+            // co-located allocator state normally keeps it alive here — but
+            // guarding against any despawn-cleanup gap or allocator/sparse
+            // selection divergence prevents inserting a phantom entry under a
+            // dead (index, generation). Generation match is the source of truth.
+            if !world.is_alive(entity) {
+                continue;
+            }
             codecs
-                .insert_sparse_raw(comp_id, world, Entity::from_bits(*entity_bits), value)
+                .insert_sparse_raw(comp_id, world, entity, value)
                 .map_err(|e| LsmError::Format(format!("sparse restore failed for {name}: {e}")))?;
         }
     }
@@ -483,6 +494,62 @@ mod tests {
 
         assert_eq!(recovered.get::<Tag>(e1).copied(), Some(Tag(111)));
         assert_eq!(recovered.get::<Tag>(e2).copied(), Some(Tag(222)));
+        // The archetype component must survive alongside the sparse one — the
+        // sparse-restore path overlays onto already-materialized entities.
+        assert_eq!(recovered.get::<SparsePos>(e1).map(|p| p.x), Some(1.0));
+        assert_eq!(recovered.get::<SparsePos>(e2).map(|p| p.x), Some(3.0));
+    }
+
+    /// Two distinct sparse component types in a single flush must both round-trip
+    /// — they occupy grouping slots 0 and 1 (name-sorted) under SPARSE_ARCH_ID
+    /// and decode independently.
+    #[test]
+    fn recover_restores_two_sparse_component_types() {
+        #[derive(Clone, Copy, Archive, Serialize, Deserialize)]
+        #[repr(C)]
+        struct PosI {
+            x: f32,
+            y: f32,
+        }
+        #[derive(Clone, Copy, PartialEq, Debug, Archive, Serialize, Deserialize)]
+        #[repr(C)]
+        struct TagA(u32);
+        #[derive(Clone, Copy, PartialEq, Debug, Archive, Serialize, Deserialize)]
+        #[repr(C)]
+        struct TagB(u64);
+
+        let dir = tempfile::tempdir().unwrap();
+        let lsm_dir = dir.path().join("lsm");
+        let log_path = lsm_dir.join("manifest.log");
+        std::fs::create_dir_all(&lsm_dir).unwrap();
+
+        let mut world = World::new();
+        let mut codecs = CodecRegistry::new();
+        codecs.register_as::<PosI>("pos_i", &mut world).unwrap();
+        codecs.register_as::<TagA>("tag_a", &mut world).unwrap();
+        codecs.register_as::<TagB>("tag_b", &mut world).unwrap();
+
+        let e = world.spawn((PosI { x: 1.0, y: 1.0 },));
+        world.insert_sparse::<TagA>(e, TagA(10));
+        world.insert_sparse::<TagB>(e, TagB(20));
+
+        let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
+        flush_and_record(
+            &world,
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(1u64)).unwrap(),
+            &mut manifest,
+            &mut log,
+            &lsm_dir,
+            &codecs,
+        )
+        .unwrap()
+        .expect("flush");
+
+        let (result, _, _) = LsmRecovery::recover::<4>(&lsm_dir, &log_path, &codecs).unwrap();
+        let recovered = result.world;
+
+        assert_eq!(recovered.get::<TagA>(e).copied(), Some(TagA(10)));
+        assert_eq!(recovered.get::<TagB>(e).copied(), Some(TagB(20)));
     }
 
     #[derive(Clone, Copy, Archive, Serialize, Deserialize)]

--- a/crates/minkowski-lsm/src/recovery.rs
+++ b/crates/minkowski-lsm/src/recovery.rs
@@ -390,12 +390,14 @@ mod tests {
         lo: u64,
         hi: u64,
     ) {
+        let codecs = CodecRegistry::new();
         flush_and_record(
             world,
             SeqRange::new(SeqNo::from(lo), SeqNo::from(hi)).unwrap(),
             manifest,
             log,
             dir,
+            &codecs,
         )
         .unwrap()
         .expect("dirty world must flush");

--- a/crates/minkowski-lsm/src/recovery.rs
+++ b/crates/minkowski-lsm/src/recovery.rs
@@ -751,4 +751,63 @@ mod tests {
             "generations must survive compaction"
         );
     }
+
+    /// Sparse components must survive compaction: the compactor carries the
+    /// newest run's sparse pages forward, re-slotted to the output schema.
+    #[test]
+    fn recover_restores_sparse_after_compaction() {
+        #[derive(Clone, Copy, Archive, Serialize, Deserialize)]
+        #[repr(C)]
+        struct SparsePos2 {
+            x: f32,
+            y: f32,
+        }
+
+        #[derive(Clone, Copy, PartialEq, Debug, Archive, Serialize, Deserialize)]
+        #[repr(C)]
+        struct Tag2(u32);
+
+        let dir = tempfile::tempdir().unwrap();
+        let lsm_dir = dir.path().join("lsm");
+        let log_path = lsm_dir.join("manifest.log");
+        std::fs::create_dir_all(&lsm_dir).unwrap();
+
+        let mut world = World::new();
+        let mut codecs = CodecRegistry::new();
+        codecs
+            .register_as::<SparsePos2>("sparse_pos2", &mut world)
+            .unwrap();
+        codecs.register_as::<Tag2>("tag2", &mut world).unwrap();
+
+        let e = world.spawn((SparsePos2 { x: 1.0, y: 2.0 },));
+        world.insert_sparse::<Tag2>(e, Tag2(999));
+
+        let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
+
+        // Flush 4 times to trigger compaction (L0 threshold is 4)
+        for i in 0..4u64 {
+            world.spawn((SparsePos2 {
+                x: i as f32,
+                y: 0.0,
+            },));
+            flush_and_record(
+                &world,
+                SeqRange::new(SeqNo::from(i), SeqNo::from(i + 1)).unwrap(),
+                &mut manifest,
+                &mut log,
+                &lsm_dir,
+                &codecs,
+            )
+            .unwrap()
+            .expect("flush");
+        }
+
+        compact_one(&mut manifest, &mut log, &lsm_dir)
+            .unwrap()
+            .expect("compaction ran");
+
+        let (result, _, _) = LsmRecovery::recover::<4>(&lsm_dir, &log_path, &codecs).unwrap();
+        let recovered = result.world;
+        assert_eq!(recovered.get::<Tag2>(e).copied(), Some(Tag2(999)));
+    }
 }

--- a/crates/minkowski-lsm/src/recovery.rs
+++ b/crates/minkowski-lsm/src/recovery.rs
@@ -132,9 +132,14 @@ impl LsmRecovery {
                     let (name, entries) = sparse_page::decode(&blob)?;
                     components.push((name, entries));
                 }
-                if !components.is_empty() {
-                    sparse = Some(StoredSparse { seq_hi, components });
-                }
+                // Update UNCONDITIONALLY (even when `components` is empty). Every
+                // flush writes the COMPLETE current sparse state, so the newest
+                // run is authoritative: a run with no sparse pages means sparse
+                // is genuinely empty and must supersede an older run's data.
+                // Skipping the update on empty would resurrect components removed
+                // between flushes (e.g. a live entity whose sparse component was
+                // removed before the newer flush).
+                sparse = Some(StoredSparse { seq_hi, components });
             }
 
             for arch_id in reader.archetype_ids() {
@@ -1034,8 +1039,79 @@ mod tests {
         );
     }
 
+    /// (g) A sparse component removed from a still-alive entity between two
+    /// flushes must NOT be resurrected: the newer run authoritatively has no
+    /// sparse pages, so it supersedes the older run that did. Regression for the
+    /// "newest run wins even when empty" rule.
+    #[test]
+    fn sparse_removed_before_second_flush_does_not_resurrect() {
+        #[derive(Clone, Copy, Archive, Serialize, Deserialize)]
+        #[repr(C)]
+        struct Pos7g {
+            x: f32,
+            y: f32,
+        }
+
+        #[derive(Clone, Copy, PartialEq, Debug, Archive, Serialize, Deserialize)]
+        #[repr(C)]
+        struct Tag7g(u32);
+
+        let dir = tempfile::tempdir().unwrap();
+        let lsm_dir = dir.path().join("lsm");
+        let log_path = lsm_dir.join("manifest.log");
+        std::fs::create_dir_all(&lsm_dir).unwrap();
+
+        let mut world = World::new();
+        let mut codecs = CodecRegistry::new();
+        codecs.register_as::<Pos7g>("pos7g", &mut world).unwrap();
+        codecs.register_as::<Tag7g>("tag7g", &mut world).unwrap();
+
+        // First flush: entity e (alive) has Tag7g(7).
+        let e = world.spawn((Pos7g { x: 1.0, y: 2.0 },));
+        world.insert_sparse::<Tag7g>(e, Tag7g(7));
+
+        let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
+        flush_and_record(
+            &world,
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(1u64)).unwrap(),
+            &mut manifest,
+            &mut log,
+            &lsm_dir,
+            &codecs,
+        )
+        .unwrap()
+        .expect("first flush");
+
+        // Remove the sparse component while e stays alive, then flush again
+        // (spawn another entity so the second flush is dirty). The second run
+        // therefore has NO sparse pages.
+        let mut cs = minkowski::EnumChangeSet::new();
+        cs.remove_sparse::<Tag7g>(&mut world, e);
+        cs.apply(&mut world).unwrap();
+        world.spawn((Pos7g { x: 9.0, y: 9.0 },));
+        flush_and_record(
+            &world,
+            SeqRange::new(SeqNo::from(1u64), SeqNo::from(2u64)).unwrap(),
+            &mut manifest,
+            &mut log,
+            &lsm_dir,
+            &codecs,
+        )
+        .unwrap()
+        .expect("second flush");
+
+        let (result, _, _) = LsmRecovery::recover::<4>(&lsm_dir, &log_path, &codecs).unwrap();
+        let recovered = result.world;
+
+        assert_eq!(
+            recovered.get::<Tag7g>(e),
+            None,
+            "removed sparse component must not be resurrected by recovery"
+        );
+    }
+
     /// Sparse components must survive compaction: the compactor carries the
-    /// newest run's sparse pages forward, re-slotted to the output schema.
+    /// newest run's sparse pages forward verbatim (self-describing blobs).
     #[test]
     fn recover_restores_sparse_after_compaction() {
         #[derive(Clone, Copy, Archive, Serialize, Deserialize)]

--- a/crates/minkowski-lsm/src/recovery.rs
+++ b/crates/minkowski-lsm/src/recovery.rs
@@ -9,11 +9,12 @@ use minkowski::{ComponentId, Entity, EnumChangeSet, World};
 use crate::allocator_meta;
 use crate::codec::CodecRegistry;
 use crate::error::LsmError;
-use crate::format::{ALLOCATOR_SLOT, ENTITY_SLOT, META_ARCH_ID, PAGE_SIZE};
+use crate::format::{ALLOCATOR_SLOT, ENTITY_SLOT, META_ARCH_ID, PAGE_SIZE, SPARSE_ARCH_ID};
 use crate::manifest::{LsmManifest, SortedRunMeta};
 use crate::manifest_log::ManifestLog;
 use crate::manifest_ops::cleanup_orphans;
 use crate::reader::SortedRunReader;
+use crate::sparse_page;
 use crate::types::Level;
 
 /// Result of an LSM recovery operation.
@@ -29,6 +30,8 @@ pub struct LsmRecovery;
 
 type ArchetypeSig = Vec<String>;
 type PageKey = (ArchetypeSig, u16, u16);
+/// Raw sparse entries for one component: `(entity_bits, rkyv_value_bytes)`.
+type SparseEntries = Vec<(u64, Vec<u8>)>;
 
 #[derive(Clone)]
 struct StoredPage {
@@ -42,6 +45,12 @@ struct StoredAllocator {
     seq_hi: u64,
     generations: Vec<u32>,
     free_list: Vec<u32>,
+}
+
+struct StoredSparse {
+    seq_hi: u64,
+    /// (component stable name, entries) resolved against the winning run's schema.
+    components: Vec<(String, SparseEntries)>,
 }
 
 impl LsmRecovery {
@@ -65,6 +74,7 @@ impl LsmRecovery {
 
         let mut pages: BTreeMap<PageKey, StoredPage> = BTreeMap::new();
         let mut allocator: Option<StoredAllocator> = None;
+        let mut sparse: Option<StoredSparse> = None;
         let mut component_layouts: BTreeMap<String, (usize, usize)> = BTreeMap::new();
         let mut max_seq_hi = 0u64;
 
@@ -103,8 +113,38 @@ impl LsmRecovery {
                 }
             }
 
+            // Sparse baseline: newest run wins wholesale (same rule as allocator).
+            if sparse.as_ref().is_none_or(|s| seq_hi >= s.seq_hi) {
+                let mut components: Vec<(String, SparseEntries)> = Vec::new();
+                for slot in reader.component_slots_for_arch(SPARSE_ARCH_ID) {
+                    let mut blob: Vec<u8> = Vec::new();
+                    for result in reader.slot_pages(SPARSE_ARCH_ID, slot) {
+                        let (_page_index, page) = result?;
+                        reader.validate_page_crc(&page)?;
+                        let len = page.header().row_count as usize;
+                        blob.extend_from_slice(&page.data()[..len]);
+                    }
+                    if blob.is_empty() {
+                        continue;
+                    }
+                    let entries = sparse_page::decode(&blob)?;
+                    let name = reader
+                        .schema()
+                        .entry_for_slot(slot)
+                        .ok_or_else(|| {
+                            LsmError::Format(format!("sparse slot {slot} missing from schema"))
+                        })?
+                        .name()
+                        .to_owned();
+                    components.push((name, entries));
+                }
+                if !components.is_empty() {
+                    sparse = Some(StoredSparse { seq_hi, components });
+                }
+            }
+
             for arch_id in reader.archetype_ids() {
-                if arch_id == META_ARCH_ID {
+                if arch_id == META_ARCH_ID || arch_id == SPARSE_ARCH_ID {
                     continue;
                 }
                 let sig = archetype_signature(&reader, arch_id)?;
@@ -158,7 +198,8 @@ impl LsmRecovery {
             pages.is_empty() || !component_layouts.is_empty(),
             "recovery: pages present but no component layouts were resolved"
         );
-        let world = materialize_world(pages, allocator.as_ref(), &component_layouts, codecs)?;
+        let mut world = materialize_world(pages, allocator.as_ref(), &component_layouts, codecs)?;
+        apply_sparse(&mut world, sparse.as_ref(), codecs)?;
         Ok((RecoveryResult { world, flush_seq }, manifest, log))
     }
 }
@@ -337,6 +378,32 @@ fn materialize_world(
     Ok(world)
 }
 
+/// Re-inserts the baseline sparse state captured from the newest run. Runs
+/// after `materialize_world` so entity generations are already restored. Uses
+/// the codec sparse seam, which sets the correct drop function for each set.
+fn apply_sparse(
+    world: &mut World,
+    stored: Option<&StoredSparse>,
+    codecs: &CodecRegistry,
+) -> Result<(), LsmError> {
+    let Some(stored) = stored else {
+        return Ok(());
+    };
+    for (name, entries) in &stored.components {
+        let comp_id = resolve_schema_component(codecs, world, name).ok_or_else(|| {
+            LsmError::Format(format!(
+                "sparse component {name} not registered on recovery"
+            ))
+        })?;
+        for (entity_bits, value) in entries {
+            codecs
+                .insert_sparse_raw(comp_id, world, Entity::from_bits(*entity_bits), value)
+                .map_err(|e| LsmError::Format(format!("sparse restore failed for {name}: {e}")))?;
+        }
+    }
+    Ok(())
+}
+
 fn reconcile_allocator(world: &mut World, stored: Option<&StoredAllocator>) {
     let mut max_index = 0u32;
     for arch_idx in 0..world.archetype_count() {
@@ -369,6 +436,55 @@ mod tests {
     use crate::manifest_ops::flush_and_record;
     use crate::types::{SeqNo, SeqRange};
     use rkyv::{Archive, Deserialize, Serialize};
+
+    #[test]
+    fn recover_restores_sparse_components() {
+        #[derive(Clone, Copy, Archive, Serialize, Deserialize)]
+        #[repr(C)]
+        struct SparsePos {
+            x: f32,
+            y: f32,
+        }
+
+        #[derive(Clone, Copy, PartialEq, Debug, Archive, Serialize, Deserialize)]
+        #[repr(C)]
+        struct Tag(u32);
+
+        let dir = tempfile::tempdir().unwrap();
+        let lsm_dir = dir.path().join("lsm");
+        let log_path = lsm_dir.join("manifest.log");
+        std::fs::create_dir_all(&lsm_dir).unwrap();
+
+        let mut world = World::new();
+        let mut codecs = CodecRegistry::new();
+        codecs
+            .register_as::<SparsePos>("sparse_pos", &mut world)
+            .unwrap();
+        codecs.register_as::<Tag>("tag", &mut world).unwrap();
+
+        let e1 = world.spawn((SparsePos { x: 1.0, y: 2.0 },));
+        let e2 = world.spawn((SparsePos { x: 3.0, y: 4.0 },));
+        world.insert_sparse::<Tag>(e1, Tag(111));
+        world.insert_sparse::<Tag>(e2, Tag(222));
+
+        let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
+        flush_and_record(
+            &world,
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(1u64)).unwrap(),
+            &mut manifest,
+            &mut log,
+            &lsm_dir,
+            &codecs,
+        )
+        .unwrap()
+        .expect("flush");
+
+        let (result, _, _) = LsmRecovery::recover::<4>(&lsm_dir, &log_path, &codecs).unwrap();
+        let recovered = result.world;
+
+        assert_eq!(recovered.get::<Tag>(e1).copied(), Some(Tag(111)));
+        assert_eq!(recovered.get::<Tag>(e2).copied(), Some(Tag(222)));
+    }
 
     #[derive(Clone, Copy, Archive, Serialize, Deserialize)]
     struct Pos {

--- a/crates/minkowski-lsm/src/schema_match.rs
+++ b/crates/minkowski-lsm/src/schema_match.rs
@@ -85,10 +85,12 @@ mod tests {
         seq_hi: u64,
     ) -> (tempfile::TempDir, SortedRunReader) {
         let dir = tempfile::tempdir().unwrap();
+        let codecs = crate::codec::CodecRegistry::new();
         let path = flush(
             world,
             SeqRange::new(SeqNo::from(seq_lo), SeqNo::from(seq_hi)).unwrap(),
             dir.path(),
+            &codecs,
         )
         .unwrap()
         .unwrap();

--- a/crates/minkowski-lsm/src/sparse_page.rs
+++ b/crates/minkowski-lsm/src/sparse_page.rs
@@ -50,6 +50,11 @@ pub fn encode(name: &str, entries: &[(u64, Vec<u8>)]) -> Vec<u8> {
 pub fn decode(bytes: &[u8]) -> Result<DecodedSparse, LsmError> {
     let mut pos = 0usize;
     let name_len = read_u32(bytes, &mut pos)? as usize;
+    if name_len == 0 {
+        return Err(LsmError::Format(
+            "sparse_page: component name is empty".to_owned(),
+        ));
+    }
     let name_end = pos
         .checked_add(name_len)
         .filter(|&e| e <= bytes.len())

--- a/crates/minkowski-lsm/src/sparse_page.rs
+++ b/crates/minkowski-lsm/src/sparse_page.rs
@@ -1,0 +1,108 @@
+//! Length-prefixed, self-delimiting encoding for a sparse component's baseline
+//! pages. One blob per sparse component: `[count u32][(entity_bits u64,
+//! value_len u32, value_bytes)…]`. Mirrors `allocator_meta` (self-describing,
+//! trailing-byte-checked). The blob is chunked at `u16::MAX` bytes across
+//! `page_index` by the writer and concatenated back by recovery before decode.
+
+use crate::error::LsmError;
+
+/// Encode a sparse component's entries into a self-delimiting blob.
+pub fn encode(entries: &[(u64, Vec<u8>)]) -> Vec<u8> {
+    let total: usize = 4 + entries.iter().map(|(_, v)| 8 + 4 + v.len()).sum::<usize>();
+    let mut out = Vec::with_capacity(total);
+    out.extend_from_slice(
+        &u32::try_from(entries.len())
+            .expect("entry count exceeds u32")
+            .to_le_bytes(),
+    );
+    for (entity_bits, value) in entries {
+        out.extend_from_slice(&entity_bits.to_le_bytes());
+        out.extend_from_slice(
+            &u32::try_from(value.len())
+                .expect("value length exceeds u32")
+                .to_le_bytes(),
+        );
+        out.extend_from_slice(value);
+    }
+    out
+}
+
+/// Decode a blob produced by [`encode`]. Errors on truncation or trailing bytes.
+pub fn decode(bytes: &[u8]) -> Result<Vec<(u64, Vec<u8>)>, LsmError> {
+    let mut pos = 0usize;
+    let count = read_u32(bytes, &mut pos)? as usize;
+    let mut entries = Vec::with_capacity(count);
+    for _ in 0..count {
+        let entity_bits = read_u64(bytes, &mut pos)?;
+        let value_len = read_u32(bytes, &mut pos)? as usize;
+        let end = pos
+            .checked_add(value_len)
+            .filter(|&e| e <= bytes.len())
+            .ok_or_else(|| LsmError::Format("sparse_page: value region truncated".to_owned()))?;
+        entries.push((entity_bits, bytes[pos..end].to_vec()));
+        pos = end;
+    }
+    if pos != bytes.len() {
+        return Err(LsmError::Format(format!(
+            "sparse_page: {} trailing bytes after decode",
+            bytes.len() - pos
+        )));
+    }
+    Ok(entries)
+}
+
+fn read_u32(bytes: &[u8], pos: &mut usize) -> Result<u32, LsmError> {
+    let end = *pos + 4;
+    let slice = bytes
+        .get(*pos..end)
+        .ok_or_else(|| LsmError::Format("sparse_page: truncated u32".to_owned()))?;
+    *pos = end;
+    Ok(u32::from_le_bytes(slice.try_into().expect("4 bytes")))
+}
+
+fn read_u64(bytes: &[u8], pos: &mut usize) -> Result<u64, LsmError> {
+    let end = *pos + 8;
+    let slice = bytes
+        .get(*pos..end)
+        .ok_or_else(|| LsmError::Format("sparse_page: truncated u64".to_owned()))?;
+    *pos = end;
+    Ok(u64::from_le_bytes(slice.try_into().expect("8 bytes")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_entries() {
+        let entries = vec![
+            (1u64, vec![10u8, 11, 12]),
+            (2u64, vec![]),
+            (0xFFFF_FFFF_0000_0001u64, vec![42u8; 300]),
+        ];
+        let blob = encode(&entries);
+        let decoded = decode(&blob).unwrap();
+        assert_eq!(decoded, entries);
+    }
+
+    #[test]
+    fn round_trips_empty() {
+        let entries: Vec<(u64, Vec<u8>)> = Vec::new();
+        let blob = encode(&entries);
+        assert_eq!(decode(&blob).unwrap(), entries);
+    }
+
+    #[test]
+    fn rejects_truncated() {
+        let blob = encode(&[(1u64, vec![1, 2, 3])]);
+        let truncated = &blob[..blob.len() - 1];
+        assert!(decode(truncated).is_err());
+    }
+
+    #[test]
+    fn rejects_trailing_garbage() {
+        let mut blob = encode(&[(1u64, vec![1, 2, 3])]);
+        blob.push(0xAB);
+        assert!(decode(&blob).is_err());
+    }
+}

--- a/crates/minkowski-lsm/src/sparse_page.rs
+++ b/crates/minkowski-lsm/src/sparse_page.rs
@@ -1,15 +1,33 @@
 //! Length-prefixed, self-delimiting encoding for a sparse component's baseline
-//! pages. One blob per sparse component: `[count u32][(entity_bits u64,
-//! value_len u32, value_bytes)…]`. Mirrors `allocator_meta` (self-describing,
-//! trailing-byte-checked). The blob is chunked at `u16::MAX` bytes across
-//! `page_index` by the writer and concatenated back by recovery before decode.
+//! pages. One blob per sparse component, carrying its own stable component
+//! NAME so recovery can resolve the component without consulting the run's
+//! `SchemaSection`: `[name_len u32][name_utf8][count u32][(entity_bits u64,
+//! value_len u32, value_bytes)…]`.
+//!
+//! Keeping the name in the blob deliberately decouples sparse storage from the
+//! archetype schema: sparse components are NOT added to `SchemaSection`, so
+//! they cannot perturb archetype component slot assignments. The blob is
+//! chunked at `u16::MAX` bytes across `page_index` by the writer and
+//! concatenated back by recovery before decode. Mirrors `allocator_meta`
+//! (self-describing, trailing-byte-checked).
 
 use crate::error::LsmError;
 
-/// Encode a sparse component's entries into a self-delimiting blob.
-pub fn encode(entries: &[(u64, Vec<u8>)]) -> Vec<u8> {
-    let total: usize = 4 + entries.iter().map(|(_, v)| 8 + 4 + v.len()).sum::<usize>();
+/// A decoded sparse blob: the component's stable name and its
+/// `(entity_bits, value_bytes)` entries.
+pub type DecodedSparse = (String, Vec<(u64, Vec<u8>)>);
+
+/// Encode a sparse component's name + entries into a self-delimiting blob.
+pub fn encode(name: &str, entries: &[(u64, Vec<u8>)]) -> Vec<u8> {
+    let total: usize =
+        4 + name.len() + 4 + entries.iter().map(|(_, v)| 8 + 4 + v.len()).sum::<usize>();
     let mut out = Vec::with_capacity(total);
+    out.extend_from_slice(
+        &u32::try_from(name.len())
+            .expect("name length exceeds u32")
+            .to_le_bytes(),
+    );
+    out.extend_from_slice(name.as_bytes());
     out.extend_from_slice(
         &u32::try_from(entries.len())
             .expect("entry count exceeds u32")
@@ -27,9 +45,20 @@ pub fn encode(entries: &[(u64, Vec<u8>)]) -> Vec<u8> {
     out
 }
 
-/// Decode a blob produced by [`encode`]. Errors on truncation or trailing bytes.
-pub fn decode(bytes: &[u8]) -> Result<Vec<(u64, Vec<u8>)>, LsmError> {
+/// Decode a blob produced by [`encode`], returning the component name and its
+/// entries. Errors on truncation, invalid UTF-8 name, or trailing bytes.
+pub fn decode(bytes: &[u8]) -> Result<DecodedSparse, LsmError> {
     let mut pos = 0usize;
+    let name_len = read_u32(bytes, &mut pos)? as usize;
+    let name_end = pos
+        .checked_add(name_len)
+        .filter(|&e| e <= bytes.len())
+        .ok_or_else(|| LsmError::Format("sparse_page: name region truncated".to_owned()))?;
+    let name = std::str::from_utf8(&bytes[pos..name_end])
+        .map_err(|e| LsmError::Format(format!("sparse_page: invalid component name: {e}")))?
+        .to_owned();
+    pos = name_end;
+
     let count = read_u32(bytes, &mut pos)? as usize;
     let mut entries = Vec::with_capacity(count);
     for _ in 0..count {
@@ -48,7 +77,7 @@ pub fn decode(bytes: &[u8]) -> Result<Vec<(u64, Vec<u8>)>, LsmError> {
             bytes.len() - pos
         )));
     }
-    Ok(entries)
+    Ok((name, entries))
 }
 
 fn read_u32(bytes: &[u8], pos: &mut usize) -> Result<u32, LsmError> {
@@ -80,28 +109,31 @@ mod tests {
             (2u64, vec![]),
             (0xFFFF_FFFF_0000_0001u64, vec![42u8; 300]),
         ];
-        let blob = encode(&entries);
-        let decoded = decode(&blob).unwrap();
+        let blob = encode("my_component", &entries);
+        let (name, decoded) = decode(&blob).unwrap();
+        assert_eq!(name, "my_component");
         assert_eq!(decoded, entries);
     }
 
     #[test]
     fn round_trips_empty() {
         let entries: Vec<(u64, Vec<u8>)> = Vec::new();
-        let blob = encode(&entries);
-        assert_eq!(decode(&blob).unwrap(), entries);
+        let blob = encode("empty_component", &entries);
+        let (name, decoded) = decode(&blob).unwrap();
+        assert_eq!(name, "empty_component");
+        assert_eq!(decoded, entries);
     }
 
     #[test]
     fn rejects_truncated() {
-        let blob = encode(&[(1u64, vec![1, 2, 3])]);
+        let blob = encode("c", &[(1u64, vec![1, 2, 3])]);
         let truncated = &blob[..blob.len() - 1];
         assert!(decode(truncated).is_err());
     }
 
     #[test]
     fn rejects_trailing_garbage() {
-        let mut blob = encode(&[(1u64, vec![1, 2, 3])]);
+        let mut blob = encode("c", &[(1u64, vec![1, 2, 3])]);
         blob.push(0xAB);
         assert!(decode(&blob).is_err());
     }

--- a/crates/minkowski-lsm/src/writer.rs
+++ b/crates/minkowski-lsm/src/writer.rs
@@ -44,10 +44,11 @@ fn to_u16(value: usize, label: &str) -> Result<u16, LsmError> {
 /// on recovery, so we refuse to write it rather than lose data.
 fn arch_id_to_u16(value: usize) -> Result<u16, LsmError> {
     let id = to_u16(value, "arch_idx")?;
-    // META_ARCH_ID is u16::MAX, so it is the only reserved arch_id value.
-    if id == META_ARCH_ID {
+    // Reserved sentinels (META_ARCH_ID = 0xFFFF, SPARSE_ARCH_ID = 0xFFFD) must
+    // never be a real archetype id, or recovery would misclassify the pages.
+    if id == META_ARCH_ID || id == SPARSE_ARCH_ID {
         return Err(LsmError::Format(format!(
-            "arch_idx {value} collides with reserved META_ARCH_ID"
+            "arch_idx {value} collides with a reserved arch_id sentinel"
         )));
     }
     Ok(id)
@@ -116,8 +117,16 @@ pub fn flush_observed(
     }
     let mut sparse_blobs: Vec<SparseBlob> = Vec::new();
     for comp_id in world.sparse_component_ids() {
-        // Skip sparse components with no codec — they cannot be serialized.
         if !codecs.has_codec(comp_id) {
+            // A sparse component with storage but no codec cannot be serialized
+            // to the baseline. Warn loudly rather than drop silently — if it
+            // holds live entries they will not survive recovery. The fix is to
+            // register the component via CodecRegistry before persisting.
+            let name = world.component_name(comp_id).unwrap_or("<unknown>");
+            eprintln!(
+                "warning: sparse component '{name}' (id={comp_id}) has no registered codec; \
+                 its data will NOT be persisted to the LSM baseline"
+            );
             continue;
         }
         let entries = codecs
@@ -138,9 +147,11 @@ pub fn flush_observed(
     // Deterministic order so a grouping-slot index is stable across identical
     // flushes (the slot is purely a per-run page grouping key).
     sparse_blobs.sort_by(|a, b| a.name.cmp(&b.name));
+    // Each blob is non-empty (it always carries at least a name + count header),
+    // so `div_ceil` yields ≥ 1 page per component.
     let sparse_page_count: usize = sparse_blobs
         .iter()
-        .map(|s| s.blob.len().div_ceil(ALLOCATOR_PAGE_MAX_BYTES).max(1))
+        .map(|s| s.blob.len().div_ceil(ALLOCATOR_PAGE_MAX_BYTES))
         .sum();
 
     // ── 2. Early return if nothing dirty ────────────────────────────────────
@@ -468,6 +479,15 @@ pub fn flush_observed(
             });
         }
     }
+
+    // Bypass-path integrity: the header's `page_count` must equal the number of
+    // pages actually written (one index entry per page). A mismatch corrupts the
+    // file (the reader trusts `page_count`), so assert it in release builds.
+    assert_eq!(
+        index_entries.len(),
+        page_count,
+        "page_count header must match the number of pages written"
+    );
 
     // (e) Sparse index — sort by (arch_id, slot, page_index) so the reader
     //     can binary-search.  Component pages are already sorted by their

--- a/crates/minkowski-lsm/src/writer.rs
+++ b/crates/minkowski-lsm/src/writer.rs
@@ -7,6 +7,7 @@ use minkowski::World;
 
 use crate::allocator_meta;
 use crate::bloom;
+use crate::codec::CodecRegistry;
 use crate::error::LsmError;
 use crate::format::*;
 use crate::schema::SchemaSection;
@@ -67,8 +68,9 @@ pub fn flush(
     world: &World,
     sequence_range: SeqRange,
     output_dir: &Path,
+    codecs: &CodecRegistry,
 ) -> Result<Option<PathBuf>, LsmError> {
-    flush_observed(world, sequence_range, output_dir, None)
+    flush_observed(world, sequence_range, output_dir, codecs, None)
 }
 
 /// Like [`flush`], but invokes `observer` once per entity ID written to an
@@ -81,8 +83,10 @@ pub fn flush_observed(
     world: &World,
     sequence_range: SeqRange,
     output_dir: &Path,
+    codecs: &CodecRegistry,
     mut observer: Option<&mut dyn FnMut(EntityKey)>,
 ) -> Result<Option<PathBuf>, LsmError> {
+    let _ = codecs; // unused until sparse serialization (next commit)
     // ── 1. Collect dirty page set ───────────────────────────────────────────
     // Key: (arch_idx, comp_id, page_index)
     let mut dirty: BTreeSet<(usize, usize, usize)> = BTreeSet::new();
@@ -516,6 +520,7 @@ mod tests {
             &world,
             SeqRange::new(SeqNo::from(0u64), SeqNo::from(0u64)).unwrap(),
             dir.path(),
+            &CodecRegistry::new(),
         )
         .unwrap();
         assert!(result.is_none());
@@ -531,6 +536,7 @@ mod tests {
             &world,
             SeqRange::new(SeqNo::from(1u64), SeqNo::from(5u64)).unwrap(),
             dir.path(),
+            &CodecRegistry::new(),
         )
         .unwrap();
         assert!(result.is_some());
@@ -548,6 +554,7 @@ mod tests {
             &world,
             SeqRange::new(SeqNo::from(10u64), SeqNo::from(20u64)).unwrap(),
             dir.path(),
+            &CodecRegistry::new(),
         )
         .unwrap();
         let path = result.unwrap();
@@ -565,6 +572,7 @@ mod tests {
             &world,
             SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
             dir.path(),
+            &CodecRegistry::new(),
         )
         .unwrap();
         assert!(result.is_some());
@@ -590,6 +598,7 @@ mod tests {
             &world,
             SeqRange::new(SeqNo::from(0u64), SeqNo::from(1u64)).unwrap(),
             dir.path(),
+            &CodecRegistry::new(),
         )
         .unwrap()
         .unwrap();
@@ -614,10 +623,12 @@ mod tests {
         let observed_clone = Rc::clone(&observed);
 
         let dir = tempfile::tempdir().unwrap();
+        let codecs = CodecRegistry::new();
         let result = flush_observed(
             &world,
             SeqRange::new(SeqNo::from(1u64), SeqNo::from(5u64)).unwrap(),
             dir.path(),
+            &codecs,
             Some(&mut |key: EntityKey| {
                 observed_clone.borrow_mut().push(key.0);
             }),
@@ -645,6 +656,7 @@ mod tests {
             &world,
             SeqRange::new(SeqNo::from(0u64), SeqNo::from(0u64)).unwrap(),
             dir.path(),
+            &CodecRegistry::new(),
         )
         .unwrap()
         .unwrap();

--- a/crates/minkowski-lsm/src/writer.rs
+++ b/crates/minkowski-lsm/src/writer.rs
@@ -105,9 +105,13 @@ pub fn flush_observed(
     }
 
     // ── 1b. Collect sparse component blobs (complete current sparse state) ───
+    // Each sparse component becomes one self-describing blob (its stable NAME is
+    // embedded by `sparse_page::encode`), chunked into SPARSE_ARCH_ID pages.
+    // Sparse components are deliberately NOT added to the archetype schema, so
+    // they cannot perturb archetype component slot assignments; recovery reads
+    // the component name from the blob, not from the schema.
     struct SparseBlob {
         name: String,
-        layout: std::alloc::Layout,
         blob: Vec<u8>,
     }
     let mut sparse_blobs: Vec<SparseBlob> = Vec::new();
@@ -123,22 +127,16 @@ pub fn flush_observed(
             continue;
         }
         // Use the codec's stable name (explicit or type_name default) so that
-        // the schema slot name matches what recovery uses to look up the codec.
-        // `world.component_name` returns the Rust type_name, which differs from
-        // an explicit stable name registered via `register_as`.
+        // recovery resolves the same codec via `resolve_name`.
         let name = codecs
             .stable_name(comp_id)
             .expect("has_codec guard ensures stable_name is Some")
             .to_owned();
-        let layout = world
-            .component_layout(comp_id)
-            .ok_or_else(|| LsmError::Format(format!("sparse component {comp_id} no layout")))?;
-        sparse_blobs.push(SparseBlob {
-            name,
-            layout,
-            blob: sparse_page::encode(&entries),
-        });
+        let blob = sparse_page::encode(&name, &entries);
+        sparse_blobs.push(SparseBlob { name, blob });
     }
+    // Deterministic order so a grouping-slot index is stable across identical
+    // flushes (the slot is purely a per-run page grouping key).
     sparse_blobs.sort_by(|a, b| a.name.cmp(&b.name));
     let sparse_page_count: usize = sparse_blobs
         .iter()
@@ -156,7 +154,11 @@ pub fn flush_observed(
         seen_comp_ids.insert(comp_id);
     }
 
-    let mut components: Vec<(String, std::alloc::Layout)> = seen_comp_ids
+    // Schema contains ONLY archetype (dirty) components. Sparse components are
+    // intentionally excluded — they carry their name in their own blob and use
+    // a separate `SPARSE_ARCH_ID` page space, so they never affect archetype
+    // slot assignment.
+    let components: Vec<(String, std::alloc::Layout)> = seen_comp_ids
         .iter()
         .map(|&comp_id| {
             let name = world
@@ -168,13 +170,6 @@ pub fn flush_observed(
             (name.to_owned(), layout)
         })
         .collect();
-
-    // Add sparse-only components to the schema so their slots resolve.
-    // `from_components` deduplicates by name, so components that appear in
-    // both archetype columns and sparse storage are not double-counted.
-    for s in &sparse_blobs {
-        components.push((s.name.clone(), s.layout));
-    }
 
     let schema = SchemaSection::from_components(&components)?;
 
@@ -441,14 +436,14 @@ pub fn flush_observed(
         });
     }
 
-    // (d3) Sparse component pages — complete current sparse state, keyed by the
-    //      component's schema slot under SPARSE_ARCH_ID. Each blob is chunked at
+    // (d3) Sparse component pages — complete current sparse state under
+    //      SPARSE_ARCH_ID. The `slot` is a per-run grouping index (the blob's
+    //      position in name-sorted order), NOT a schema slot — recovery reads
+    //      the component name from the blob. Each blob is chunked at
     //      ALLOCATOR_PAGE_MAX_BYTES (the row_count u16 cap); recovery
     //      concatenates chunks per slot before decode.
-    for s in &sparse_blobs {
-        let slot = schema
-            .slot_for(&s.name)
-            .expect("sparse component must be in schema");
+    for (group_idx, s) in sparse_blobs.iter().enumerate() {
+        let slot = to_u16(group_idx, "sparse group slot")?;
         for (page_index, chunk) in s.blob.chunks(ALLOCATOR_PAGE_MAX_BYTES).enumerate() {
             let page_index = to_u16(page_index, "sparse page_index")?;
             let page_crc = crc32fast::hash(chunk);
@@ -761,17 +756,16 @@ mod tests {
         let path = flush(&world, range, dir.path(), &codecs).unwrap().unwrap();
 
         let reader = SortedRunReader::open(&path).unwrap();
-        let tag_slot = reader
-            .schema()
-            .slot_for("tag")
-            .expect("tag must be in schema");
+        // Sparse components are NOT in the archetype schema; the single sparse
+        // component occupies grouping slot 0 and carries its name in the blob.
         let mut blob = Vec::new();
-        for result in reader.slot_pages(SPARSE_ARCH_ID, tag_slot) {
+        for result in reader.slot_pages(SPARSE_ARCH_ID, 0) {
             let (_pi, page) = result.unwrap();
             reader.validate_page_crc(&page).unwrap();
             blob.extend_from_slice(&page.data()[..page.header().row_count as usize]);
         }
-        let entries = sparse_page::decode(&blob).unwrap();
+        let (name, entries) = sparse_page::decode(&blob).unwrap();
+        assert_eq!(name, "tag");
         let mut tags: Vec<u64> = entries.iter().map(|(e, _)| *e).collect();
         tags.sort_unstable();
         let mut want = vec![e1.to_bits(), e2.to_bits()];

--- a/crates/minkowski-lsm/src/writer.rs
+++ b/crates/minkowski-lsm/src/writer.rs
@@ -11,6 +11,7 @@ use crate::codec::CodecRegistry;
 use crate::error::LsmError;
 use crate::format::*;
 use crate::schema::SchemaSection;
+use crate::sparse_page;
 use crate::types::SeqRange;
 
 /// The value passed to an [`EntryObserver`] for each entity written to an
@@ -86,7 +87,6 @@ pub fn flush_observed(
     codecs: &CodecRegistry,
     mut observer: Option<&mut dyn FnMut(EntityKey)>,
 ) -> Result<Option<PathBuf>, LsmError> {
-    let _ = codecs; // unused until sparse serialization (next commit)
     // ── 1. Collect dirty page set ───────────────────────────────────────────
     // Key: (arch_idx, comp_id, page_index)
     let mut dirty: BTreeSet<(usize, usize, usize)> = BTreeSet::new();
@@ -104,8 +104,49 @@ pub fn flush_observed(
         }
     }
 
+    // ── 1b. Collect sparse component blobs (complete current sparse state) ───
+    struct SparseBlob {
+        name: String,
+        layout: std::alloc::Layout,
+        blob: Vec<u8>,
+    }
+    let mut sparse_blobs: Vec<SparseBlob> = Vec::new();
+    for comp_id in world.sparse_component_ids() {
+        // Skip sparse components with no codec — they cannot be serialized.
+        if !codecs.has_codec(comp_id) {
+            continue;
+        }
+        let entries = codecs
+            .serialize_sparse(comp_id, world)
+            .map_err(|e| LsmError::Format(format!("sparse serialize failed: {e}")))?;
+        if entries.is_empty() {
+            continue;
+        }
+        // Use the codec's stable name (explicit or type_name default) so that
+        // the schema slot name matches what recovery uses to look up the codec.
+        // `world.component_name` returns the Rust type_name, which differs from
+        // an explicit stable name registered via `register_as`.
+        let name = codecs
+            .stable_name(comp_id)
+            .expect("has_codec guard ensures stable_name is Some")
+            .to_owned();
+        let layout = world
+            .component_layout(comp_id)
+            .ok_or_else(|| LsmError::Format(format!("sparse component {comp_id} no layout")))?;
+        sparse_blobs.push(SparseBlob {
+            name,
+            layout,
+            blob: sparse_page::encode(&entries),
+        });
+    }
+    sparse_blobs.sort_by(|a, b| a.name.cmp(&b.name));
+    let sparse_page_count: usize = sparse_blobs
+        .iter()
+        .map(|s| s.blob.len().div_ceil(ALLOCATOR_PAGE_MAX_BYTES).max(1))
+        .sum();
+
     // ── 2. Early return if nothing dirty ────────────────────────────────────
-    if dirty.is_empty() {
+    if dirty.is_empty() && sparse_blobs.is_empty() {
         return Ok(None);
     }
 
@@ -115,7 +156,7 @@ pub fn flush_observed(
         seen_comp_ids.insert(comp_id);
     }
 
-    let components: Vec<(String, std::alloc::Layout)> = seen_comp_ids
+    let mut components: Vec<(String, std::alloc::Layout)> = seen_comp_ids
         .iter()
         .map(|&comp_id| {
             let name = world
@@ -127,6 +168,13 @@ pub fn flush_observed(
             (name.to_owned(), layout)
         })
         .collect();
+
+    // Add sparse-only components to the schema so their slots resolve.
+    // `from_components` deduplicates by name, so components that appear in
+    // both archetype columns and sparse storage are not double-counted.
+    for s in &sparse_blobs {
+        components.push((s.name.clone(), s.layout));
+    }
 
     let schema = SchemaSection::from_components(&components)?;
 
@@ -189,7 +237,8 @@ pub fn flush_observed(
     // (a) Header — write with crc32 = 0, patch later.
     let page_count = dirty.len()
         + entity_dirty.values().map(BTreeSet::len).sum::<usize>()
-        + allocator_page_count;
+        + allocator_page_count
+        + sparse_page_count;
     let header = Header {
         magic: MAGIC,
         version: VERSION,
@@ -390,6 +439,39 @@ pub fn flush_observed(
             _pad: 0,
             file_offset,
         });
+    }
+
+    // (d3) Sparse component pages — complete current sparse state, keyed by the
+    //      component's schema slot under SPARSE_ARCH_ID. Each blob is chunked at
+    //      ALLOCATOR_PAGE_MAX_BYTES (the row_count u16 cap); recovery
+    //      concatenates chunks per slot before decode.
+    for s in &sparse_blobs {
+        let slot = schema
+            .slot_for(&s.name)
+            .expect("sparse component must be in schema");
+        for (page_index, chunk) in s.blob.chunks(ALLOCATOR_PAGE_MAX_BYTES).enumerate() {
+            let page_index = to_u16(page_index, "sparse page_index")?;
+            let page_crc = crc32fast::hash(chunk);
+            let file_offset = w.stream_position()?;
+            let ph = PageHeader {
+                arch_id: SPARSE_ARCH_ID,
+                slot,
+                page_index,
+                // chunk.len() <= ALLOCATOR_PAGE_MAX_BYTES == u16::MAX, so this fits.
+                row_count: chunk.len() as u16,
+                page_crc32: page_crc,
+                _padding: 0,
+            };
+            w.write_all(ph.as_bytes())?;
+            w.write_all(chunk)?;
+            index_entries.push(IndexEntry {
+                arch_id: SPARSE_ARCH_ID,
+                slot,
+                page_index,
+                _pad: 0,
+                file_offset,
+            });
+        }
     }
 
     // (e) Sparse index — sort by (arch_id, slot, page_index) so the reader
@@ -642,6 +724,59 @@ mod tests {
         assert!(seen.contains(&e1.to_bits()), "e1 not observed");
         assert!(seen.contains(&e2.to_bits()), "e2 not observed");
         assert!(seen.contains(&e3.to_bits()), "e3 not observed");
+    }
+
+    #[test]
+    fn flush_persists_sparse_pages() {
+        use crate::codec::CodecRegistry;
+        use crate::format::SPARSE_ARCH_ID;
+        use crate::reader::SortedRunReader;
+        use crate::sparse_page;
+        use crate::types::{SeqNo, SeqRange};
+        use minkowski::World;
+
+        #[derive(Clone, Copy, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+        #[repr(C)]
+        struct Pos {
+            x: f32,
+            y: f32,
+        }
+        #[derive(Clone, Copy, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+        #[repr(C)]
+        struct Tag(u32);
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut world = World::new();
+        let mut codecs = CodecRegistry::new();
+        codecs.register_as::<Pos>("pos", &mut world).unwrap();
+        codecs.register_as::<Tag>("tag", &mut world).unwrap();
+
+        world.spawn((Pos { x: 1.0, y: 2.0 },));
+        let e1 = world.spawn((Pos { x: 3.0, y: 4.0 },));
+        let e2 = world.spawn((Pos { x: 5.0, y: 6.0 },));
+        world.insert_sparse::<Tag>(e1, Tag(111));
+        world.insert_sparse::<Tag>(e2, Tag(222));
+
+        let range = SeqRange::new(SeqNo::from(0u64), SeqNo::from(1u64)).unwrap();
+        let path = flush(&world, range, dir.path(), &codecs).unwrap().unwrap();
+
+        let reader = SortedRunReader::open(&path).unwrap();
+        let tag_slot = reader
+            .schema()
+            .slot_for("tag")
+            .expect("tag must be in schema");
+        let mut blob = Vec::new();
+        for result in reader.slot_pages(SPARSE_ARCH_ID, tag_slot) {
+            let (_pi, page) = result.unwrap();
+            reader.validate_page_crc(&page).unwrap();
+            blob.extend_from_slice(&page.data()[..page.header().row_count as usize]);
+        }
+        let entries = sparse_page::decode(&blob).unwrap();
+        let mut tags: Vec<u64> = entries.iter().map(|(e, _)| *e).collect();
+        tags.sort_unstable();
+        let mut want = vec![e1.to_bits(), e2.to_bits()];
+        want.sort_unstable();
+        assert_eq!(tags, want);
     }
 
     #[test]

--- a/crates/minkowski-lsm/tests/compaction_integration.rs
+++ b/crates/minkowski-lsm/tests/compaction_integration.rs
@@ -8,6 +8,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 
 use minkowski::World;
+use minkowski_lsm::codec::CodecRegistry;
 use minkowski_lsm::compactor::{compact_one, compact_one_observed};
 use minkowski_lsm::format::ENTITY_SLOT;
 use minkowski_lsm::manifest::LsmManifest;
@@ -37,9 +38,16 @@ fn do_flush<const N: usize>(
     seq_hi: u64,
 ) -> std::path::PathBuf {
     let seq_range = SeqRange::new(SeqNo::from(seq_lo), SeqNo::from(seq_hi)).unwrap();
-    flush_and_record(world, seq_range, manifest, log, run_dir)
-        .unwrap()
-        .expect("world must be dirty for flush to produce Some")
+    flush_and_record(
+        world,
+        seq_range,
+        manifest,
+        log,
+        run_dir,
+        &CodecRegistry::new(),
+    )
+    .unwrap()
+    .expect("world must be dirty for flush to produce Some")
 }
 
 /// Collect all entity IDs from the entity-slot pages of arch_id 0 in a reader.

--- a/crates/minkowski-lsm/tests/integration.rs
+++ b/crates/minkowski-lsm/tests/integration.rs
@@ -1,6 +1,7 @@
 use std::alloc::Layout;
 
 use minkowski::World;
+use minkowski_lsm::codec::CodecRegistry;
 use minkowski_lsm::error::LsmError;
 use minkowski_lsm::format::{ENTITY_SLOT, PAGE_SIZE};
 use minkowski_lsm::reader::SortedRunReader;
@@ -33,6 +34,7 @@ fn flush_and_open(world: &World) -> (tempfile::TempDir, SortedRunReader) {
         world,
         SeqRange::new(SeqNo::from(0u64), SeqNo::from(100u64)).unwrap(),
         dir.path(),
+        &CodecRegistry::new(),
     )
     .unwrap()
     .expect("flush should produce a file");
@@ -227,6 +229,7 @@ fn no_dirty_pages_no_file() {
         &world,
         SeqRange::new(SeqNo::from(0u64), SeqNo::from(0u64)).unwrap(),
         dir.path(),
+        &CodecRegistry::new(),
     )
     .unwrap();
     assert!(
@@ -262,6 +265,7 @@ fn crc_corruption_detected() {
         &world,
         SeqRange::new(SeqNo::from(0u64), SeqNo::from(50u64)).unwrap(),
         dir.path(),
+        &CodecRegistry::new(),
     )
     .unwrap()
     .unwrap();
@@ -334,6 +338,7 @@ fn header_crc_corruption_detected() {
         &world,
         SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
         dir.path(),
+        &CodecRegistry::new(),
     )
     .unwrap()
     .unwrap();
@@ -526,6 +531,7 @@ fn zst_component_round_trip() {
         &world,
         SeqRange::new(SeqNo::from(0u64), SeqNo::from(0u64)).unwrap(),
         dir.path(),
+        &CodecRegistry::new(),
     )
     .unwrap()
     .unwrap();

--- a/crates/minkowski-lsm/tests/manifest_integration.rs
+++ b/crates/minkowski-lsm/tests/manifest_integration.rs
@@ -5,6 +5,7 @@ use std::io::Write;
 use std::path::PathBuf;
 
 use minkowski::World;
+use minkowski_lsm::codec::CodecRegistry;
 use minkowski_lsm::error::LsmError;
 use minkowski_lsm::manifest_log::{ManifestEntry, ManifestLog, ManifestTag};
 use minkowski_lsm::manifest_ops::{cleanup_orphans, flush_and_record};
@@ -47,6 +48,7 @@ fn three_flushes_then_replay() {
         &mut manifest,
         &mut log,
         dir.path(),
+        &CodecRegistry::new(),
     )
     .unwrap()
     .unwrap();
@@ -65,6 +67,7 @@ fn three_flushes_then_replay() {
         &mut manifest,
         &mut log,
         dir.path(),
+        &CodecRegistry::new(),
     )
     .unwrap()
     .unwrap();
@@ -78,6 +81,7 @@ fn three_flushes_then_replay() {
         &mut manifest,
         &mut log,
         dir.path(),
+        &CodecRegistry::new(),
     )
     .unwrap()
     .unwrap();
@@ -124,6 +128,7 @@ fn corrupt_tail_partial_recovery() {
         &mut manifest,
         &mut log,
         dir.path(),
+        &CodecRegistry::new(),
     )
     .unwrap();
     world.clear_all_dirty_pages();
@@ -135,6 +140,7 @@ fn corrupt_tail_partial_recovery() {
         &mut manifest,
         &mut log,
         dir.path(),
+        &CodecRegistry::new(),
     )
     .unwrap();
 
@@ -177,6 +183,7 @@ fn replay_converges_at_every_truncation_prefix() {
             &mut manifest,
             &mut log,
             dir.path(),
+            &CodecRegistry::new(),
         )
         .unwrap();
         world.clear_all_dirty_pages();
@@ -255,6 +262,7 @@ fn replay_truncates_log_on_promote_of_missing_run() {
         &mut manifest,
         &mut log,
         dir.path(),
+        &CodecRegistry::new(),
     )
     .unwrap();
 
@@ -305,6 +313,7 @@ fn cleanup_removes_orphans_and_tmp() {
         &mut manifest,
         &mut log,
         dir.path(),
+        &CodecRegistry::new(),
     )
     .unwrap();
 
@@ -342,6 +351,7 @@ fn replay_truncates_log_on_unsorted_coverage() {
         &mut manifest,
         &mut log,
         dir.path(),
+        &CodecRegistry::new(),
     )
     .unwrap();
 
@@ -410,6 +420,7 @@ fn replay_truncates_log_on_invalid_level_byte() {
         &mut manifest,
         &mut log,
         dir.path(),
+        &CodecRegistry::new(),
     )
     .unwrap();
 
@@ -466,6 +477,7 @@ fn replay_truncates_log_on_unknown_tag_byte() {
         &mut manifest,
         &mut log,
         dir.path(),
+        &CodecRegistry::new(),
     )
     .unwrap();
 
@@ -520,6 +532,7 @@ fn replay_truncates_log_on_inverted_seq_range() {
         &mut manifest,
         &mut log,
         dir.path(),
+        &CodecRegistry::new(),
     )
     .unwrap();
 
@@ -587,6 +600,7 @@ fn replay_truncates_log_on_zero_page_count() {
         &mut manifest,
         &mut log,
         dir.path(),
+        &CodecRegistry::new(),
     )
     .unwrap();
 
@@ -657,6 +671,7 @@ fn replay_truncates_log_on_invalid_compaction_input_level() {
         &mut manifest,
         &mut log,
         dir.path(),
+        &CodecRegistry::new(),
     )
     .unwrap();
 
@@ -729,6 +744,7 @@ fn replay_truncates_log_on_remove_of_missing_run() {
         &mut manifest,
         &mut log,
         dir.path(),
+        &CodecRegistry::new(),
     )
     .unwrap();
 
@@ -782,6 +798,7 @@ fn recover_then_flush_then_recover_roundtrips_state() {
         &mut manifest,
         &mut log,
         dir.path(),
+        &CodecRegistry::new(),
     )
     .unwrap();
     world.clear_all_dirty_pages();
@@ -792,6 +809,7 @@ fn recover_then_flush_then_recover_roundtrips_state() {
         &mut manifest,
         &mut log,
         dir.path(),
+        &CodecRegistry::new(),
     )
     .unwrap();
     drop(log);
@@ -941,6 +959,7 @@ fn flush_and_record_clean_world_no_change() {
         &mut manifest,
         &mut log,
         dir.path(),
+        &CodecRegistry::new(),
     )
     .unwrap();
     assert!(result.is_none());

--- a/crates/minkowski-persist/benches/persist.rs
+++ b/crates/minkowski-persist/benches/persist.rs
@@ -39,7 +39,7 @@ fn setup() -> (World, CodecRegistry) {
 }
 
 fn bench_lsm_flush(c: &mut Criterion) {
-    let (world, _codecs) = setup();
+    let (world, codecs) = setup();
     let dir = tempfile::tempdir().unwrap();
     let log_path = dir.path().join("manifest.log");
 
@@ -52,6 +52,7 @@ fn bench_lsm_flush(c: &mut Criterion) {
                 &mut manifest,
                 &mut log,
                 dir.path(),
+                &codecs,
             )
             .unwrap();
         });
@@ -69,6 +70,7 @@ fn bench_lsm_recover(c: &mut Criterion) {
         &mut manifest,
         &mut log,
         dir.path(),
+        &codecs,
     )
     .unwrap()
     .expect("flush");

--- a/crates/minkowski-persist/src/checkpoint.rs
+++ b/crates/minkowski-persist/src/checkpoint.rs
@@ -259,6 +259,87 @@ mod tests {
         );
     }
 
+    /// Codex PR #199 P1 scenario: a checkpoint triggered by a sparse-only
+    /// removal writes NO run (flush returns None) yet still acknowledges the
+    /// flush. Verify the removed sparse component does NOT resurrect on recovery.
+    #[test]
+    fn sparse_only_removal_checkpoint_does_not_resurrect() {
+        use crate::recover::recover_world;
+        use crate::wal::WalConfig;
+
+        #[derive(Clone, Copy, PartialEq, Debug, Archive, Serialize, Deserialize)]
+        #[repr(C)]
+        struct TagR(u32);
+
+        let dir = tempfile::tempdir().unwrap();
+        let wal_dir = dir.path().join("testr.wal");
+        let lsm_dir = dir.path().join("lsmr");
+
+        let mut world = World::new();
+        let mut codecs = CodecRegistry::new();
+        codecs.register_as::<Pos>("pos", &mut world).unwrap();
+        codecs.register_as::<TagR>("tag_r", &mut world).unwrap();
+
+        let config = WalConfig {
+            max_segment_bytes: 64 * 1024 * 1024,
+            max_bytes_between_checkpoints: Some(128),
+        };
+        let mut wal = Wal::create(&wal_dir, &codecs, config).unwrap();
+        let mut handler = AutoCheckpoint::new(&lsm_dir);
+
+        // Spawn e (recorded in WAL) and attach a sparse component in-memory.
+        let e = world.alloc_entity();
+        let mut cs = minkowski::EnumChangeSet::new();
+        cs.spawn_bundle(&mut world, e, (Pos { x: 1.0, y: 2.0 },))
+            .unwrap();
+        wal.append(&cs, &codecs).unwrap();
+        cs.apply(&mut world).unwrap();
+        world.insert_sparse::<TagR>(e, TagR(7));
+
+        // Checkpoint 1: writes run A containing the sparse TagR.
+        handler
+            .on_checkpoint_needed(&mut world, &mut wal, &codecs)
+            .unwrap();
+
+        // Force the exact Codex condition: no archetype page is dirty at the
+        // next checkpoint (a complete flush would clear dirty bits), and the
+        // only mutation since is a sparse removal.
+        world.clear_all_dirty_pages();
+        let mut cs2 = minkowski::EnumChangeSet::new();
+        cs2.remove_sparse::<TagR>(&mut world, e);
+        wal.append(&cs2, &codecs).unwrap();
+        cs2.apply(&mut world).unwrap();
+
+        // Checkpoint 2: flush finds nothing to persist (no dirty pages, no sparse
+        // entries) and returns None — but on_checkpoint_needed still acks.
+        handler
+            .on_checkpoint_needed(&mut world, &mut wal, &codecs)
+            .unwrap();
+
+        // FAITHFULNESS CHECK: checkpoint 2 must have written NO run (flush None),
+        // so only run A exists — this is Codex's exact premise.
+        let run_count = std::fs::read_dir(&lsm_dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| e.path().extension().is_some_and(|x| x == "run"))
+            .count();
+        assert_eq!(run_count, 1, "checkpoint 2 must write no run (flush None)");
+
+        // Recover from scratch. The removal lives only in the WAL tail; recovery
+        // must apply it on top of run A's (stale) sparse baseline.
+        let log_path = lsm_dir.join("manifest.log");
+        let mut wal2 = Wal::open(&wal_dir, &codecs, WalConfig::default()).unwrap();
+        let recovered = recover_world(&lsm_dir, &log_path, &mut wal2, &codecs).unwrap();
+
+        assert_eq!(
+            recovered.get::<TagR>(e),
+            None,
+            "a sparse component removed via a no-run checkpoint must not resurrect"
+        );
+        // The entity itself must still be alive (only its sparse component went).
+        assert_eq!(recovered.get::<Pos>(e).map(|p| p.x), Some(1.0));
+    }
+
     #[test]
     fn auto_checkpoint_saves_registered_index() {
         use crate::index::load_btree_index;

--- a/crates/minkowski-persist/src/checkpoint.rs
+++ b/crates/minkowski-persist/src/checkpoint.rs
@@ -71,7 +71,7 @@ impl CheckpointHandler for AutoCheckpoint {
         &mut self,
         world: &mut World,
         wal: &mut Wal,
-        _codecs: &CodecRegistry,
+        codecs: &CodecRegistry,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let flush_seq = wal.next_seq();
         let lo = wal.last_checkpoint_seq().unwrap_or(0);
@@ -80,7 +80,14 @@ impl CheckpointHandler for AutoCheckpoint {
 
         let mut manifest = self.manifest.lock();
         let mut log = self.manifest_log.lock();
-        flush_and_record(world, seq_range, &mut manifest, &mut log, &self.lsm_dir)?;
+        flush_and_record(
+            world,
+            seq_range,
+            &mut manifest,
+            &mut log,
+            &self.lsm_dir,
+            codecs,
+        )?;
 
         // Best-effort compaction when L0 is over threshold.
         while manifest

--- a/crates/minkowski-persist/src/checkpoint.rs
+++ b/crates/minkowski-persist/src/checkpoint.rs
@@ -178,6 +178,87 @@ mod tests {
         assert_eq!(runs.len(), 1);
     }
 
+    /// (f) Regression test (Codex-#5): sparse components must survive a full
+    /// `AutoCheckpoint` → `recover_world` round-trip. Before the sparse
+    /// durability feature, `acknowledge_flush` advanced past sparse state that
+    /// was never written to LSM, silently losing it on recovery.
+    #[test]
+    fn checkpoint_then_recover_preserves_sparse() {
+        use crate::recover::recover_world;
+        use crate::wal::WalConfig;
+
+        #[derive(Clone, Copy, PartialEq, Debug, Archive, Serialize, Deserialize)]
+        #[repr(C)]
+        struct Tag7f(u32);
+
+        let dir = tempfile::tempdir().unwrap();
+        let wal_dir = dir.path().join("test7f.wal");
+        let lsm_dir = dir.path().join("lsm7f");
+
+        let mut world = World::new();
+        let mut codecs = CodecRegistry::new();
+        codecs.register_as::<Pos>("pos", &mut world).unwrap();
+        codecs.register_as::<Tag7f>("tag7f", &mut world).unwrap();
+
+        // Low threshold so that a handful of WAL appends trigger a checkpoint.
+        let config = WalConfig {
+            max_segment_bytes: 64 * 1024 * 1024,
+            max_bytes_between_checkpoints: Some(128),
+        };
+        let mut wal = Wal::create(&wal_dir, &codecs, config).unwrap();
+
+        // Spawn an entity and record it in the WAL.
+        let e = world.alloc_entity();
+        let mut cs = minkowski::EnumChangeSet::new();
+        cs.spawn_bundle(&mut world, e, (Pos { x: 1.0, y: 2.0 },))
+            .unwrap();
+        wal.append(&cs, &codecs).unwrap();
+        cs.apply(&mut world).unwrap();
+
+        // Attach a sparse component directly to the world (not via WAL, so it
+        // only exists in the in-memory world and must be captured by the LSM
+        // flush triggered by the checkpoint).
+        world.insert_sparse::<Tag7f>(e, Tag7f(42));
+
+        // Append more records until checkpoint is needed.
+        for i in 0..10u32 {
+            let e2 = world.alloc_entity();
+            let mut cs2 = minkowski::EnumChangeSet::new();
+            cs2.spawn_bundle(
+                &mut world,
+                e2,
+                (Pos {
+                    x: i as f32,
+                    y: 0.0,
+                },),
+            )
+            .unwrap();
+            wal.append(&cs2, &codecs).unwrap();
+            cs2.apply(&mut world).unwrap();
+        }
+
+        assert!(wal.checkpoint_needed(), "checkpoint must be needed");
+
+        // Run the checkpoint: flushes world (including sparse) to LSM.
+        let mut handler = AutoCheckpoint::new(&lsm_dir);
+        handler
+            .on_checkpoint_needed(&mut world, &mut wal, &codecs)
+            .unwrap();
+
+        assert!(!wal.checkpoint_needed(), "checkpoint must be acknowledged");
+
+        // Recover via a fresh WAL handle — simulates a crash-reopen.
+        let log_path = lsm_dir.join("manifest.log");
+        let mut wal2 = Wal::open(&wal_dir, &codecs, WalConfig::default()).unwrap();
+        let recovered = recover_world(&lsm_dir, &log_path, &mut wal2, &codecs).unwrap();
+
+        assert_eq!(
+            recovered.get::<Tag7f>(e).copied(),
+            Some(Tag7f(42)),
+            "sparse component must survive checkpoint → recover round-trip"
+        );
+    }
+
     #[test]
     fn auto_checkpoint_saves_registered_index() {
         use crate::index::load_btree_index;

--- a/crates/minkowski-persist/src/index.rs
+++ b/crates/minkowski-persist/src/index.rs
@@ -538,6 +538,7 @@ mod tests {
                 &mut manifest,
                 &mut log,
                 &lsm_dir,
+                &codecs,
             )
             .unwrap()
             .expect("flush");

--- a/crates/minkowski-persist/src/recover.rs
+++ b/crates/minkowski-persist/src/recover.rs
@@ -34,6 +34,16 @@ pub fn recover_world(
         for id in codecs.registered_ids() {
             codecs.register_one(id, &mut world);
         }
+        // INVARIANT (replay floor): we replay from the newest LSM run's seq_hi,
+        // NOT the WAL's last acknowledged flush_seq. `AutoCheckpoint` may
+        // acknowledge a flush_seq ahead of the LSM baseline when a checkpoint
+        // had nothing to persist (e.g. a sparse-only removal → `flush` returns
+        // None). That is benign ONLY because the WAL is never truncated below
+        // this floor, so every mutation in `[result.flush_seq, end)` — including
+        // such a removal — is still replayed on top of the baseline. If WAL
+        // truncation is ever added it MUST NOT delete records at or above the
+        // newest run's seq_hi, or removed state would resurrect. Covered by
+        // `checkpoint::tests::sparse_only_removal_checkpoint_does_not_resurrect`.
         wal.replay_from(result.flush_seq, &mut world, codecs)?;
         Ok(world)
     } else {

--- a/crates/minkowski-persist/src/recover.rs
+++ b/crates/minkowski-persist/src/recover.rs
@@ -107,4 +107,89 @@ mod tests {
         assert_eq!(recovered.query::<(&Health,)>().count(), 1);
         assert_eq!(recovered.query::<(&Health,)>().next().unwrap().0.0, 42);
     }
+
+    /// (e) Sparse component in LSM baseline + sparse mutation appended to WAL
+    /// tail after the flush_seq both appear in the recovered world.
+    #[test]
+    fn recover_world_restores_sparse_then_wal_tail() {
+        #[derive(Clone, Copy, Archive, Serialize, Deserialize)]
+        #[repr(C)]
+        struct Pos7e {
+            x: f32,
+            y: f32,
+        }
+
+        // Baseline sparse component — written by flush.
+        #[derive(Clone, Copy, PartialEq, Debug, Archive, Serialize, Deserialize)]
+        #[repr(C)]
+        struct BaseTag7e(u32);
+
+        // WAL-tail sparse component — written after the flush.
+        #[derive(Clone, Copy, PartialEq, Debug, Archive, Serialize, Deserialize)]
+        #[repr(C)]
+        struct TailTag7e(u32);
+
+        let dir = tempfile::tempdir().unwrap();
+        let lsm_dir = dir.path().join("lsm");
+        let log_path = lsm_dir.join("manifest.log");
+        let wal_dir = dir.path().join("test7e.wal");
+        std::fs::create_dir_all(&lsm_dir).unwrap();
+
+        let mut world = World::new();
+        let mut codecs = CodecRegistry::new();
+        codecs.register_as::<Pos7e>("pos7e", &mut world).unwrap();
+        codecs
+            .register_as::<BaseTag7e>("base_tag7e", &mut world)
+            .unwrap();
+        codecs
+            .register_as::<TailTag7e>("tail_tag7e", &mut world)
+            .unwrap();
+
+        // Spawn an entity, attach a baseline sparse component.
+        let e_base = world.spawn((Pos7e { x: 1.0, y: 0.0 },));
+        world.insert_sparse::<BaseTag7e>(e_base, BaseTag7e(100));
+
+        // Flush baseline to LSM.
+        let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
+        flush_and_record(
+            &world,
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(0u64)).unwrap(),
+            &mut manifest,
+            &mut log,
+            &lsm_dir,
+            &codecs,
+        )
+        .unwrap()
+        .expect("baseline flush");
+
+        // Post-flush: append a WAL record that inserts a sparse component on a
+        // new entity. This is the "WAL tail" that replay_from must pick up.
+        let mut wal = Wal::create(&wal_dir, &codecs, crate::wal::WalConfig::default()).unwrap();
+
+        let e_tail = world.alloc_entity();
+        let mut cs = minkowski::EnumChangeSet::new();
+        cs.spawn_bundle(&mut world, e_tail, (Pos7e { x: 2.0, y: 0.0 },))
+            .unwrap();
+        cs.insert_sparse::<TailTag7e>(&mut world, e_tail, TailTag7e(200));
+        wal.append(&cs, &codecs).unwrap();
+        cs.apply(&mut world).unwrap();
+
+        // Open a second WAL handle (simulates crash-reopen) and recover.
+        let mut wal2 = Wal::open(&wal_dir, &codecs, crate::wal::WalConfig::default()).unwrap();
+        let recovered = recover_world(&lsm_dir, &log_path, &mut wal2, &codecs).unwrap();
+
+        // Baseline sparse survives via apply_sparse.
+        assert_eq!(
+            recovered.get::<BaseTag7e>(e_base).copied(),
+            Some(BaseTag7e(100)),
+            "baseline sparse must survive recover"
+        );
+
+        // WAL-tail sparse survives via replay_from.
+        assert_eq!(
+            recovered.get::<TailTag7e>(e_tail).copied(),
+            Some(TailTag7e(200)),
+            "WAL-tail sparse must survive replay"
+        );
+    }
 }

--- a/crates/minkowski-persist/src/recover.rs
+++ b/crates/minkowski-persist/src/recover.rs
@@ -88,6 +88,7 @@ mod tests {
             &mut manifest,
             &mut log,
             &lsm_dir,
+            &codecs,
         )
         .unwrap()
         .expect("flush");

--- a/crates/minkowski-persist/src/replication.rs
+++ b/crates/minkowski-persist/src/replication.rs
@@ -628,6 +628,7 @@ mod tests {
             &mut manifest,
             &mut log,
             &lsm_dir,
+            &codecs,
         )
         .unwrap()
         .expect("flush");

--- a/examples/examples/persist.rs
+++ b/examples/examples/persist.rs
@@ -95,6 +95,7 @@ fn main() {
         &mut manifest,
         &mut log,
         &lsm_dir,
+        &codecs,
     )
     .unwrap()
     .expect("baseline flush");

--- a/examples/examples/replicate.rs
+++ b/examples/examples/replicate.rs
@@ -70,6 +70,7 @@ fn source_side(tx: &mpsc::Sender<WireMessage>) {
         &mut manifest,
         &mut log,
         &lsm_dir,
+        &codecs,
     )
     .unwrap()
     .expect("flush");


### PR DESCRIPTION
## Summary

Makes sparse component storage (`PagedSparseSet`) durable across crash recovery by persisting it as **first-class LSM baseline state**, mirroring the Group B allocator pattern. Fixes Codex review #5 (sparse silently lost on recovery — the flush never persisted sparse, and `acknowledge_flush` advanced the baseline past it).

Stacked on `cursor/lsm-phase-5-cutover` (PR #198); sibling of the Group D recovery rewrite. **Do not merge to `main` until C and D both land** — the cutover deletes v2 snapshots.

## Design

- **Baseline = complete snapshot.** Every flush writes the complete current sparse state unconditionally; recovery takes the **newest run's** sparse wholesale (highest `seq_hi`); compaction carries it forward. This is the allocator's whole-state/newest-wins model, not the archetype delta model.
- **Sparse is decoupled from the archetype schema.** Each sparse component is one self-describing blob — `sparse_page::encode` embeds the component's stable **name** (`[name_len][name][count][(entity_bits, value_len, value)…]`). Sparse pages live under a reserved `SPARSE_ARCH_ID = 0xFFFD` and use a per-run grouping-slot index. Recovery reads the name from the blob, not the schema.
  - *Why decoupled:* adding sparse names to the shared `SchemaSection` (the first cut) re-sorted global slot assignment and shifted **archetype** component slots, tripping the pre-existing `materialize_world` slot-vs-position assumption (Codex #4, owned by Group D). Keeping sparse out of the schema leaves archetype recovery untouched.
- **Values use the existing codec seam** (`serialize_sparse` / `insert_sparse_raw`, rkyv) — correct `drop_fn` handling for free. Per-page CRC guards integrity; corruption is fatal.
- **Restore order:** `apply_sparse` runs after `materialize_world` (entity generations restored) and before WAL-tail replay, so baseline sparse + post-`flush_seq` sparse mutations compose.

## Test plan

- [x] Sparse round-trip recovery (values + generations)
- [x] **Codex-#5 regression** — `checkpoint → acknowledge_flush → recover` preserves sparse (would fail on the cutover branch today)
- [x] Despawn-before-checkpoint leaves nothing (net-state snapshot, not replay)
- [x] Multi-page sparse (blob > `u16::MAX`, chunk + concat)
- [x] Generation reuse across a despawn boundary
- [x] Newest-run-wins, including **empty wins** — a sparse component removed from a live entity between flushes is not resurrected (regression test verified to fail without the fix)
- [x] WAL-tail compose (baseline sparse + post-flush sparse mutations)
- [x] Compaction carry-forward survives recovery
- [x] `cargo test -p minkowski-lsm -p minkowski-persist` (314 tests) + `cargo clippy --all-targets -D warnings`

## Reviewed

Per-task spec + quality review during subagent-driven execution, plus a final holistic review that caught the "empty newest run must win" correctness bug (now fixed + regression-tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)