### PR TITLE
fix(lsm): close dense raw-copy soundness hole (require codec at flush)

### DIFF
--- a/crates/minkowski-lsm/src/codec.rs
+++ b/crates/minkowski-lsm/src/codec.rs
@@ -105,6 +105,11 @@ struct ComponentCodec {
     /// accepted non-ZST components (raw-copyability is enforced at registration,
     /// so the archived layout matches native); `None` for ZSTs (nothing to copy).
     raw_copy_size: Option<usize>,
+    /// `TypeId` of the concrete component type this codec was registered for.
+    /// `ComponentId` is a per-world index, so the flush gate compares this to the
+    /// flushed world's `component_type_id` to confirm the codec actually
+    /// describes the type whose native bytes are being persisted.
+    type_id: std::any::TypeId,
 }
 
 /// Maps ComponentId to rkyv codecs. Separate from core's ComponentRegistry —
@@ -120,6 +125,14 @@ impl CodecRegistry {
             codecs: HashMap::new(),
             by_name: HashMap::new(),
         }
+    }
+
+    /// `TypeId` of the component type registered under `id`, or `None` if no
+    /// codec is registered for that id. `ComponentId` is a per-world index, so
+    /// the flush gate compares this to the flushed world's `component_type_id`
+    /// to confirm the codec describes the type actually being persisted.
+    pub fn type_id(&self, id: ComponentId) -> Option<std::any::TypeId> {
+        self.codecs.get(&id).map(|c| c.type_id)
     }
 
     /// Register a component type for persistence.
@@ -280,6 +293,7 @@ impl CodecRegistry {
                 serialize_sparse_fn,
                 insert_sparse_fn,
                 raw_copy_size,
+                type_id: std::any::TypeId::of::<T>(),
             },
         );
         Ok(())

--- a/crates/minkowski-lsm/src/codec.rs
+++ b/crates/minkowski-lsm/src/codec.rs
@@ -127,12 +127,14 @@ impl CodecRegistry {
         }
     }
 
-    /// `TypeId` of the component type registered under `id`, or `None` if no
-    /// codec is registered for that id. `ComponentId` is a per-world index, so
-    /// the flush gate compares this to the flushed world's `component_type_id`
-    /// to confirm the codec describes the type actually being persisted.
-    pub fn type_id(&self, id: ComponentId) -> Option<std::any::TypeId> {
-        self.codecs.get(&id).map(|c| c.type_id)
+    /// Whether a codec is registered for the given component *type*, regardless
+    /// of which numeric `ComponentId` it was filed under. The flush gate uses
+    /// this to certify a dense column's type is raw-copyable: `ComponentId` is a
+    /// per-world index, so resolving by type (not id) is correct across a
+    /// registry and world that assigned the type different ids (e.g. after
+    /// recovery re-registers components into a fresh world).
+    pub fn has_codec_for_type(&self, type_id: std::any::TypeId) -> bool {
+        self.codecs.values().any(|c| c.type_id == type_id)
     }
 
     /// Register a component type for persistence.

--- a/crates/minkowski-lsm/src/compaction_writer.rs
+++ b/crates/minkowski-lsm/src/compaction_writer.rs
@@ -830,8 +830,8 @@ mod tests {
 
     // ── Component types ──────────────────────────────────────────────────────
 
-    #[derive(Clone, Copy)]
-    #[expect(dead_code)]
+    #[derive(Clone, Copy, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+    #[repr(C)]
     struct Pos {
         x: f32,
         y: f32,
@@ -840,14 +840,18 @@ mod tests {
     // ── Helper ───────────────────────────────────────────────────────────────
 
     /// Flush `world` to a temp dir and open a reader. Returns the dir (kept
-    /// alive by the caller) and the reader.
+    /// alive by the caller) and the reader. Registers `Pos` into a codec
+    /// registry first — the dense flush gate refuses any dense component
+    /// lacking a codec. `register_component` is idempotent, so reusing the same
+    /// world across calls is fine.
     fn flush_to_reader(
-        world: &World,
+        world: &mut World,
         seq_lo: u64,
         seq_hi: u64,
     ) -> (tempfile::TempDir, SortedRunReader) {
         let dir = tempfile::tempdir().unwrap();
-        let codecs = crate::codec::CodecRegistry::new();
+        let mut codecs = crate::codec::CodecRegistry::new();
+        codecs.register_as::<Pos>("pos", world).unwrap();
         let path = flush(
             world,
             SeqRange::new(SeqNo::from(seq_lo), SeqNo::from(seq_hi)).unwrap(),
@@ -886,12 +890,12 @@ mod tests {
     fn build_emit_list_from_two_runs_dedup_keeps_newest() {
         let mut world = World::new();
         let e = world.spawn((Pos { x: 0.0, y: 0.0 },));
-        let (_dir_old, reader_old) = flush_to_reader(&world, 1, 10);
+        let (_dir_old, reader_old) = flush_to_reader(&mut world, 1, 10);
 
         // "Modify" the entity — in this test we just flush the same world
         // again (the entity is still dirty) to represent a newer run containing
         // the same entity ID.
-        let (_dir_new, reader_new) = flush_to_reader(&world, 11, 20);
+        let (_dir_new, reader_new) = flush_to_reader(&mut world, 11, 20);
 
         let old_arch = pos_arch_id(&reader_old);
         let new_arch = pos_arch_id(&reader_new);
@@ -928,7 +932,7 @@ mod tests {
         let mut world_old = World::new();
         let e1 = world_old.spawn((Pos { x: 1.0, y: 0.0 },));
         let e2 = world_old.spawn((Pos { x: 2.0, y: 0.0 },));
-        let (_dir_old, reader_old) = flush_to_reader(&world_old, 1, 10);
+        let (_dir_old, reader_old) = flush_to_reader(&mut world_old, 1, 10);
 
         // Newer run: only E3 (index 2 — placeholder spawns advance past 0, 1).
         let mut world_new = World::new();
@@ -940,7 +944,7 @@ mod tests {
         world_new.despawn(ph1);
         world_new.despawn(ph2);
         let e3 = world_new.spawn((Pos { x: 3.0, y: 0.0 },));
-        let (_dir_new, reader_new) = flush_to_reader(&world_new, 11, 20);
+        let (_dir_new, reader_new) = flush_to_reader(&mut world_new, 11, 20);
 
         let old_arch = pos_arch_id(&reader_old);
         let new_arch = pos_arch_id(&reader_new);
@@ -976,7 +980,7 @@ mod tests {
     fn build_emit_list_skips_inputs_where_archetype_missing() {
         let mut world = World::new();
         let e = world.spawn((Pos { x: 0.0, y: 0.0 },));
-        let (_dir, reader) = flush_to_reader(&world, 0, 10);
+        let (_dir, reader) = flush_to_reader(&mut world, 0, 10);
 
         let arch = pos_arch_id(&reader);
 
@@ -1001,7 +1005,7 @@ mod tests {
     fn build_emit_list_rejects_length_mismatch() {
         let mut world = World::new();
         world.spawn((Pos { x: 0.0, y: 0.0 },));
-        let (_dir, reader) = flush_to_reader(&world, 0, 10);
+        let (_dir, reader) = flush_to_reader(&mut world, 0, 10);
 
         let inputs = [&reader, &reader]; // len 2
         let arch_ids = [Some(0u16)]; // len 1 — mismatch
@@ -1055,7 +1059,7 @@ mod tests {
         let e1 = world_a.spawn((Pos { x: 1.0, y: 10.0 },));
         let e2 = world_a.spawn((Pos { x: 2.0, y: 20.0 },));
         let e3 = world_a.spawn((Pos { x: 3.0, y: 30.0 },));
-        let (_dir_a, reader_a) = flush_to_reader(&world_a, 1, 10);
+        let (_dir_a, reader_a) = flush_to_reader(&mut world_a, 1, 10);
 
         // ── Build run B (E4, E5) ──────────────────────────────────────────────
         // Advance allocator past indices 0, 1, 2 (used by E1–E3) so E4/E5
@@ -1069,7 +1073,7 @@ mod tests {
         world_b.despawn(ph3);
         let e4 = world_b.spawn((Pos { x: 4.0, y: 40.0 },));
         let e5 = world_b.spawn((Pos { x: 5.0, y: 50.0 },));
-        let (_dir_b, reader_b) = flush_to_reader(&world_b, 11, 20);
+        let (_dir_b, reader_b) = flush_to_reader(&mut world_b, 11, 20);
 
         // ── Discover component name ───────────────────────────────────────────
         let arch_info_a = arch_component_names(&reader_a);
@@ -1166,7 +1170,7 @@ mod tests {
         // ── Run OLD: entity E with Pos.x = 1.0 ───────────────────────────────
         let mut world_old = World::new();
         let e = world_old.spawn((Pos { x: 1.0, y: 0.0 },));
-        let (_dir_old, reader_old) = flush_to_reader(&world_old, 1, 5);
+        let (_dir_old, reader_old) = flush_to_reader(&mut world_old, 1, 5);
 
         // ── Run NEW: same entity bits (re-created in a new world at index 0)
         //    but with Pos.x = 2.0 to represent the updated value.
@@ -1178,7 +1182,7 @@ mod tests {
             e_new.to_bits(),
             "entity IDs must match for the update test to be meaningful"
         );
-        let (_dir_new, reader_new) = flush_to_reader(&world_new, 6, 10);
+        let (_dir_new, reader_new) = flush_to_reader(&mut world_new, 6, 10);
 
         // ── Discover component name ───────────────────────────────────────────
         let arch_info = arch_component_names(&reader_old);
@@ -1282,8 +1286,8 @@ mod tests {
         let _e1 = world.spawn((Pos { x: 1.0, y: 0.0 },));
         let _e2 = world.spawn((Pos { x: 2.0, y: 0.0 },));
 
-        let (_dir_a, reader_a) = flush_to_reader(&world, 1, 5);
-        let (_dir_b, reader_b) = flush_to_reader(&world, 6, 10);
+        let (_dir_a, reader_a) = flush_to_reader(&mut world, 1, 5);
+        let (_dir_b, reader_b) = flush_to_reader(&mut world, 6, 10);
 
         let arch_info = arch_component_names(&reader_a);
         assert_eq!(arch_info.len(), 1);

--- a/crates/minkowski-lsm/src/compactor.rs
+++ b/crates/minkowski-lsm/src/compactor.rs
@@ -430,21 +430,30 @@ mod tests {
 
     // ── Component types ──────────────────────────────────────────────────────
 
-    #[derive(Clone, Copy)]
-    #[expect(dead_code)]
+    #[derive(Clone, Copy, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+    #[repr(C)]
     struct Pos {
         x: f32,
         y: f32,
     }
 
-    #[derive(Clone, Copy)]
-    #[expect(dead_code)]
+    #[derive(Clone, Copy, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+    #[repr(C)]
     struct Vel {
         dx: f32,
         dy: f32,
     }
 
     // ── Test helpers ─────────────────────────────────────────────────────────
+
+    /// Build a `CodecRegistry` with `Pos`/`Vel` registered — the dense flush
+    /// gate refuses any dense component lacking a codec.
+    fn test_codecs(world: &mut World) -> crate::codec::CodecRegistry {
+        let mut codecs = crate::codec::CodecRegistry::new();
+        codecs.register_as::<Pos>("pos", world).unwrap();
+        codecs.register_as::<Vel>("vel", world).unwrap();
+        codecs
+    }
 
     /// Flush a fresh world with N_ENTITIES Pos entities as L0 run `seq_no`.
     /// Returns the path of the written run.
@@ -457,6 +466,7 @@ mod tests {
         n_entities: usize,
     ) -> PathBuf {
         let mut world = World::new();
+        let codecs = test_codecs(&mut world);
         for i in 0..n_entities {
             world.spawn((Pos {
                 x: i as f32,
@@ -464,7 +474,6 @@ mod tests {
             },));
         }
         let seq_range = SeqRange::new(SeqNo::from(seq_lo), SeqNo::from(seq_hi)).unwrap();
-        let codecs = crate::codec::CodecRegistry::new();
         flush_and_record(&world, seq_range, manifest, log, run_dir, &codecs)
             .unwrap()
             .expect("world is dirty, flush must return Some")
@@ -635,7 +644,7 @@ mod tests {
             let lo = (run_i as u64) * 10;
             let hi = lo + 9;
             let seq_range = SeqRange::new(SeqNo::from(lo), SeqNo::from(hi)).unwrap();
-            let codecs = crate::codec::CodecRegistry::new();
+            let codecs = test_codecs(&mut world);
             flush_and_record(
                 &world,
                 seq_range,
@@ -807,7 +816,7 @@ mod tests {
                 },));
             }
             let seq_range = SeqRange::new(SeqNo::from(i * 10), SeqNo::from(i * 10 + 9)).unwrap();
-            let codecs = crate::codec::CodecRegistry::new();
+            let codecs = test_codecs(&mut world);
             flush_and_record(
                 &world,
                 seq_range,
@@ -925,7 +934,7 @@ mod tests {
             let lo = (run_i as u64) * 10;
             let hi = lo + 9;
             let seq_range = SeqRange::new(SeqNo::from(lo), SeqNo::from(hi)).unwrap();
-            let codecs = crate::codec::CodecRegistry::new();
+            let codecs = test_codecs(&mut world);
             flush_and_record(
                 &world,
                 seq_range,
@@ -1034,7 +1043,7 @@ mod tests {
             let lo = (run_i as u64) * 10;
             let hi = lo + 9;
             let seq_range = SeqRange::new(SeqNo::from(lo), SeqNo::from(hi)).unwrap();
-            let codecs = crate::codec::CodecRegistry::new();
+            let codecs = test_codecs(&mut world);
             flush_and_record(
                 &world,
                 seq_range,
@@ -1154,7 +1163,7 @@ mod tests {
             let lo = (run_i as u64) * 10;
             let hi = lo + 9;
             let seq_range = SeqRange::new(SeqNo::from(lo), SeqNo::from(hi)).unwrap();
-            let codecs = crate::codec::CodecRegistry::new();
+            let codecs = test_codecs(&mut world);
             flush_and_record(
                 &world,
                 seq_range,
@@ -1200,7 +1209,7 @@ mod tests {
             let lo = (run_i as u64) * 10;
             let hi = lo + 9;
             let seq_range = SeqRange::new(SeqNo::from(lo), SeqNo::from(hi)).unwrap();
-            let codecs = crate::codec::CodecRegistry::new();
+            let codecs = test_codecs(&mut world);
             flush_and_record(
                 &world,
                 seq_range,

--- a/crates/minkowski-lsm/src/manifest_ops.rs
+++ b/crates/minkowski-lsm/src/manifest_ops.rs
@@ -108,8 +108,8 @@ mod tests {
     use crate::codec::CodecRegistry;
     use crate::types::{Level, PageCount, SeqNo, SeqRange, SizeBytes};
 
-    #[derive(Clone, Copy)]
-    #[expect(dead_code)]
+    #[derive(Clone, Copy, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+    #[repr(C)]
     struct Pos {
         x: f32,
         y: f32,
@@ -118,6 +118,8 @@ mod tests {
     #[test]
     fn flush_and_record_dirty_world() {
         let mut world = World::new();
+        let mut codecs = CodecRegistry::new();
+        codecs.register_as::<Pos>("pos", &mut world).unwrap();
         for i in 0..5 {
             world.spawn((Pos {
                 x: i as f32,
@@ -128,7 +130,6 @@ mod tests {
         let log_path = dir.path().join("manifest.log");
         let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
-        let codecs = CodecRegistry::new();
         let result = flush_and_record(
             &world,
             SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),

--- a/crates/minkowski-lsm/src/reader.rs
+++ b/crates/minkowski-lsm/src/reader.rs
@@ -527,23 +527,33 @@ mod tests {
     use minkowski::World;
     use std::path::PathBuf;
 
-    #[derive(Clone, Copy)]
-    #[expect(dead_code)]
+    #[derive(Clone, Copy, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+    #[repr(C)]
     struct Pos {
         x: f32,
         y: f32,
     }
 
-    #[derive(Clone, Copy)]
-    #[expect(dead_code)]
+    #[derive(Clone, Copy, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+    #[repr(C)]
     struct Vel {
         dx: f32,
         dy: f32,
     }
 
+    /// Build a `CodecRegistry` with `Pos`/`Vel` registered — the dense flush
+    /// gate refuses any dense component lacking a codec.
+    fn test_codecs(world: &mut World) -> crate::codec::CodecRegistry {
+        let mut codecs = crate::codec::CodecRegistry::new();
+        codecs.register_as::<Pos>("pos", world).unwrap();
+        codecs.register_as::<Vel>("vel", world).unwrap();
+        codecs
+    }
+
     /// Helper: spawn entities and flush to a sorted run file.
     fn flush_world_with_pos(n: usize) -> (tempfile::TempDir, std::path::PathBuf, World) {
         let mut world = World::new();
+        let codecs = test_codecs(&mut world);
         for i in 0..n {
             world.spawn((Pos {
                 x: i as f32,
@@ -551,7 +561,6 @@ mod tests {
             },));
         }
         let dir = tempfile::tempdir().unwrap();
-        let codecs = crate::codec::CodecRegistry::new();
         let path = flush(
             &world,
             SeqRange::new(SeqNo::from(10u64), SeqNo::from(20u64)).unwrap(),
@@ -638,12 +647,12 @@ mod tests {
     #[test]
     fn archetype_ids_returns_sorted_unique() {
         let mut world = World::new();
+        let codecs = test_codecs(&mut world);
         // Create two archetypes
         world.spawn((Pos { x: 1.0, y: 2.0 },));
         world.spawn((Vel { dx: 1.0, dy: 0.0 },));
 
         let dir = tempfile::tempdir().unwrap();
-        let codecs = crate::codec::CodecRegistry::new();
         let path = flush(
             &world,
             SeqRange::new(SeqNo::from(0u64), SeqNo::from(0u64)).unwrap(),
@@ -712,6 +721,7 @@ mod tests {
     #[test]
     fn multi_component_index_lookup() {
         let mut world = World::new();
+        let codecs = test_codecs(&mut world);
         for i in 0..10 {
             world.spawn((
                 Pos {
@@ -726,7 +736,6 @@ mod tests {
         }
 
         let dir = tempfile::tempdir().unwrap();
-        let codecs = crate::codec::CodecRegistry::new();
         let path = flush(
             &world,
             SeqRange::new(SeqNo::from(0u64), SeqNo::from(100u64)).unwrap(),

--- a/crates/minkowski-lsm/src/recovery.rs
+++ b/crates/minkowski-lsm/src/recovery.rs
@@ -252,6 +252,11 @@ fn archetype_signature(reader: &SortedRunReader, arch_id: u16) -> Result<Archety
     Ok(names)
 }
 
+/// Resolve a sparse component's stable name to the codec registry's
+/// `ComponentId`. Sparse restore (`apply_sparse`) uses this id to locate the
+/// codec, whose `insert_sparse_fn` re-registers the concrete type into the
+/// recovered world itself — so the *registry* id (not a recovered-world local
+/// id) is the correct value here.
 fn resolve_schema_component(
     codecs: &CodecRegistry,
     world: &World,
@@ -264,6 +269,32 @@ fn resolve_schema_component(
         .registered_ids()
         .into_iter()
         .find(|&id| world.component_name(id).is_some_and(|n| n == schema_name))
+}
+
+/// Resolve a dense archetype component (stored in the schema under its Rust
+/// `type_name`) to the RECOVERED world's local `ComponentId`.
+///
+/// `register_one` populated `world` with fresh, sequentially-assigned local ids
+/// in sorted `registered_ids()` order. Those ids need NOT equal the codec
+/// registry's ids: if the registry has a gap (e.g. a non-codec component
+/// occupied an earlier id in the world the registry was built against), or was
+/// built against a differently-ordered world, the registry id and the recovered
+/// world's local id diverge. Resolving through the registry id (`resolve_name`)
+/// would then return an id absent from `world`, failing `import_target`. The
+/// schema stores `World::component_name` (the `type_name`), which matches the
+/// recovered world's `component_name` for every codec-registered type, so we
+/// resolve against the world's own table. Returns `None` for a schema component
+/// with no codec (a legacy run predating the dense raw-copy gate) so the caller
+/// registers a raw placeholder.
+fn resolve_local_component(world: &World, type_name: &str) -> Option<ComponentId> {
+    let mut id = 0;
+    while let Some(name) = world.component_name(id) {
+        if name == type_name {
+            return Some(id);
+        }
+        id += 1;
+    }
+    None
 }
 
 /// Build the entity-allocator state for recovery.
@@ -329,7 +360,7 @@ fn materialize_world(
     // layout, and build name -> ComponentId.
     let mut name_to_id: HashMap<String, ComponentId> = HashMap::new();
     for (name, (size, align)) in component_layouts {
-        let id = if let Some(local_id) = resolve_schema_component(codecs, &world, name) {
+        let id = if let Some(local_id) = resolve_local_component(&world, name) {
             local_id
         } else {
             let layout = Layout::from_size_align(*size, *align).map_err(|_| {
@@ -647,6 +678,59 @@ mod tests {
         assert_eq!(recovered.get::<ZComp>(both).copied(), Some(ZComp(20)));
         assert_eq!(recovered.get::<ZComp>(zonly).copied(), Some(ZComp(99)));
         assert_eq!(recovered.get::<AComp>(zonly), None);
+    }
+
+    /// Codex P2 (round 3) regression: a codec registered at a NON-CONTIGUOUS id
+    /// must still recover. When a non-codec component takes an earlier id in the
+    /// world the registry is built against, the codec lands at a gapped id (here
+    /// id 1, with id 0 codec-less). Recovery's `register_one` compacts that codec
+    /// to local id 0 in the fresh world; resolving the schema name through the
+    /// registry id (1) would then point at a component absent from the recovered
+    /// world and fail `import_target`. Resolving against the recovered world's
+    /// own component table fixes it. (End-to-end flush + recover.)
+    #[test]
+    fn recover_codec_at_noncontiguous_id() {
+        #[derive(Clone, Copy, PartialEq, Debug, Archive, Serialize, Deserialize)]
+        #[repr(C)]
+        struct Payload(u64);
+
+        // A bare component type with no codec, registered FIRST so it occupies
+        // ComponentId 0 in the world the registry is built against.
+        #[derive(Clone, Copy)]
+        #[repr(C)]
+        struct Filler(u32);
+
+        let dir = tempfile::tempdir().unwrap();
+        let lsm_dir = dir.path().join("lsm");
+        let log_path = lsm_dir.join("manifest.log");
+        std::fs::create_dir_all(&lsm_dir).unwrap();
+
+        let mut world = World::new();
+        let mut codecs = CodecRegistry::new();
+        // Filler takes id 0 (no codec); Payload's codec lands at registry id 1.
+        world.register_component::<Filler>();
+        codecs.register::<Payload>(&mut world).unwrap();
+
+        let e = world.spawn((Payload(42),));
+
+        let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
+        flush_and_record(
+            &world,
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(1u64)).unwrap(),
+            &mut manifest,
+            &mut log,
+            &lsm_dir,
+            &codecs,
+        )
+        .unwrap()
+        .expect("flush");
+
+        let (result, _, _) = LsmRecovery::recover::<4>(&lsm_dir, &log_path, &codecs).unwrap();
+        assert_eq!(
+            result.world.get::<Payload>(e).copied(),
+            Some(Payload(42)),
+            "component whose codec sits at a gapped registry id must recover"
+        );
     }
 
     #[test]

--- a/crates/minkowski-lsm/src/recovery.rs
+++ b/crates/minkowski-lsm/src/recovery.rs
@@ -536,10 +536,13 @@ fn materialize_world(
                 LsmError::Format(format!("import page build failed for {sig:?}: {e}"))
             })?;
             // SAFETY: each column slice is the native byte image of a raw-copyable
-            // component (enforced at codec registration); the source pages passed
-            // per-page CRC validation on read; every entity in `entities` is
-            // alive per the allocator state restored above (dead rows were
-            // filtered out).
+            // component. Raw-copyability is enforced at BOTH ends: codec
+            // registration rejects non-raw-copyable types, AND the dense flush
+            // path refuses to persist any dense component lacking a codec — so a
+            // run can only contain dense columns proven raw-copyable. The source
+            // pages passed per-page CRC validation on read, and every entity in
+            // `entities` is alive per the allocator state restored above (dead
+            // rows were filtered out).
             unsafe {
                 world.import_page(&import_page).map_err(|e| {
                     LsmError::Format(format!("import_page failed for {sig:?}: {e}"))
@@ -770,15 +773,15 @@ mod tests {
         dir: &Path,
         lo: u64,
         hi: u64,
+        codecs: &CodecRegistry,
     ) {
-        let codecs = CodecRegistry::new();
         flush_and_record(
             world,
             SeqRange::new(SeqNo::from(lo), SeqNo::from(hi)).unwrap(),
             manifest,
             log,
             dir,
-            &codecs,
+            codecs,
         )
         .unwrap()
         .expect("dirty world must flush");
@@ -805,7 +808,7 @@ mod tests {
         }
 
         let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
-        flush_world(&world, &mut manifest, &mut log, dir.path(), 0, 10);
+        flush_world(&world, &mut manifest, &mut log, dir.path(), 0, 10, &codecs);
 
         let (manifest_check, _) = ManifestLog::recover::<4>(&log_path).unwrap();
         assert_eq!(manifest_check.total_runs(), 1);
@@ -830,12 +833,12 @@ mod tests {
         world.spawn((Pos { x: 1.0, y: 2.0 },));
 
         let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
-        flush_world(&world, &mut manifest, &mut log, dir.path(), 0, 5);
+        flush_world(&world, &mut manifest, &mut log, dir.path(), 0, 5, &codecs);
 
         for (pos,) in world.query::<(&mut Pos,)>() {
             pos.x = 99.0;
         }
-        flush_world(&world, &mut manifest, &mut log, dir.path(), 5, 10);
+        flush_world(&world, &mut manifest, &mut log, dir.path(), 5, 10, &codecs);
 
         let (mut result, _, _) = LsmRecovery::recover::<4>(dir.path(), &log_path, &codecs).unwrap();
         let x = result.world.query::<(&Pos,)>().next().unwrap().0.x;
@@ -889,7 +892,7 @@ mod tests {
         );
 
         let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
-        flush_world(&world, &mut manifest, &mut log, dir.path(), 0, 10);
+        flush_world(&world, &mut manifest, &mut log, dir.path(), 0, 10, &codecs);
 
         let (mut result, _, _) = LsmRecovery::recover::<4>(dir.path(), &log_path, &codecs).unwrap();
 
@@ -937,7 +940,7 @@ mod tests {
         };
 
         let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
-        flush_world(&world, &mut manifest, &mut log, dir.path(), 0, 10);
+        flush_world(&world, &mut manifest, &mut log, dir.path(), 0, 10, &codecs);
 
         let (mut result, _, _) = LsmRecovery::recover::<4>(dir.path(), &log_path, &codecs).unwrap();
         assert_eq!(result.world.query::<(&Pos,)>().count(), n);
@@ -994,6 +997,7 @@ mod tests {
                 dir.path(),
                 seq * 10,
                 seq * 10 + 9,
+                &codecs,
             );
         }
 

--- a/crates/minkowski-lsm/src/schema_match.rs
+++ b/crates/minkowski-lsm/src/schema_match.rs
@@ -64,28 +64,32 @@ mod tests {
     use minkowski::World;
 
     // Component types used in tests.
-    #[derive(Clone, Copy)]
-    #[expect(dead_code)]
+    #[derive(Clone, Copy, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+    #[repr(C)]
     struct Pos {
         x: f32,
         y: f32,
     }
 
-    #[derive(Clone, Copy)]
-    #[expect(dead_code)]
+    #[derive(Clone, Copy, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+    #[repr(C)]
     struct Vel {
         dx: f32,
         dy: f32,
     }
 
-    /// Helper: flush a world to a temp dir, return the reader.
+    /// Helper: flush a world to a temp dir, return the reader. Registers
+    /// `Pos`/`Vel` codecs first — the dense flush gate refuses any dense
+    /// component lacking a codec. `register_component` is idempotent.
     fn flush_to_reader(
-        world: &World,
+        world: &mut World,
         seq_lo: u64,
         seq_hi: u64,
     ) -> (tempfile::TempDir, SortedRunReader) {
         let dir = tempfile::tempdir().unwrap();
-        let codecs = crate::codec::CodecRegistry::new();
+        let mut codecs = crate::codec::CodecRegistry::new();
+        codecs.register_as::<Pos>("pos", world).unwrap();
+        codecs.register_as::<Vel>("vel", world).unwrap();
         let path = flush(
             world,
             SeqRange::new(SeqNo::from(seq_lo), SeqNo::from(seq_hi)).unwrap(),
@@ -103,7 +107,7 @@ mod tests {
     fn single_archetype_found() {
         let mut world = World::new();
         world.spawn((Pos { x: 1.0, y: 2.0 },));
-        let (_dir, reader) = flush_to_reader(&world, 0, 10);
+        let (_dir, reader) = flush_to_reader(&mut world, 0, 10);
 
         // We don't know the exact name ahead of time — check the positive path
         // by enumerating arch_ids, looking up the name from the schema, and
@@ -122,7 +126,7 @@ mod tests {
     fn nonexistent_returns_none() {
         let mut world = World::new();
         world.spawn((Pos { x: 1.0, y: 2.0 },));
-        let (_dir, reader) = flush_to_reader(&world, 0, 10);
+        let (_dir, reader) = flush_to_reader(&mut world, 0, 10);
 
         let result = find_archetype_by_components(&reader, &["DoesNotExist"]);
         assert!(result.is_none());
@@ -137,7 +141,7 @@ mod tests {
         let mut world_a = World::new();
         world_a.spawn((Pos { x: 0.0, y: 0.0 },));
         world_a.spawn((Pos { x: 1.0, y: 1.0 }, Vel { dx: 1.0, dy: 0.0 }));
-        let (_dir_a, reader_a) = flush_to_reader(&world_a, 0, 10);
+        let (_dir_a, reader_a) = flush_to_reader(&mut world_a, 0, 10);
 
         // Run B: spawn (Pos, Vel) first, then (Pos,).
         // A different world means different archetype registration order, so
@@ -145,7 +149,7 @@ mod tests {
         let mut world_b = World::new();
         world_b.spawn((Pos { x: 2.0, y: 2.0 }, Vel { dx: 2.0, dy: 0.0 }));
         world_b.spawn((Pos { x: 3.0, y: 3.0 },));
-        let (_dir_b, reader_b) = flush_to_reader(&world_b, 10, 20);
+        let (_dir_b, reader_b) = flush_to_reader(&mut world_b, 10, 20);
 
         // Resolve the actual component names used in run A for each archetype.
         let arch_ids_a = reader_a.archetype_ids();

--- a/crates/minkowski-lsm/src/writer.rs
+++ b/crates/minkowski-lsm/src/writer.rs
@@ -129,14 +129,37 @@ pub fn flush_observed(
                 // Only fires when this component actually contributes a page to the
                 // run; a component whose every dirty page is past `arch_len` writes
                 // nothing and must not trip a false positive.
-                if writes_any && !codecs.has_codec(comp_id) {
-                    let name = world.component_name(comp_id).unwrap_or("<unknown>");
-                    return Err(LsmError::Format(format!(
-                        "dense component '{name}' (id={comp_id}) has no registered codec; \
-                         it cannot be persisted to the LSM baseline because its native \
-                         bytes are not provably raw-copyable. Register it via \
-                         CodecRegistry::register before flushing."
-                    )));
+                if writes_any {
+                    if !codecs.has_codec(comp_id) {
+                        let name = world.component_name(comp_id).unwrap_or("<unknown>");
+                        return Err(LsmError::Format(format!(
+                            "dense component '{name}' (id={comp_id}) has no registered codec; \
+                             it cannot be persisted to the LSM baseline because its native \
+                             bytes are not provably raw-copyable. Register it via \
+                             CodecRegistry::register before flushing."
+                        )));
+                    }
+                    // `has_codec(comp_id)` only proves *some* codec sits at this
+                    // numeric id. ComponentId is a per-world index, so a registry
+                    // built against a different world could hold a raw-copyable
+                    // codec at the same id while THIS world's component there is a
+                    // different, possibly non-raw-copyable type — silently passing
+                    // the gate above and persisting native bytes that dangle on
+                    // recovery. Confirm the codec describes the exact type being
+                    // flushed by comparing TypeIds (stable across worlds, so a
+                    // recovered world re-flushed with its codecs still validates).
+                    let codec_ty = codecs.type_id(comp_id);
+                    let world_ty = world.component_type_id(comp_id);
+                    if codec_ty != world_ty {
+                        let name = world.component_name(comp_id).unwrap_or("<unknown>");
+                        return Err(LsmError::Format(format!(
+                            "dense component '{name}' (id={comp_id}) does not match its \
+                             registered codec's type (codec {codec_ty:?}, world \
+                             {world_ty:?}); the CodecRegistry was built for a different \
+                             component identity. A codec must be registered for the exact \
+                             component type being flushed."
+                        )));
+                    }
                 }
             }
         }
@@ -943,6 +966,52 @@ mod tests {
         let msg = format!("{}", result.unwrap_err());
         assert!(
             msg.contains("no registered codec"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    /// Codex P1 regression: `has_codec(comp_id)` is a per-world numeric-id lookup.
+    /// A `CodecRegistry` built against one world holds a codec at some id; if a
+    /// DIFFERENT world has a DIFFERENT component type at that same id, the codec
+    /// gate would pass on the id alone while the flushed column is actually the
+    /// other type — persisting native bytes that dangle on recovery. The flush
+    /// must compare the codec's TypeId to the flushed world's component TypeId
+    /// and reject the mismatch. (Same type from another world is sound — the
+    /// TypeId matches — so the failure is keyed on type identity, not world.)
+    #[test]
+    fn flush_rejects_codec_for_wrong_type_at_same_id() {
+        #[derive(Clone, Copy, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+        #[repr(C)]
+        struct Acodec(u32);
+        #[derive(Clone, Copy)]
+        #[repr(C)]
+        struct Bworld(u64);
+
+        // Registry built against `other`: Acodec is its first component → id 0.
+        let mut other = World::new();
+        let mut codecs = CodecRegistry::new();
+        codecs.register::<Acodec>(&mut other).unwrap();
+
+        // The world we actually flush has a DIFFERENT type as its first
+        // component → also id 0. `has_codec(0)` is true (Acodec's codec), but
+        // the column bytes are Bworld's. The TypeId check must catch this.
+        let mut world = World::new();
+        world.spawn((Bworld(7),));
+
+        let dir = tempfile::tempdir().unwrap();
+        let result = flush(
+            &world,
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(1u64)).unwrap(),
+            dir.path(),
+            &codecs,
+        );
+        assert!(
+            result.is_err(),
+            "flushing a column whose codec is registered for a different type must error"
+        );
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("does not match its registered codec's type"),
             "unexpected error: {msg}"
         );
     }

--- a/crates/minkowski-lsm/src/writer.rs
+++ b/crates/minkowski-lsm/src/writer.rs
@@ -120,44 +120,29 @@ pub fn flush_observed(
                 }
                 // Soundness gate: a dense column is persisted as NATIVE bytes and
                 // memcpy'd back verbatim on recovery, which is only sound for a
-                // raw-copyable (POD) type. Codec registration enforces
-                // raw-copyability, so a missing codec means the bytes are not
-                // provably position-independent (they may hold heap pointers like
-                // String/Vec). Refuse to flush rather than write bytes that would
-                // be unsound to restore. (Mirrors the sparse skip-warn above, but
-                // dense data must hard-error — it cannot be silently dropped.)
-                // Only fires when this component actually contributes a page to the
-                // run; a component whose every dirty page is past `arch_len` writes
-                // nothing and must not trip a false positive.
+                // raw-copyable (POD) type. Codec registration certifies
+                // raw-copyability per TYPE. Resolve the codec by the flushed
+                // world's component *type*, never by its per-world ComponentId:
+                // a registry built against a different world can file the same
+                // type under a different id (so id-keyed lookup over-rejects) or
+                // a different type under this id (so id-keyed lookup is unsound).
+                // No codec for this type ⇒ its native bytes are not provably
+                // position-independent (may hold heap pointers like String/Vec) ⇒
+                // hard-error rather than persist bytes that would dangle on
+                // recovery. (Mirrors the sparse skip-warn above, but dense data
+                // must hard-error — it cannot be silently dropped.) Only fires
+                // when the component actually contributes a page to the run.
                 if writes_any {
-                    if !codecs.has_codec(comp_id) {
+                    let has_codec = world
+                        .component_type_id(comp_id)
+                        .is_some_and(|ty| codecs.has_codec_for_type(ty));
+                    if !has_codec {
                         let name = world.component_name(comp_id).unwrap_or("<unknown>");
                         return Err(LsmError::Format(format!(
-                            "dense component '{name}' (id={comp_id}) has no registered codec; \
-                             it cannot be persisted to the LSM baseline because its native \
-                             bytes are not provably raw-copyable. Register it via \
+                            "dense component '{name}' (id={comp_id}) has no registered codec \
+                             for its type; it cannot be persisted to the LSM baseline because \
+                             its native bytes are not provably raw-copyable. Register it via \
                              CodecRegistry::register before flushing."
-                        )));
-                    }
-                    // `has_codec(comp_id)` only proves *some* codec sits at this
-                    // numeric id. ComponentId is a per-world index, so a registry
-                    // built against a different world could hold a raw-copyable
-                    // codec at the same id while THIS world's component there is a
-                    // different, possibly non-raw-copyable type — silently passing
-                    // the gate above and persisting native bytes that dangle on
-                    // recovery. Confirm the codec describes the exact type being
-                    // flushed by comparing TypeIds (stable across worlds, so a
-                    // recovered world re-flushed with its codecs still validates).
-                    let codec_ty = codecs.type_id(comp_id);
-                    let world_ty = world.component_type_id(comp_id);
-                    if codec_ty != world_ty {
-                        let name = world.component_name(comp_id).unwrap_or("<unknown>");
-                        return Err(LsmError::Format(format!(
-                            "dense component '{name}' (id={comp_id}) does not match its \
-                             registered codec's type (codec {codec_ty:?}, world \
-                             {world_ty:?}); the CodecRegistry was built for a different \
-                             component identity. A codec must be registered for the exact \
-                             component type being flushed."
                         )));
                     }
                 }
@@ -972,12 +957,11 @@ mod tests {
 
     /// Codex P1 regression: `has_codec(comp_id)` is a per-world numeric-id lookup.
     /// A `CodecRegistry` built against one world holds a codec at some id; if a
-    /// DIFFERENT world has a DIFFERENT component type at that same id, the codec
-    /// gate would pass on the id alone while the flushed column is actually the
-    /// other type — persisting native bytes that dangle on recovery. The flush
-    /// must compare the codec's TypeId to the flushed world's component TypeId
-    /// and reject the mismatch. (Same type from another world is sound — the
-    /// TypeId matches — so the failure is keyed on type identity, not world.)
+    /// DIFFERENT world has a DIFFERENT component type at that same id, an id-keyed
+    /// gate would pass while the flushed column is actually the other (possibly
+    /// non-raw-copyable) type — persisting native bytes that dangle on recovery.
+    /// Resolving the codec by the flushed world's component *type* rejects this:
+    /// the registry has no codec for `Bworld`.
     #[test]
     fn flush_rejects_codec_for_wrong_type_at_same_id() {
         #[derive(Clone, Copy, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
@@ -993,8 +977,8 @@ mod tests {
         codecs.register::<Acodec>(&mut other).unwrap();
 
         // The world we actually flush has a DIFFERENT type as its first
-        // component → also id 0. `has_codec(0)` is true (Acodec's codec), but
-        // the column bytes are Bworld's. The TypeId check must catch this.
+        // component → also id 0. An id-keyed `has_codec(0)` would pass (Acodec's
+        // codec), but the column bytes are Bworld's, which has no codec.
         let mut world = World::new();
         world.spawn((Bworld(7),));
 
@@ -1007,12 +991,50 @@ mod tests {
         );
         assert!(
             result.is_err(),
-            "flushing a column whose codec is registered for a different type must error"
+            "flushing a column whose type has no codec must error"
         );
         let msg = format!("{}", result.unwrap_err());
         assert!(
-            msg.contains("does not match its registered codec's type"),
+            msg.contains("no registered codec for its type"),
             "unexpected error: {msg}"
+        );
+    }
+
+    /// Codex P2 regression: the gate must resolve the codec by TYPE, not by the
+    /// flushed world's numeric `ComponentId`. A registry that filed a type under
+    /// a different id than the flushed world (e.g. after recovery re-registers
+    /// components into a fresh world in a different order) must still flush — the
+    /// codec for the type exists, just under another id.
+    #[test]
+    fn flush_accepts_codec_for_type_at_different_id() {
+        #[derive(Clone, Copy, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+        #[repr(C)]
+        struct Filler(u32);
+        #[derive(Clone, Copy, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+        #[repr(C)]
+        struct Payload(u64);
+
+        // Registry built against `other`: Filler at id 0, Payload at id 1.
+        let mut other = World::new();
+        let mut codecs = CodecRegistry::new();
+        codecs.register::<Filler>(&mut other).unwrap();
+        codecs.register::<Payload>(&mut other).unwrap();
+
+        // Flushed world has only Payload → id 0 (a DIFFERENT id than the registry
+        // filed it under). Resolving by type, the Payload codec is found anyway.
+        let mut world = World::new();
+        world.spawn((Payload(7),));
+
+        let dir = tempfile::tempdir().unwrap();
+        let result = flush(
+            &world,
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(1u64)).unwrap(),
+            dir.path(),
+            &codecs,
+        );
+        assert!(
+            result.is_ok(),
+            "a codec resolved by type must accept a type filed under a different id: {result:?}"
         );
     }
 }

--- a/crates/minkowski-lsm/src/writer.rs
+++ b/crates/minkowski-lsm/src/writer.rs
@@ -108,13 +108,35 @@ pub fn flush_observed(
         // rows from older runs against the authoritative persisted allocator.
         for &comp_id in world.archetype_component_ids(arch_idx) {
             if let Some(pages) = world.column_dirty_pages(arch_idx, comp_id) {
+                let mut writes_any = false;
                 for page in pages {
                     let start_row = page * PAGE_SIZE;
                     if start_row >= arch_len {
                         continue;
                     }
+                    writes_any = true;
                     dirty.insert((arch_idx, comp_id, page));
                     entity_dirty.entry(arch_idx).or_default().insert(page);
+                }
+                // Soundness gate: a dense column is persisted as NATIVE bytes and
+                // memcpy'd back verbatim on recovery, which is only sound for a
+                // raw-copyable (POD) type. Codec registration enforces
+                // raw-copyability, so a missing codec means the bytes are not
+                // provably position-independent (they may hold heap pointers like
+                // String/Vec). Refuse to flush rather than write bytes that would
+                // be unsound to restore. (Mirrors the sparse skip-warn above, but
+                // dense data must hard-error — it cannot be silently dropped.)
+                // Only fires when this component actually contributes a page to the
+                // run; a component whose every dirty page is past `arch_len` writes
+                // nothing and must not trip a false positive.
+                if writes_any && !codecs.has_codec(comp_id) {
+                    let name = world.component_name(comp_id).unwrap_or("<unknown>");
+                    return Err(LsmError::Format(format!(
+                        "dense component '{name}' (id={comp_id}) has no registered codec; \
+                         it cannot be persisted to the LSM baseline because its native \
+                         bytes are not provably raw-copyable. Register it via \
+                         CodecRegistry::register before flushing."
+                    )));
                 }
             }
         }
@@ -608,23 +630,34 @@ mod tests {
     use crate::types::{SeqNo, SeqRange};
     use minkowski::World;
 
-    #[derive(Clone, Copy)]
-    #[expect(dead_code)]
+    #[derive(Clone, Copy, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+    #[repr(C)]
     struct Pos {
         x: f32,
         y: f32,
     }
 
-    #[derive(Clone, Copy)]
-    #[expect(dead_code)]
+    #[derive(Clone, Copy, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+    #[repr(C)]
     struct Vel {
         dx: f32,
         dy: f32,
     }
 
+    /// Build a `CodecRegistry` with the module-level `Pos`/`Vel` test components
+    /// registered, mirroring real callers that register dense components before
+    /// flushing. The dense flush gate refuses any dense component lacking a codec.
+    fn codecs_with(world: &mut World) -> CodecRegistry {
+        let mut codecs = CodecRegistry::new();
+        codecs.register_as::<Pos>("pos", world).unwrap();
+        codecs.register_as::<Vel>("vel", world).unwrap();
+        codecs
+    }
+
     #[test]
     fn flush_no_dirty_pages_returns_none() {
         let mut world = World::new();
+        let codecs = codecs_with(&mut world);
         world.spawn((Pos { x: 1.0, y: 2.0 },));
         world.clear_all_dirty_pages();
         let dir = tempfile::tempdir().unwrap();
@@ -632,7 +665,7 @@ mod tests {
             &world,
             SeqRange::new(SeqNo::from(0u64), SeqNo::from(0u64)).unwrap(),
             dir.path(),
-            &CodecRegistry::new(),
+            &codecs,
         )
         .unwrap();
         assert!(result.is_none());
@@ -641,13 +674,14 @@ mod tests {
     #[test]
     fn flush_dirty_pages_creates_file() {
         let mut world = World::new();
+        let codecs = codecs_with(&mut world);
         world.spawn((Pos { x: 1.0, y: 2.0 },)); // Pages are dirty from spawn.
         let dir = tempfile::tempdir().unwrap();
         let result = flush(
             &world,
             SeqRange::new(SeqNo::from(1u64), SeqNo::from(5u64)).unwrap(),
             dir.path(),
-            &CodecRegistry::new(),
+            &codecs,
         )
         .unwrap();
         assert!(result.is_some());
@@ -659,13 +693,14 @@ mod tests {
     #[test]
     fn file_has_correct_header_magic() {
         let mut world = World::new();
+        let codecs = codecs_with(&mut world);
         world.spawn((Pos { x: 1.0, y: 2.0 },));
         let dir = tempfile::tempdir().unwrap();
         let result = flush(
             &world,
             SeqRange::new(SeqNo::from(10u64), SeqNo::from(20u64)).unwrap(),
             dir.path(),
-            &CodecRegistry::new(),
+            &codecs,
         )
         .unwrap();
         let path = result.unwrap();
@@ -676,6 +711,7 @@ mod tests {
     #[test]
     fn flush_multi_component() {
         let mut world = World::new();
+        let codecs = codecs_with(&mut world);
         world.spawn((Pos { x: 1.0, y: 2.0 }, Vel { dx: 0.5, dy: -0.5 }));
         world.spawn((Pos { x: 3.0, y: 4.0 }, Vel { dx: 1.0, dy: 1.0 }));
         let dir = tempfile::tempdir().unwrap();
@@ -683,7 +719,7 @@ mod tests {
             &world,
             SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
             dir.path(),
-            &CodecRegistry::new(),
+            &codecs,
         )
         .unwrap();
         assert!(result.is_some());
@@ -709,6 +745,7 @@ mod tests {
     #[test]
     fn flush_archetype_shrink_page_count_matches() {
         let mut world = World::new();
+        let codecs = codecs_with(&mut world);
         // 600 entities → 3 pages of 256.
         let mut all = Vec::new();
         for i in 0..600u32 {
@@ -730,7 +767,7 @@ mod tests {
             &world,
             SeqRange::new(SeqNo::from(0u64), SeqNo::from(1u64)).unwrap(),
             dir.path(),
-            &CodecRegistry::new(),
+            &codecs,
         )
         .unwrap()
         .unwrap();
@@ -745,13 +782,14 @@ mod tests {
     #[test]
     fn header_crc_is_valid() {
         let mut world = World::new();
+        let codecs = codecs_with(&mut world);
         world.spawn((Pos { x: 1.0, y: 2.0 },));
         let dir = tempfile::tempdir().unwrap();
         let path = flush(
             &world,
             SeqRange::new(SeqNo::from(0u64), SeqNo::from(1u64)).unwrap(),
             dir.path(),
-            &CodecRegistry::new(),
+            &codecs,
         )
         .unwrap()
         .unwrap();
@@ -768,6 +806,7 @@ mod tests {
         use std::rc::Rc;
 
         let mut world = World::new();
+        let codecs = codecs_with(&mut world);
         let e1 = world.spawn((Pos { x: 0.0, y: 0.0 },));
         let e2 = world.spawn((Pos { x: 1.0, y: 1.0 },));
         let e3 = world.spawn((Pos { x: 2.0, y: 2.0 },));
@@ -776,7 +815,6 @@ mod tests {
         let observed_clone = Rc::clone(&observed);
 
         let dir = tempfile::tempdir().unwrap();
-        let codecs = CodecRegistry::new();
         let result = flush_observed(
             &world,
             SeqRange::new(SeqNo::from(1u64), SeqNo::from(5u64)).unwrap(),
@@ -852,6 +890,7 @@ mod tests {
     #[test]
     fn flush_produces_run_with_bloom_filter() {
         let mut world = World::new();
+        let codecs = codecs_with(&mut world);
         world.spawn((Pos { x: 1.0, y: 2.0 },));
         world.spawn((Pos { x: 3.0, y: 4.0 },));
         world.spawn((Pos { x: 5.0, y: 6.0 },));
@@ -861,7 +900,7 @@ mod tests {
             &world,
             SeqRange::new(SeqNo::from(0u64), SeqNo::from(0u64)).unwrap(),
             dir.path(),
-            &CodecRegistry::new(),
+            &codecs,
         )
         .unwrap()
         .unwrap();
@@ -874,6 +913,37 @@ mod tests {
         assert!(
             footer.bloom_filter_offset > 0,
             "bloom_filter_offset must be non-zero for dirty flush"
+        );
+    }
+
+    /// Soundness gate: a dense component registered in core but absent from the
+    /// `CodecRegistry` is not provably raw-copyable. Flushing its native bytes
+    /// would memcpy a possibly heap-owning value back verbatim on recovery (UB).
+    /// The flush path must hard-error rather than persist such a column.
+    #[test]
+    fn flush_rejects_dense_component_without_codec() {
+        #[derive(Clone, Copy)]
+        #[repr(C)]
+        struct Uncodec(u32);
+
+        let mut world = World::new();
+        world.spawn((Uncodec(1),)); // registered in core, NOT in the CodecRegistry
+        let dir = tempfile::tempdir().unwrap();
+        let codecs = CodecRegistry::new();
+        let result = flush(
+            &world,
+            SeqRange::new(SeqNo::from(0u64), SeqNo::from(1u64)).unwrap(),
+            dir.path(),
+            &codecs,
+        );
+        assert!(
+            result.is_err(),
+            "flushing a codec-less dense component must error"
+        );
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("no registered codec"),
+            "unexpected error: {msg}"
         );
     }
 }

--- a/crates/minkowski-lsm/tests/compaction_integration.rs
+++ b/crates/minkowski-lsm/tests/compaction_integration.rs
@@ -20,7 +20,8 @@ use minkowski_lsm::writer::EntityKey;
 
 // ── Component types ──────────────────────────────────────────────────────────
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[repr(C)]
 struct Pos {
     x: f32,
     y: f32,
@@ -28,9 +29,12 @@ struct Pos {
 
 // ── Helper ───────────────────────────────────────────────────────────────────
 
-/// Do one flush from `world` (which must have dirty pages) and return the run path.
+/// Do one flush from `world` (which must have dirty pages) and return the run
+/// path. Registers `Pos` in a codec registry first — the dense flush gate
+/// refuses any dense component lacking a codec. `register_component` is
+/// idempotent, so reusing the same world across calls is fine.
 fn do_flush<const N: usize>(
-    world: &World,
+    world: &mut World,
     manifest: &mut LsmManifest<N>,
     log: &mut ManifestLog,
     run_dir: &std::path::Path,
@@ -38,16 +42,11 @@ fn do_flush<const N: usize>(
     seq_hi: u64,
 ) -> std::path::PathBuf {
     let seq_range = SeqRange::new(SeqNo::from(seq_lo), SeqNo::from(seq_hi)).unwrap();
-    flush_and_record(
-        world,
-        seq_range,
-        manifest,
-        log,
-        run_dir,
-        &CodecRegistry::new(),
-    )
-    .unwrap()
-    .expect("world must be dirty for flush to produce Some")
+    let mut codecs = CodecRegistry::new();
+    codecs.register_as::<Pos>("pos", world).unwrap();
+    flush_and_record(world, seq_range, manifest, log, run_dir, &codecs)
+        .unwrap()
+        .expect("world must be dirty for flush to produce Some")
 }
 
 /// Collect all entity IDs from the entity-slot pages of arch_id 0 in a reader.
@@ -108,7 +107,7 @@ fn flush_four_times_then_compact_consolidates_l0_to_l1() {
             y: 0.0,
         },));
         do_flush(
-            &world,
+            &mut world,
             &mut manifest,
             &mut log,
             dir.path(),
@@ -181,7 +180,7 @@ fn compact_preserves_all_entities() {
         }
         let lo = (flush_i as u64) * 10;
         let hi = lo + 9;
-        do_flush(&world, &mut manifest, &mut log, dir.path(), lo, hi);
+        do_flush(&mut world, &mut manifest, &mut log, dir.path(), lo, hi);
     }
 
     assert_eq!(
@@ -239,7 +238,7 @@ fn compact_with_entity_updates_keeps_newest_version() {
     let _b0 = world0.spawn((Pos { x: 0.0, y: 0.0 },));
     let hero_entity = world0.spawn((Pos { x: 1.0, y: 2.0 },));
     let hero_bits = hero_entity.to_bits();
-    do_flush(&world0, &mut manifest, &mut log, dir.path(), 0, 9);
+    do_flush(&mut world0, &mut manifest, &mut log, dir.path(), 0, 9);
 
     // --- Flush 1: update hero's Pos ---
     // We create a new world where the hero entity is represented with the same
@@ -259,17 +258,17 @@ fn compact_with_entity_updates_keeps_newest_version() {
         hero_bits,
         "hero entity must have the same bits in world1"
     );
-    do_flush(&world1, &mut manifest, &mut log, dir.path(), 10, 19);
+    do_flush(&mut world1, &mut manifest, &mut log, dir.path(), 10, 19);
 
     // --- Flush 2: new entities (to get a dirty page) ---
     let mut world2 = World::new();
     world2.spawn((Pos { x: 100.0, y: 200.0 },));
-    do_flush(&world2, &mut manifest, &mut log, dir.path(), 20, 29);
+    do_flush(&mut world2, &mut manifest, &mut log, dir.path(), 20, 29);
 
     // --- Flush 3: new entities ---
     let mut world3 = World::new();
     world3.spawn((Pos { x: 200.0, y: 300.0 },));
-    do_flush(&world3, &mut manifest, &mut log, dir.path(), 30, 39);
+    do_flush(&mut world3, &mut manifest, &mut log, dir.path(), 30, 39);
 
     assert_eq!(manifest.runs_at_level(Level::L0).len(), 4);
 
@@ -309,7 +308,7 @@ fn compact_emits_exactly_one_compaction_commit_entry() {
             y: 0.0,
         },));
         do_flush(
-            &world,
+            &mut world,
             &mut manifest,
             &mut log,
             dir.path(),
@@ -384,7 +383,7 @@ fn needs_compaction_parity_with_compact_one() {
             y: 0.0,
         },));
         do_flush(
-            &world,
+            &mut world,
             &mut manifest,
             &mut log,
             dir.path(),
@@ -403,7 +402,7 @@ fn needs_compaction_parity_with_compact_one() {
     {
         let mut world = World::new();
         world.spawn((Pos { x: 99.0, y: 0.0 },));
-        do_flush(&world, &mut manifest, &mut log, dir.path(), 30, 39);
+        do_flush(&mut world, &mut manifest, &mut log, dir.path(), 30, 39);
     }
     assert!(
         manifest.needs_compaction().unwrap(),
@@ -455,7 +454,7 @@ fn compact_then_recover_roundtrips_state() {
             all_bits.insert(e.to_bits());
         }
         let lo = (flush_i as u64) * 10;
-        do_flush(&world, &mut manifest, &mut log, dir.path(), lo, lo + 9);
+        do_flush(&mut world, &mut manifest, &mut log, dir.path(), lo, lo + 9);
     }
 
     assert_eq!(manifest.runs_at_level(Level::L0).len(), n_flushes);
@@ -545,7 +544,7 @@ fn compact_one_observed_fires_for_each_output_entity() {
             all_bits.insert(e.to_bits());
         }
         let lo = (flush_i as u64) * 10;
-        do_flush(&world, &mut manifest, &mut log, dir.path(), lo, lo + 9);
+        do_flush(&mut world, &mut manifest, &mut log, dir.path(), lo, lo + 9);
     }
 
     let observed: Rc<RefCell<Vec<u64>>> = Rc::new(RefCell::new(Vec::new()));

--- a/crates/minkowski-lsm/tests/integration.rs
+++ b/crates/minkowski-lsm/tests/integration.rs
@@ -9,32 +9,47 @@ use minkowski_lsm::schema::SchemaEntry;
 use minkowski_lsm::types::{SeqNo, SeqRange};
 use minkowski_lsm::writer::flush;
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[repr(C)]
 struct Pos {
     x: f32,
     y: f32,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[repr(C)]
 struct Vel {
     dx: f32,
     dy: f32,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[repr(C)]
 struct Health(u32);
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
+/// Build a `CodecRegistry` with the flushable test components (`Pos`/`Vel`/
+/// `Health`) registered. The dense flush gate refuses any dense component
+/// lacking a codec, so every persisted dense column must be registered here.
+fn test_codecs(world: &mut World) -> CodecRegistry {
+    let mut codecs = CodecRegistry::new();
+    codecs.register_as::<Pos>("pos", world).unwrap();
+    codecs.register_as::<Vel>("vel", world).unwrap();
+    codecs.register_as::<Health>("health", world).unwrap();
+    codecs
+}
+
 /// Flush the world and return (tempdir, path, reader).
 /// The tempdir must be kept alive for the duration of the test.
-fn flush_and_open(world: &World) -> (tempfile::TempDir, SortedRunReader) {
+fn flush_and_open(world: &mut World) -> (tempfile::TempDir, SortedRunReader) {
     let dir = tempfile::tempdir().unwrap();
+    let codecs = test_codecs(world);
     let path = flush(
         world,
         SeqRange::new(SeqNo::from(0u64), SeqNo::from(100u64)).unwrap(),
         dir.path(),
-        &CodecRegistry::new(),
+        &codecs,
     )
     .unwrap()
     .expect("flush should produce a file");
@@ -60,7 +75,7 @@ fn round_trip_single_archetype() {
         ));
     }
 
-    let (_dir, reader) = flush_and_open(&world);
+    let (_dir, reader) = flush_and_open(&mut world);
 
     // There is one archetype (arch_id = 0).
     let schema = reader.schema();
@@ -118,7 +133,7 @@ fn round_trip_partial_page() {
         },));
     }
 
-    let (_dir, reader) = flush_and_open(&world);
+    let (_dir, reader) = flush_and_open(&mut world);
     let schema = reader.schema();
     assert_eq!(schema.len(), 1);
 
@@ -182,7 +197,7 @@ fn multi_archetype_flush() {
         "should have at least 2 archetypes"
     );
 
-    let (_dir, reader) = flush_and_open(&world);
+    let (_dir, reader) = flush_and_open(&mut world);
     let schema = reader.schema();
 
     // Schema must contain all three component types.
@@ -260,12 +275,13 @@ fn crc_corruption_detected() {
         },));
     }
 
+    let codecs = test_codecs(&mut world);
     let dir = tempfile::tempdir().unwrap();
     let path = flush(
         &world,
         SeqRange::new(SeqNo::from(0u64), SeqNo::from(50u64)).unwrap(),
         dir.path(),
-        &CodecRegistry::new(),
+        &codecs,
     )
     .unwrap()
     .unwrap();
@@ -333,12 +349,13 @@ fn header_crc_corruption_detected() {
         },));
     }
 
+    let codecs = test_codecs(&mut world);
     let dir = tempfile::tempdir().unwrap();
     let path = flush(
         &world,
         SeqRange::new(SeqNo::from(0u64), SeqNo::from(10u64)).unwrap(),
         dir.path(),
-        &CodecRegistry::new(),
+        &codecs,
     )
     .unwrap()
     .unwrap();
@@ -393,7 +410,7 @@ fn schema_contains_correct_entries() {
     let mut world = World::new();
     world.spawn((Pos { x: 1.0, y: 2.0 }, Vel { dx: 0.5, dy: -0.5 }));
 
-    let (_dir, reader) = flush_and_open(&world);
+    let (_dir, reader) = flush_and_open(&mut world);
     let schema = reader.schema();
 
     assert_eq!(schema.len(), 2, "schema should have exactly 2 entries");
@@ -433,7 +450,7 @@ fn sparse_index_finds_all_pages() {
         },));
     }
 
-    let (_dir, reader) = flush_and_open(&world);
+    let (_dir, reader) = flush_and_open(&mut world);
 
     let schema = reader.schema();
     let pos_slot = schema
@@ -494,7 +511,7 @@ fn entity_pages_match_world() {
         },));
     }
 
-    let (_dir, reader) = flush_and_open(&world);
+    let (_dir, reader) = flush_and_open(&mut world);
 
     let entity_page = reader
         .get_page(0, ENTITY_SLOT, 0)
@@ -519,10 +536,13 @@ fn entity_pages_match_world() {
 
 #[test]
 fn zst_component_round_trip() {
-    #[derive(Clone, Copy)]
+    #[derive(Clone, Copy, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+    #[repr(C)]
     struct Marker;
 
     let mut world = World::new();
+    let mut codecs = CodecRegistry::new();
+    codecs.register_as::<Marker>("marker", &mut world).unwrap();
     for _ in 0..5 {
         world.spawn((Marker,));
     }
@@ -531,7 +551,7 @@ fn zst_component_round_trip() {
         &world,
         SeqRange::new(SeqNo::from(0u64), SeqNo::from(0u64)).unwrap(),
         dir.path(),
-        &CodecRegistry::new(),
+        &codecs,
     )
     .unwrap()
     .unwrap();

--- a/crates/minkowski-lsm/tests/manifest_integration.rs
+++ b/crates/minkowski-lsm/tests/manifest_integration.rs
@@ -11,18 +11,27 @@ use minkowski_lsm::manifest_log::{ManifestEntry, ManifestLog, ManifestTag};
 use minkowski_lsm::manifest_ops::{cleanup_orphans, flush_and_record};
 use minkowski_lsm::types::{Level, SeqNo, SeqRange};
 
-#[derive(Clone, Copy)]
-#[expect(dead_code)]
+#[derive(Clone, Copy, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[repr(C)]
 struct Pos {
     x: f32,
     y: f32,
 }
 
-#[derive(Clone, Copy)]
-#[expect(dead_code)]
+#[derive(Clone, Copy, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
+#[repr(C)]
 struct Vel {
     dx: f32,
     dy: f32,
+}
+
+/// Build a `CodecRegistry` with `Pos`/`Vel` registered — the dense flush gate
+/// refuses any dense component lacking a codec.
+fn mk_codecs(world: &mut World) -> CodecRegistry {
+    let mut codecs = CodecRegistry::new();
+    codecs.register_as::<Pos>("pos", world).unwrap();
+    codecs.register_as::<Vel>("vel", world).unwrap();
+    codecs
 }
 
 // ── Lifecycle ───────────────────────────────────────────────────────────────
@@ -34,6 +43,7 @@ fn three_flushes_then_replay() {
     let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
+    let codecs = mk_codecs(&mut world);
 
     // Flush 1: spawn some entities.
     for i in 0..5 {
@@ -48,7 +58,7 @@ fn three_flushes_then_replay() {
         &mut manifest,
         &mut log,
         dir.path(),
-        &CodecRegistry::new(),
+        &codecs,
     )
     .unwrap()
     .unwrap();
@@ -67,7 +77,7 @@ fn three_flushes_then_replay() {
         &mut manifest,
         &mut log,
         dir.path(),
-        &CodecRegistry::new(),
+        &codecs,
     )
     .unwrap()
     .unwrap();
@@ -81,7 +91,7 @@ fn three_flushes_then_replay() {
         &mut manifest,
         &mut log,
         dir.path(),
-        &CodecRegistry::new(),
+        &codecs,
     )
     .unwrap()
     .unwrap();
@@ -119,6 +129,7 @@ fn corrupt_tail_partial_recovery() {
     let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
+    let codecs = mk_codecs(&mut world);
     world.spawn((Pos { x: 1.0, y: 2.0 },));
 
     // Two good flushes.
@@ -128,7 +139,7 @@ fn corrupt_tail_partial_recovery() {
         &mut manifest,
         &mut log,
         dir.path(),
-        &CodecRegistry::new(),
+        &codecs,
     )
     .unwrap();
     world.clear_all_dirty_pages();
@@ -140,7 +151,7 @@ fn corrupt_tail_partial_recovery() {
         &mut manifest,
         &mut log,
         dir.path(),
-        &CodecRegistry::new(),
+        &codecs,
     )
     .unwrap();
 
@@ -170,6 +181,7 @@ fn replay_converges_at_every_truncation_prefix() {
     let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
+    let codecs = mk_codecs(&mut world);
     for i in 0..3u64 {
         world.spawn((Pos {
             x: i as f32,
@@ -183,7 +195,7 @@ fn replay_converges_at_every_truncation_prefix() {
             &mut manifest,
             &mut log,
             dir.path(),
-            &CodecRegistry::new(),
+            &codecs,
         )
         .unwrap();
         world.clear_all_dirty_pages();
@@ -254,6 +266,7 @@ fn replay_truncates_log_on_promote_of_missing_run() {
     let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
+    let codecs = mk_codecs(&mut world);
     world.spawn((Pos { x: 1.0, y: 0.0 },));
     // Real flush: produces a genuine AddRunAndSequence entry.
     flush_and_record(
@@ -262,7 +275,7 @@ fn replay_truncates_log_on_promote_of_missing_run() {
         &mut manifest,
         &mut log,
         dir.path(),
-        &CodecRegistry::new(),
+        &codecs,
     )
     .unwrap();
 
@@ -304,6 +317,7 @@ fn cleanup_removes_orphans_and_tmp() {
     let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
+    let codecs = mk_codecs(&mut world);
     world.spawn((Pos { x: 1.0, y: 2.0 },));
 
     // One real flush.
@@ -313,7 +327,7 @@ fn cleanup_removes_orphans_and_tmp() {
         &mut manifest,
         &mut log,
         dir.path(),
-        &CodecRegistry::new(),
+        &codecs,
     )
     .unwrap();
 
@@ -343,6 +357,7 @@ fn replay_truncates_log_on_unsorted_coverage() {
     let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
+    let codecs = mk_codecs(&mut world);
     world.spawn((Pos { x: 1.0, y: 0.0 },));
     // One real flush, produces a valid AddRunAndSequence frame.
     flush_and_record(
@@ -351,7 +366,7 @@ fn replay_truncates_log_on_unsorted_coverage() {
         &mut manifest,
         &mut log,
         dir.path(),
-        &CodecRegistry::new(),
+        &codecs,
     )
     .unwrap();
 
@@ -413,6 +428,7 @@ fn replay_truncates_log_on_invalid_level_byte() {
     let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
+    let codecs = mk_codecs(&mut world);
     world.spawn((Pos { x: 1.0, y: 0.0 },));
     flush_and_record(
         &world,
@@ -420,7 +436,7 @@ fn replay_truncates_log_on_invalid_level_byte() {
         &mut manifest,
         &mut log,
         dir.path(),
-        &CodecRegistry::new(),
+        &codecs,
     )
     .unwrap();
 
@@ -470,6 +486,7 @@ fn replay_truncates_log_on_unknown_tag_byte() {
     let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
+    let codecs = mk_codecs(&mut world);
     world.spawn((Pos { x: 1.0, y: 0.0 },));
     flush_and_record(
         &world,
@@ -477,7 +494,7 @@ fn replay_truncates_log_on_unknown_tag_byte() {
         &mut manifest,
         &mut log,
         dir.path(),
-        &CodecRegistry::new(),
+        &codecs,
     )
     .unwrap();
 
@@ -524,6 +541,7 @@ fn replay_truncates_log_on_inverted_seq_range() {
     let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
+    let codecs = mk_codecs(&mut world);
     world.spawn((Pos { x: 1.0, y: 0.0 },));
     // One real flush, produces a valid AddRunAndSequence frame.
     flush_and_record(
@@ -532,7 +550,7 @@ fn replay_truncates_log_on_inverted_seq_range() {
         &mut manifest,
         &mut log,
         dir.path(),
-        &CodecRegistry::new(),
+        &codecs,
     )
     .unwrap();
 
@@ -592,6 +610,7 @@ fn replay_truncates_log_on_zero_page_count() {
     let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
+    let codecs = mk_codecs(&mut world);
     world.spawn((Pos { x: 1.0, y: 0.0 },));
     // One real flush — produces a valid AddRunAndSequence entry.
     flush_and_record(
@@ -600,7 +619,7 @@ fn replay_truncates_log_on_zero_page_count() {
         &mut manifest,
         &mut log,
         dir.path(),
-        &CodecRegistry::new(),
+        &codecs,
     )
     .unwrap();
 
@@ -663,6 +682,7 @@ fn replay_truncates_log_on_invalid_compaction_input_level() {
     let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
+    let codecs = mk_codecs(&mut world);
     world.spawn((Pos { x: 1.0, y: 0.0 },));
     // One real flush so there's something to survive the replay truncation.
     flush_and_record(
@@ -671,7 +691,7 @@ fn replay_truncates_log_on_invalid_compaction_input_level() {
         &mut manifest,
         &mut log,
         dir.path(),
-        &CodecRegistry::new(),
+        &codecs,
     )
     .unwrap();
 
@@ -736,6 +756,7 @@ fn replay_truncates_log_on_remove_of_missing_run() {
     let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
+    let codecs = mk_codecs(&mut world);
     world.spawn((Pos { x: 1.0, y: 0.0 },));
     // One real flush — produces a valid AddRunAndSequence entry.
     flush_and_record(
@@ -744,7 +765,7 @@ fn replay_truncates_log_on_remove_of_missing_run() {
         &mut manifest,
         &mut log,
         dir.path(),
-        &CodecRegistry::new(),
+        &codecs,
     )
     .unwrap();
 
@@ -791,6 +812,7 @@ fn recover_then_flush_then_recover_roundtrips_state() {
 
     // Two flushes produce two AddRunAndSequence frames.
     let mut world = World::new();
+    let codecs = mk_codecs(&mut world);
     world.spawn((Pos { x: 1.0, y: 0.0 },));
     flush_and_record(
         &world,
@@ -798,7 +820,7 @@ fn recover_then_flush_then_recover_roundtrips_state() {
         &mut manifest,
         &mut log,
         dir.path(),
-        &CodecRegistry::new(),
+        &codecs,
     )
     .unwrap();
     world.clear_all_dirty_pages();
@@ -809,7 +831,7 @@ fn recover_then_flush_then_recover_roundtrips_state() {
         &mut manifest,
         &mut log,
         dir.path(),
-        &CodecRegistry::new(),
+        &codecs,
     )
     .unwrap();
     drop(log);
@@ -950,6 +972,7 @@ fn flush_and_record_clean_world_no_change() {
     let (mut manifest, mut log) = ManifestLog::recover::<4>(&log_path).unwrap();
 
     let mut world = World::new();
+    let codecs = mk_codecs(&mut world);
     world.spawn((Pos { x: 1.0, y: 2.0 },));
     world.clear_all_dirty_pages();
 
@@ -959,7 +982,7 @@ fn flush_and_record_clean_world_no_change() {
         &mut manifest,
         &mut log,
         dir.path(),
-        &CodecRegistry::new(),
+        &codecs,
     )
     .unwrap();
     assert!(result.is_none());

--- a/crates/minkowski/src/component.rs
+++ b/crates/minkowski/src/component.rs
@@ -49,6 +49,11 @@ pub(crate) struct ComponentInfo {
     pub name: &'static str,
     pub layout: Layout,
     pub drop_fn: Option<unsafe fn(*mut u8)>,
+    /// `TypeId` of the concrete component type, or `None` for slots registered
+    /// via [`ComponentRegistry::register_raw`] (recovery placeholders with no
+    /// concrete Rust type). Lets external registries confirm a `ComponentId`
+    /// resolves to the type they expect.
+    pub type_id: Option<TypeId>,
 }
 
 #[doc(hidden)]
@@ -92,6 +97,7 @@ impl ComponentRegistry {
             name: std::any::type_name::<T>(),
             layout: Layout::new::<T>(),
             drop_fn,
+            type_id: Some(type_id),
         });
         self.by_type.insert(type_id, id);
         self.version += 1;
@@ -113,6 +119,7 @@ impl ComponentRegistry {
             name,
             layout,
             drop_fn: None,
+            type_id: None,
         });
         self.version += 1;
         id

--- a/crates/minkowski/src/import.rs
+++ b/crates/minkowski/src/import.rs
@@ -198,7 +198,8 @@ impl World {
     /// Each column slice must be the native (in-memory) byte image of
     /// `entities.len()` consecutive values of the corresponding component type.
     /// For LSM recovery this is guaranteed by the raw-copyable invariant enforced
-    /// at codec registration plus per-page CRC validation on read.
+    /// at both codec registration and flush (a dense component without a codec is
+    /// refused), plus per-page CRC validation on read.
     ///
     /// - The entities in `page.entities` must be unique and must not already be
     ///   placed in any archetype (across this and prior imported pages). The LSM

--- a/crates/minkowski/src/storage/blob_vec.rs
+++ b/crates/minkowski/src/storage/blob_vec.rs
@@ -184,9 +184,10 @@ impl BlobVec {
     /// - `bytes.len()` must equal `count * item_layout.size()`.
     /// - `bytes` must be a valid native (in-memory) representation of `count`
     ///   consecutive items of this column's type. For LSM recovery this is
-    ///   guaranteed by the raw-copyable invariant enforced at codec registration
-    ///   (a type whose archived size equals its native size carries no live
-    ///   pointers, so its native bytes are position-independent).
+    ///   guaranteed by the raw-copyable invariant enforced at both codec
+    ///   registration and flush — a dense component without a codec is refused,
+    ///   and a type whose archived size equals its native size carries no live
+    ///   pointers, so its native bytes are position-independent.
     pub(crate) unsafe fn append_bytes_unchecked(&mut self, bytes: &[u8], count: usize) {
         let size = self.item_layout.size();
         if size == 0 {

--- a/crates/minkowski/src/world.rs
+++ b/crates/minkowski/src/world.rs
@@ -2010,6 +2010,22 @@ impl World {
         }
     }
 
+    /// `TypeId` of the component registered at `id`, or `None` if unregistered
+    /// or registered without a concrete type (via [`register_component_raw`],
+    /// e.g. a recovery placeholder). `ComponentId` is a *per-world* index;
+    /// external registries (e.g. a persistence `CodecRegistry`) use this to
+    /// confirm an id resolves to the *type* they expect rather than trusting the
+    /// numeric id across worlds.
+    ///
+    /// [`register_component_raw`]: World::register_component_raw
+    pub fn component_type_id(&self, id: ComponentId) -> Option<std::any::TypeId> {
+        if id < self.components.len() {
+            self.components.info(id).type_id
+        } else {
+            None
+        }
+    }
+
     /// Number of registered component types.
     pub fn component_count(&self) -> usize {
         self.components.len()


### PR DESCRIPTION
## Summary
Closes the last open soundness hole in the LSM Phase 5 recovery work. PR #198 landed the bulk import-driven recovery and the codex #4 fix on `main`, but the **dense-component raw-copyability gate was never applied at flush** — so `main` currently has a reachable UB hole.

A dense archetype column is flushed as **native** bytes and `memcpy`'d back verbatim on recovery (`World::import_page` → `BlobVec::append_bytes_unchecked`). That is sound only for raw-copyable (POD) types. `CodecRegistry::register` already rejects non-raw-copyable types (`CodecError::NotRawCopyable`), but the dense flush path persisted **every** dense component regardless of codec. A `String`-bearing component registered only in core (`world.register_component::<T>()`) therefore bypassed the gate, flushed its live `String { ptr, len, cap }`, and recovery restored a dangling pointer.

## Fix
Flush now hard-errors on a dirty **dense** component that lacks a codec (mirrors the existing sparse skip-warn, but dense data can't be silently dropped). Combined with the registration gate (`codec ⟹ raw-copyable`), every persisted dense column is provably POD — making the `import_page` SAFETY contract true end to end. The gate only fires for components that actually contribute a page to the run (`writes_any` guard), avoiding false positives on shrink-past-`arch_len` cases.

Also updates the three `unsafe` SAFETY comments (`import_page`, `append_bytes_unchecked`, recovery call site) to state the dual enforcement, and threads real codecs through the flush-exercising tests.

## Testing
- New regression test `flush_rejects_dense_component_without_codec`.
- `cargo test --workspace` (1275 passed), clippy `-D warnings` clean, fmt clean.
- The unsafe seam was Miri-validated in the prior import work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)