### PR TITLE
fix(lsm): recovery import-error drop-safety (N5) + bind decode proof to its bytes

### DIFF
--- a/crates/minkowski-lsm/benches/page_codec.rs
+++ b/crates/minkowski-lsm/benches/page_codec.rs
@@ -42,7 +42,7 @@ use iai_callgrind::{library_benchmark, library_benchmark_group, main};
 use minkowski_lsm::bench_support::{
     BenchName, BenchPos, Layout, Shape, WorkloadParams, build_world,
 };
-use minkowski_lsm::codec::{CodecRegistry, CrcProof};
+use minkowski_lsm::codec::CodecRegistry;
 use minkowski_lsm::manifest_log::ManifestLog;
 use minkowski_lsm::manifest_ops::flush_and_record;
 use minkowski_lsm::reader::SortedRunReader;
@@ -180,9 +180,9 @@ fn setup_rkyv_decode() -> (CodecRegistry, TypeId, Vec<Vec<u8>>) {
     (codecs, TypeId::of::<BenchName>(), heap_rows())
 }
 
-/// Codec + `BenchName` TypeId + `HEAP_ROWS` serialized rows + a `CrcProof` per
-/// row, for the unchecked decode bench. Proofs are minted in setup (not measured).
-fn setup_rkyv_decode_unchecked() -> (CodecRegistry, TypeId, Vec<Vec<u8>>, Vec<CrcProof>) {
+/// Codec + `BenchName` TypeId + `HEAP_ROWS` serialized rows, for the unchecked
+/// decode bench.
+fn setup_rkyv_decode_unchecked() -> (CodecRegistry, TypeId, Vec<Vec<u8>>) {
     let (_world, codecs) = build_world(&WorkloadParams {
         entities: 1,
         shape: Shape::Heap,
@@ -191,11 +191,7 @@ fn setup_rkyv_decode_unchecked() -> (CodecRegistry, TypeId, Vec<Vec<u8>>, Vec<Cr
         seed: SEED,
     });
     let rows = heap_rows();
-    let proofs = rows
-        .iter()
-        .map(|r| CrcProof::verify(r, crc32fast::hash(r)).expect("fresh crc matches"))
-        .collect();
-    (codecs, TypeId::of::<BenchName>(), rows, proofs)
+    (codecs, TypeId::of::<BenchName>(), rows)
 }
 
 // ── benches (only the body is measured) ─────────────────────────────────────
@@ -270,12 +266,12 @@ fn rkyv_decode_256(input: (CodecRegistry, TypeId, Vec<Vec<u8>>)) {
 
 #[library_benchmark]
 #[bench::heap(setup = setup_rkyv_decode_unchecked)]
-fn rkyv_decode_unchecked_256(input: (CodecRegistry, TypeId, Vec<Vec<u8>>, Vec<CrcProof>)) {
-    let (codecs, ty, rows, proofs) = input;
-    for (row, proof) in rows.iter().zip(proofs.iter()) {
+fn rkyv_decode_unchecked_256(input: (CodecRegistry, TypeId, Vec<Vec<u8>>)) {
+    let (codecs, ty, rows) = input;
+    for row in &rows {
         // SAFETY: `row` was just serialized by this binary's codec for
         // `BenchName`, so it is a valid archive of that type.
-        let native = unsafe { codecs.deserialize_unchecked_by_type(ty, row, proof) }
+        let native = unsafe { codecs.deserialize_unchecked_by_type(ty, row) }
             .expect("codec for BenchName")
             .expect("decode ok");
         // Same ownership dance as rkyv_decode_256: read out unaligned, drop once.

--- a/crates/minkowski-lsm/src/codec.rs
+++ b/crates/minkowski-lsm/src/codec.rs
@@ -92,9 +92,11 @@ struct ComponentCodec {
     serialize_fn: SerializeFn,
     deserialize_fn: DeserializeFn,
     /// Like `deserialize_fn` but skips rkyv bytecheck via `access_unchecked`.
-    /// Only reachable through `deserialize_unchecked_by_type`, which requires a
-    /// `CrcProof`. Sound ONLY when the recovery fingerprint gate (spec §2.1) has
-    /// also confirmed the on-disk layout matches this binary's.
+    /// Only reachable through the `unsafe deserialize_unchecked_by_type`, whose
+    /// caller asserts archive validity. Sound ONLY when the recovery fingerprint
+    /// gate (spec §2.1) has confirmed the on-disk layout matches this binary's and
+    /// the per-page `CrcProof` (which gates construction of `DecodeMode::Unchecked`)
+    /// has confirmed byte integrity.
     deserialize_unchecked_fn: DeserializeFn,
     register_fn: RegisterFn,
     serialize_sparse_fn: SerializeSparseFn,
@@ -208,18 +210,16 @@ impl CodecRegistry {
     ///
     /// # Safety
     /// `bytes` MUST be a valid rkyv archive of the type identified by `type_id` —
-    /// i.e. produced by this binary's codec for that type and not since mutated.
-    /// `CrcProof` proves only byte INTEGRITY (the bytes are unchanged since the
-    /// writer emitted them); it does NOT prove the writer emitted a structurally
-    /// valid archive of THIS binary's type. The caller must independently establish
-    /// well-formedness — recovery does so via the per-run decode-fingerprint gate
-    /// (`fingerprint::run_fingerprint` match) before reaching this. Calling with a
-    /// CRC-valid-but-malformed archive is undefined behavior.
+    /// produced by this binary's codec for that type and not since mutated. This
+    /// is NOT implied by a CRC check alone (CRC proves integrity, not rkyv
+    /// well-formedness); recovery establishes it via the per-run decode-fingerprint
+    /// gate (`fingerprint::run_fingerprint` match) plus the per-page `CrcProof`
+    /// (integrity) that gated construction of `DecodeMode::Unchecked`. Calling with
+    /// a CRC-valid-but-malformed archive is undefined behavior.
     pub unsafe fn deserialize_unchecked_by_type(
         &self,
         type_id: std::any::TypeId,
         bytes: &[u8],
-        _proof: &CrcProof,
     ) -> Option<Result<Vec<u8>, CodecError>> {
         let codec = self.codecs.values().find(|c| c.type_id == type_id)?;
         Some((codec.deserialize_unchecked_fn)(bytes))
@@ -383,11 +383,13 @@ impl CodecRegistry {
                     std::mem::size_of::<T::Archived>()
                 )));
             }
-            // SAFETY: the only caller, `deserialize_unchecked_by_type`, requires a
-            // `CrcProof` (unforgeable; minted only by a real CRC check), so `bytes`
-            // are integrity-verified, writer-authored archive bytes. Combined with
-            // the recovery-side fingerprint gate (only runs whose Serialized layout
-            // matches this binary reach the unchecked path), these are a valid
+            // SAFETY: the only caller, the `unsafe deserialize_unchecked_by_type`,
+            // documents a precondition that `bytes` is a valid writer-authored
+            // archive. Recovery discharges it: the per-page `CrcProof` (unforgeable;
+            // minted only by a real CRC check) gates construction of
+            // `DecodeMode::Unchecked`, so `bytes` are integrity-verified; combined
+            // with the recovery-side fingerprint gate (only runs whose Serialized
+            // layout matches this binary reach the unchecked path), these are a valid
             // archive of `T::Archived`; skipping bytecheck is sound. See spec §2/§2.1.
             // The page framing (offset table → row slices) is validated by
             // `serialized_page::decode` on BOTH the checked and unchecked paths
@@ -691,9 +693,10 @@ impl Default for CodecRegistry {
 /// is [`CrcProof::verify`], which runs the actual checksum.
 ///
 /// Used by [`CodecRegistry::decode`] to gate the `raw_copy_size` fast path
-/// (direct memcpy, skipping rkyv bytecheck), and by
-/// [`CodecRegistry::deserialize_unchecked_by_type`] to gate the
-/// bytecheck-skipping Serialized decode path (spec §2.1). Both are
+/// (direct memcpy, skipping rkyv bytecheck), and by recovery to gate
+/// construction of `DecodeMode::Unchecked` — the integrity half of the
+/// precondition for the bytecheck-skipping Serialized decode path
+/// ([`CodecRegistry::deserialize_unchecked_by_type`], spec §2.1). Both are
 /// soundness-critical: without a proof, the unsafe fast paths are unreachable.
 /// Producers: WAL frame reader
 /// ([`minkowski_persist::wal::read_next_frame`]), LSM page validator
@@ -1189,10 +1192,9 @@ mod raw_copy_tests {
         }
 
         let checked = codecs.deserialize_by_type(ty, &bytes).unwrap().unwrap();
-        let proof = CrcProof::verify(&bytes, crc32fast::hash(&bytes)).unwrap();
         // SAFETY: `bytes` was just serialized by this binary's codec for
         // `WithHeap`, so it is a valid archive of that type.
-        let unchecked = unsafe { codecs.deserialize_unchecked_by_type(ty, &bytes, &proof) }
+        let unchecked = unsafe { codecs.deserialize_unchecked_by_type(ty, &bytes) }
             .expect("codec exists")
             .expect("unchecked decode ok");
 
@@ -1233,10 +1235,8 @@ mod raw_copy_tests {
     fn deserialize_unchecked_returns_err_for_truncated_slice() {
         // N3 length guard: `deserialize_unchecked_by_type` must return `Err`
         // (not panic or read OOB) when the byte slice is shorter than
-        // `size_of::<T::Archived>()`. Feed a deliberately-truncated slice with a
-        // freshly-minted `CrcProof` over those exact bytes — the proof proves
-        // integrity of the truncated slice, not of a valid archive. The result
-        // must be `Some(Err(_))`.
+        // `size_of::<T::Archived>()`. Feed a deliberately-truncated slice; the
+        // function must detect the short length and return `Some(Err(_))`.
         let mut world = World::new();
         let mut codecs = CodecRegistry::new();
         codecs
@@ -1246,11 +1246,10 @@ mod raw_copy_tests {
 
         // A slice of 1 byte — guaranteed shorter than ArchivedWithHeap.
         let truncated = [0xFFu8; 1];
-        let proof = CrcProof::verify(&truncated, crc32fast::hash(&truncated)).unwrap();
         // SAFETY: we are intentionally testing the length-guard error path with a
         // truncated slice. The function must detect the short length and return
         // `Err` before any archive access.
-        let result = unsafe { codecs.deserialize_unchecked_by_type(ty, &truncated, &proof) };
+        let result = unsafe { codecs.deserialize_unchecked_by_type(ty, &truncated) };
         assert!(
             matches!(result, Some(Err(_))),
             "truncated slice must yield Some(Err(_)), got {result:?}"

--- a/crates/minkowski-lsm/src/codec.rs
+++ b/crates/minkowski-lsm/src/codec.rs
@@ -117,6 +117,11 @@ struct ComponentCodec {
     /// registration. Feeds the decode fingerprint (spec §2.1): a change here
     /// across a binary upgrade fails the gate and forces checked decode.
     archived_size: usize,
+    /// `drop_in_place` for the concrete type, used to free reconstructed native
+    /// values (e.g. the heap of a `String`) that were decoded into a byte buffer
+    /// but never transferred into a World column (the recovery import-error path).
+    /// For POD types this is a no-op; it is only invoked on Serialized columns.
+    drop_fn: unsafe fn(*mut u8),
     /// `TypeId` of the concrete component type this codec was registered for.
     /// `ComponentId` is a per-world index, so the flush gate compares this to the
     /// flushed world's `component_type_id` to confirm the codec actually
@@ -439,6 +444,17 @@ impl CodecRegistry {
             Ok(())
         };
 
+        let drop_fn: unsafe fn(*mut u8) = |ptr| {
+            // SAFETY: `ptr` points to the byte image of a valid `T` owned by the
+            // caller, dropped exactly once. The recovery decode buffer is a plain
+            // `Vec<u8>` (alignment 1), so the bytes are NOT guaranteed aligned to
+            // `T`; read the value out *unaligned* into an owned, aligned local and
+            // drop that. This frees the heap exactly once without ever forming an
+            // unaligned reference (which `drop_in_place` on `ptr.cast::<T>()` would).
+            let value = unsafe { std::ptr::read_unaligned(ptr.cast::<T>()) };
+            drop(value);
+        };
+
         self.by_name.insert(stable_name.clone(), comp_id);
         self.codecs.insert(
             comp_id,
@@ -454,6 +470,7 @@ impl CodecRegistry {
                 raw_copy_size,
                 raw_copyable,
                 archived_size: std::mem::size_of::<T::Archived>(),
+                drop_fn,
                 type_id: std::any::TypeId::of::<T>(),
                 type_name: std::any::type_name::<T>(),
             },
@@ -524,6 +541,16 @@ impl CodecRegistry {
             .values()
             .find(|c| c.type_name == type_name)
             .map(|c| c.archived_size)
+    }
+
+    /// `drop_in_place` for a registered component *type*. Recovery uses this to
+    /// free reconstructed heap values that never reach a World column on an
+    /// import-error path. Resolve by `TypeId` (the recovery decode key).
+    pub(crate) fn drop_fn_by_type(&self, type_id: std::any::TypeId) -> Option<unsafe fn(*mut u8)> {
+        self.codecs
+            .values()
+            .find(|c| c.type_id == type_id)
+            .map(|c| c.drop_fn)
     }
 
     /// Native (in-memory) size and align for the component whose Rust `type_name`

--- a/crates/minkowski-lsm/src/codec.rs
+++ b/crates/minkowski-lsm/src/codec.rs
@@ -119,7 +119,9 @@ struct ComponentCodec {
     /// registration. Feeds the decode fingerprint (spec §2.1): a change here
     /// across a binary upgrade fails the gate and forces checked decode.
     archived_size: usize,
-    /// `drop_in_place` for the concrete type, used to free reconstructed native
+    /// Element drop for the concrete type (reads the row out UNALIGNED then drops —
+    /// the recovery decode buffer is a plain `Vec<u8>`, align 1, so a `drop_in_place`
+    /// on the unaligned pointer would be UB), used to free reconstructed native
     /// values (e.g. the heap of a `String`) that were decoded into a byte buffer
     /// but never transferred into a World column (the recovery import-error path).
     /// For POD types this is a no-op; it is only invoked on Serialized columns.
@@ -545,9 +547,9 @@ impl CodecRegistry {
             .map(|c| c.archived_size)
     }
 
-    /// `drop_in_place` for a registered component *type*. Recovery uses this to
-    /// free reconstructed heap values that never reach a World column on an
-    /// import-error path. Resolve by `TypeId` (the recovery decode key).
+    /// Element drop fn (unaligned-read-then-drop) for a registered component *type*.
+    /// Recovery uses this to free reconstructed heap values that never reach a World
+    /// column on an import-error path. Resolve by `TypeId` (the recovery decode key).
     pub(crate) fn drop_fn_by_type(&self, type_id: std::any::TypeId) -> Option<unsafe fn(*mut u8)> {
         self.codecs
             .values()

--- a/crates/minkowski-lsm/src/reader.rs
+++ b/crates/minkowski-lsm/src/reader.rs
@@ -290,14 +290,20 @@ impl SortedRunReader {
         }))
     }
 
-    /// Validate the CRC of a specific page and return a [`CrcProof`] on success.
+    /// Validate the CRC of a page and return the proven payload slice together
+    /// with a [`CrcProof`] over EXACTLY those bytes. Returning the slice (rather
+    /// than re-deriving it at the call site) binds the proof to the bytes the
+    /// caller will store/decode — they cannot drift apart.
     ///
     /// The returned token feeds into [`CodecRegistry::decode`]'s `raw_copy_size`
     /// fast path (direct memcpy, skipping rkyv bytecheck). The CRC covers exactly
     /// the page's data bytes: `row_count * item_size` for RawCopy dense pages
     /// (excluding the zero-padding tail), the whole `[offsets][values]` body for
     /// Serialized dense pages, and the raw byte chunk for sparse pages.
-    pub fn validate_page_crc(&self, page: &PageRef<'_>) -> Result<CrcProof, LsmError> {
+    pub fn validate_page_crc<'p>(
+        &self,
+        page: &PageRef<'p>,
+    ) -> Result<(&'p [u8], CrcProof), LsmError> {
         // Sparse pages store `chunk.len()` in `row_count` (byte count, not row
         // count). Serialized dense pages carry a variable-length body whose true
         // length is the whole `data()` slice (offsets + values, no padding tail) —
@@ -313,11 +319,13 @@ impl SortedRunReader {
         };
         let payload = &page.data()[..actual_len];
 
-        CrcProof::verify(payload, page.header().page_crc32).ok_or_else(|| LsmError::Crc {
-            offset: page.file_offset(),
-            expected: page.header().page_crc32,
-            actual: crc32fast::hash(payload),
-        })
+        let proof =
+            CrcProof::verify(payload, page.header().page_crc32).ok_or_else(|| LsmError::Crc {
+                offset: page.file_offset(),
+                expected: page.header().page_crc32,
+                actual: crc32fast::hash(payload),
+            })?;
+        Ok((payload, proof))
     }
 
     /// Get the schema section.
@@ -860,8 +868,6 @@ mod tests {
 
     #[test]
     fn validate_page_crc_returns_proof_token() {
-        use crate::codec::CrcProof;
-
         let (_dir, path, _world) = flush_world_with_pos(5);
         let reader = SortedRunReader::open(&path).unwrap();
 
@@ -872,7 +878,7 @@ mod tests {
             .get_page(entry.arch_id, entry.slot, entry.page_index)
             .unwrap()
             .unwrap();
-        let proof: CrcProof = reader.validate_page_crc(&page).unwrap();
+        let (_payload, proof) = reader.validate_page_crc(&page).unwrap();
         let _ = proof;
     }
 

--- a/crates/minkowski-lsm/src/recovery.rs
+++ b/crates/minkowski-lsm/src/recovery.rs
@@ -220,9 +220,8 @@ impl LsmRecovery {
                 let mut saw_allocator = false;
                 for result in reader.slot_pages(META_ARCH_ID, ALLOCATOR_SLOT) {
                     let (_page_index, page) = result?;
-                    reader.validate_page_crc(&page)?;
-                    let payload_len = page.header().row_count as usize;
-                    alloc_blob.extend_from_slice(&page.data()[..payload_len]);
+                    let (payload, _proof) = reader.validate_page_crc(&page)?;
+                    alloc_blob.extend_from_slice(payload);
                     saw_allocator = true;
                 }
                 if saw_allocator {
@@ -242,9 +241,8 @@ impl LsmRecovery {
                     let mut blob: Vec<u8> = Vec::new();
                     for result in reader.slot_pages(SPARSE_ARCH_ID, slot) {
                         let (_page_index, page) = result?;
-                        reader.validate_page_crc(&page)?;
-                        let len = page.header().row_count as usize;
-                        blob.extend_from_slice(&page.data()[..len]);
+                        let (payload, _proof) = reader.validate_page_crc(&page)?;
+                        blob.extend_from_slice(payload);
                     }
                     if blob.is_empty() {
                         continue;
@@ -273,30 +271,21 @@ impl LsmRecovery {
                 for slot in reader.component_slots_for_arch(arch_id) {
                     // component_slots_for_arch excludes ENTITY_SLOT, so every slot
                     // here has a named schema entry.
-                    let (name, item_size, kind) = {
+                    let (name, kind) = {
                         let entry = reader.schema().entry_for_slot(slot).ok_or_else(|| {
                             LsmError::Format(format!("missing schema entry for slot {slot}"))
                         })?;
-                        (
-                            entry.name().to_owned(),
-                            entry.item_size as usize,
-                            entry.storage_kind(),
-                        )
+                        (entry.name().to_owned(), entry.storage_kind())
                     };
                     for result in reader.slot_pages(arch_id, slot) {
                         let (page_index, page) = result?;
-                        let proof = reader.validate_page_crc(&page)?;
-                        // RawCopy pages are zero-padded to the full stride, so we
-                        // slice the live `row_count * item_size` prefix. Serialized
-                        // pages are variable-length (`[offsets][values]`); the
-                        // reader sizes them exactly, so the WHOLE body is the
-                        // payload — slicing by native stride would corrupt them.
-                        let payload: &[u8] = match kind {
-                            crate::schema::StorageKind::RawCopy => {
-                                &page.data()[..page.header().row_count as usize * item_size]
-                            }
-                            crate::schema::StorageKind::Serialized => page.data(),
-                        };
+                        // The proven slice already equals the live payload:
+                        // `validate_page_crc` returns `row_count * item_size` for
+                        // RawCopy pages (the live prefix, excluding zero-padding)
+                        // and the whole `[offsets][values]` body for Serialized
+                        // pages. Binding the proof to exactly these bytes here means
+                        // `DecodeMode::Unchecked(proof)` certifies what we store.
+                        let (payload, proof) = reader.validate_page_crc(&page)?;
                         // Only Serialized pages from a fingerprint-matched run may
                         // skip bytecheck; everything else decodes checked.
                         let decode_mode = if run_allows_unchecked
@@ -319,14 +308,13 @@ impl LsmRecovery {
 
                 for result in reader.entity_pages(arch_id) {
                     let (page_index, page) = result?;
-                    reader.validate_page_crc(&page)?;
-                    let payload_len = page.header().row_count as usize * 8;
+                    let (payload, _proof) = reader.validate_page_crc(&page)?;
                     store_page(
                         &mut pages,
                         (sig.clone(), ColumnKey::Entity, page_index),
                         seq_hi,
                         page.header().row_count,
-                        &page.data()[..payload_len],
+                        payload,
                         // Entity pages are raw 8-byte IDs, never Serialized.
                         DecodeMode::Checked,
                     );
@@ -563,14 +551,14 @@ fn native_column_page(
                         // emitted them). Together the fingerprint gate (layout) and
                         // the CrcProof (integrity) establish that `slice` is a valid
                         // rkyv archive of `ty`, satisfying the method's precondition.
-                        DecodeMode::Unchecked(proof) => {
+                        DecodeMode::Unchecked(_proof) => {
                             // Count each unchecked per-page decode call (one per live
                             // Serialized row batch). Thread-local so concurrent tests
                             // on different threads cannot interfere. Used by white-box
                             // tests only.
                             #[cfg(test)]
                             UNCHECKED_SERIALIZED_DECODES.with(|c| c.set(c.get() + 1));
-                            unsafe { codecs.deserialize_unchecked_by_type(ty, slice, proof) }
+                            unsafe { codecs.deserialize_unchecked_by_type(ty, slice) }
                                 .ok_or_else(|| {
                                     LsmError::Format(
                                         "no codec for serialized column type on recovery"

--- a/crates/minkowski-lsm/src/recovery.rs
+++ b/crates/minkowski-lsm/src/recovery.rs
@@ -76,6 +76,79 @@ struct StoredPage {
     decode_mode: DecodeMode,
 }
 
+/// Owns the decoded native bytes of one column during recovery. For a Serialized
+/// column the bytes byte-own reconstructed heap values (e.g. `String`); if the
+/// guard is dropped while still `armed` (the import-error path), it runs the
+/// component's `drop_fn` on each row so those heap allocations are freed — a plain
+/// `Vec<u8>` drop would leak them. After `import_page` succeeds, ownership has
+/// transferred to the archetype column, so the caller calls `disarm()` and the
+/// guard then drops ONLY its byte buffer (no element drops → no double free).
+/// RawCopy/POD columns are constructed with `armed: None`.
+struct DecodedColumn {
+    bytes: Vec<u8>,
+    /// `Some((drop_fn, item_size))` for Serialized columns owning heap values;
+    /// `None` for RawCopy/POD or after `disarm()`.
+    armed: Option<ColumnDrop>,
+}
+
+/// `(drop_in_place, native item stride)` for an armed Serialized column guard.
+type ColumnDrop = (unsafe fn(*mut u8), usize);
+
+impl DecodedColumn {
+    fn as_slice(&self) -> &[u8] {
+        &self.bytes
+    }
+    /// Ownership of the heap values has transferred to a World column; do not run
+    /// element drops (the byte buffer still drops normally, freeing the `u8` alloc).
+    fn disarm(&mut self) {
+        self.armed = None;
+    }
+}
+
+impl Drop for DecodedColumn {
+    fn drop(&mut self) {
+        if let Some((drop_fn, item_size)) = self.armed
+            && item_size > 0
+        {
+            let rows = self.bytes.len() / item_size;
+            for i in 0..rows {
+                // SAFETY: `bytes` holds `rows` contiguous byte images of this
+                // column's native type (produced by `native_column_page` for a
+                // Serialized column with this `item_size` stride). `drop_fn` reads
+                // each row out *unaligned* and drops it (the buffer is a plain
+                // `Vec<u8>`, alignment 1, so the rows are not aligned to T). Each
+                // row is dropped exactly once and never read afterward.
+                unsafe { drop_fn(self.bytes.as_mut_ptr().add(i * item_size)) };
+            }
+        }
+    }
+}
+
+/// Wrap a decoded column buffer in a drop guard. Serialized columns are armed
+/// with the type's `drop_fn` so heap values are freed if the guard is dropped
+/// before `import_page` takes ownership; RawCopy/POD columns are unarmed.
+fn guard_column(
+    bytes: Vec<u8>,
+    kind: crate::schema::StorageKind,
+    type_id: Option<std::any::TypeId>,
+    item_size: usize,
+    codecs: &CodecRegistry,
+) -> Result<DecodedColumn, LsmError> {
+    let armed = match kind {
+        crate::schema::StorageKind::Serialized => {
+            let ty = type_id.ok_or_else(|| {
+                LsmError::Format("serialized column has no type for drop guard".to_owned())
+            })?;
+            let drop_fn = codecs.drop_fn_by_type(ty).ok_or_else(|| {
+                LsmError::Format("no codec drop_fn for serialized column".to_owned())
+            })?;
+            Some((drop_fn, item_size))
+        }
+        crate::schema::StorageKind::RawCopy => None,
+    };
+    Ok(DecodedColumn { bytes, armed })
+}
+
 #[derive(Clone)]
 struct StoredAllocator {
     seq_hi: u64,
@@ -485,7 +558,7 @@ fn native_column_page(
                         // `decode_fingerprint` is non-zero and equals this binary's
                         // recomputed `run_fingerprint` (layout-provenance: the
                         // archived/native layout of `ty` matches what produced these
-                        // bytes) — AND `proof` is the per-page `CrcProof` certifying
+                        // bytes) — AND `_proof` is the per-page `CrcProof` certifying
                         // these exact bytes' integrity (unchanged since the writer
                         // emitted them). Together the fingerprint gate (layout) and
                         // the CrcProof (integrity) establish that `slice` is a valid
@@ -701,8 +774,9 @@ fn materialize_world(
 
             // Fast path: every entity on the page is alive — use the contiguous
             // column slices directly, no copy.
-            let (entities, col_slices): (Vec<Entity>, Vec<Vec<u8>>) = if live_count == row_count {
-                let cols: Vec<Vec<u8>> = comp_pairs
+            let (entities, mut col_slices): (Vec<Entity>, Vec<DecodedColumn>) =
+                if live_count == row_count {
+                    let cols: Vec<DecodedColumn> = comp_pairs
                     .iter()
                     .enumerate()
                     .map(|(i, (_, name))| {
@@ -751,92 +825,98 @@ fn materialize_world(
                              {row_count} * {item_size}",
                             native.len()
                         );
-                        Ok(native)
+                        guard_column(native, kind, type_id, item_size, codecs)
                     })
                     .collect::<Result<_, _>>()?;
-                (page_entities.clone(), cols)
-            } else {
-                // Slow path: compact the page down to its live rows. Rebuild
-                // the entity Vec and each column's byte buffer with only the
-                // rows whose entity is alive, so `import_page` sees a
-                // consistent (entities, columns) pair with no dead rows.
-                let mut live_entities = Vec::with_capacity(live_count);
-                for (&e, &alive) in page_entities.iter().zip(live_mask.iter()) {
-                    if alive {
-                        live_entities.push(e);
+                    (page_entities.clone(), cols)
+                } else {
+                    // Slow path: compact the page down to its live rows. Rebuild
+                    // the entity Vec and each column's byte buffer with only the
+                    // rows whose entity is alive, so `import_page` sees a
+                    // consistent (entities, columns) pair with no dead rows.
+                    let mut live_entities = Vec::with_capacity(live_count);
+                    for (&e, &alive) in page_entities.iter().zip(live_mask.iter()) {
+                        if alive {
+                            live_entities.push(e);
+                        }
                     }
-                }
-                let mut live_cols: Vec<Vec<u8>> = Vec::with_capacity(comp_pairs.len());
-                for (i, (_, name)) in comp_pairs.iter().enumerate() {
-                    let col_pages = columns
-                        .get(&ColumnKey::Component((*name).clone()))
-                        .ok_or_else(|| {
-                            LsmError::Format(format!("archetype {sig:?} missing column {name}"))
+                    let mut live_cols: Vec<DecodedColumn> = Vec::with_capacity(comp_pairs.len());
+                    for (i, (_, name)) in comp_pairs.iter().enumerate() {
+                        let col_pages = columns
+                            .get(&ColumnKey::Component((*name).clone()))
+                            .ok_or_else(|| {
+                                LsmError::Format(format!("archetype {sig:?} missing column {name}"))
+                            })?;
+                        let page = col_pages.get(&page_index).ok_or_else(|| {
+                            LsmError::Format(format!(
+                                "archetype {sig:?} column {name} missing page {page_index}"
+                            ))
                         })?;
-                    let page = col_pages.get(&page_index).ok_or_else(|| {
-                        LsmError::Format(format!(
-                            "archetype {sig:?} column {name} missing page {page_index}"
-                        ))
-                    })?;
-                    if page.row_count as usize != row_count {
-                        return Err(LsmError::Format(format!(
-                            "archetype {sig:?} column {name} page {page_index} has {} rows, \
+                        if page.row_count as usize != row_count {
+                            return Err(LsmError::Format(format!(
+                                "archetype {sig:?} column {name} page {page_index} has {} rows, \
                              entity page has {row_count}",
-                            page.row_count
-                        )));
-                    }
-                    // Materialize ONLY the live rows' native bytes. Passing the
-                    // live mask is load-bearing: decoding a dead Serialized row
-                    // would reconstruct a heap-owning value that is never imported
-                    // into the World (so its drop_fn never runs) → a leak. The
-                    // mask skips dead rows entirely, so they are never decoded.
-                    let (kind, type_id) = col_kinds[i];
-                    let item_size = item_sizes[i];
-                    let buf = native_column_page(
-                        page,
-                        kind,
-                        type_id,
-                        codecs,
-                        item_size,
-                        Some(&live_mask),
-                        &page.decode_mode,
-                    )
-                    .map_err(|e| {
-                        LsmError::Format(format!("archetype {sig:?} column {name}: {e}"))
-                    })?;
-                    // The compacted buffer must be exactly `live_count` native
-                    // items wide, or it disagrees with the live-row layout.
-                    assert_eq!(
-                        buf.len(),
-                        live_count * item_size,
-                        "compacted column {name} page {page_index} is {} bytes, expected \
+                                page.row_count
+                            )));
+                        }
+                        // Materialize ONLY the live rows' native bytes. Passing the
+                        // live mask is load-bearing: decoding a dead Serialized row
+                        // would reconstruct a heap-owning value that is never imported
+                        // into the World (so its drop_fn never runs) → a leak. The
+                        // mask skips dead rows entirely, so they are never decoded.
+                        let (kind, type_id) = col_kinds[i];
+                        let item_size = item_sizes[i];
+                        let buf = native_column_page(
+                            page,
+                            kind,
+                            type_id,
+                            codecs,
+                            item_size,
+                            Some(&live_mask),
+                            &page.decode_mode,
+                        )
+                        .map_err(|e| {
+                            LsmError::Format(format!("archetype {sig:?} column {name}: {e}"))
+                        })?;
+                        // The compacted buffer must be exactly `live_count` native
+                        // items wide, or it disagrees with the live-row layout.
+                        assert_eq!(
+                            buf.len(),
+                            live_count * item_size,
+                            "compacted column {name} page {page_index} is {} bytes, expected \
                          {live_count} * {item_size}",
-                        buf.len()
-                    );
-                    live_cols.push(buf);
-                }
-                (live_entities, live_cols)
-            };
+                            buf.len()
+                        );
+                        live_cols.push(guard_column(buf, kind, type_id, item_size, codecs)?);
+                    }
+                    (live_entities, live_cols)
+                };
 
-            // Borrow the column bytes back as slices for `ImportPage::page`.
-            let col_refs: Vec<&[u8]> = col_slices.iter().map(Vec::as_slice).collect();
-            let import_page = target.page(&entities, &col_refs).map_err(|e| {
-                LsmError::Format(format!("import page build failed for {sig:?}: {e}"))
-            })?;
-            // SAFETY: each column slice is the native (in-memory) byte image of
-            // its component, produced by `native_column_page`: RawCopy columns
-            // are the on-disk native bytes verbatim; Serialized columns are
-            // decoded row-by-row into native values whose heap ownership rides
-            // inside the bytes and transfers into the archetype column (which
-            // holds T's drop_fn — a Serialized column always has a codec, so it
-            // was registered via the typed path, never raw). Every dense column
-            // has a codec (the flush gate proves it). The source pages passed
-            // per-page CRC validation on read, and every entity in `entities` is
-            // alive per the allocator state restored above (dead rows filtered).
-            unsafe {
-                world.import_page(&import_page).map_err(|e| {
-                    LsmError::Format(format!("import_page failed for {sig:?}: {e}"))
-                })?;
+            // Borrow the guarded column bytes as slices for `ImportPage::page`.
+            let import_result = {
+                let col_refs: Vec<&[u8]> = col_slices.iter().map(DecodedColumn::as_slice).collect();
+                let import_page = target.page(&entities, &col_refs).map_err(|e| {
+                    LsmError::Format(format!("import page build failed for {sig:?}: {e}"))
+                })?; // early return drops col_slices (armed) → heap values freed
+                // SAFETY: each column slice is the native (in-memory) byte image of
+                // its component, produced by `native_column_page`: RawCopy columns
+                // are the on-disk native bytes verbatim; Serialized columns are
+                // decoded row-by-row into native values whose heap ownership rides
+                // inside the bytes and transfers into the archetype column (which
+                // holds T's drop_fn — a Serialized column always has a codec, so it
+                // was registered via the typed path, never raw). Every dense column
+                // has a codec (the flush gate proves it). The source pages passed
+                // per-page CRC validation on read, and every entity in `entities` is
+                // alive per the allocator state restored above (dead rows filtered).
+                unsafe { world.import_page(&import_page) }
+                    .map_err(|e| LsmError::Format(format!("import_page failed for {sig:?}: {e}")))
+                // col_refs + import_page dropped at block end, releasing the borrow
+            };
+            import_result?; // on Err, col_slices (armed) drops here → heap values freed
+            // Success: ownership transferred to archetype columns; disarm so the
+            // guards drop only their byte buffers (no element drops → no double free).
+            for col in &mut col_slices {
+                col.disarm();
             }
         }
     }
@@ -1503,6 +1583,167 @@ mod tests {
             delta, 2,
             "recovered heap column must drop exactly two reconstructed values"
         );
+    }
+
+    /// N5 regression: a Serialized column guard that is dropped while still armed
+    /// (the import-error path) must run the type's `drop_fn` on every row, freeing
+    /// each reconstructed heap value. A plain `Vec<u8>` drop would leak them.
+    #[test]
+    fn decoded_column_guard_frees_heap_value_when_armed() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static DROPS: AtomicUsize = AtomicUsize::new(0);
+
+        #[derive(Clone, Archive, Serialize, Deserialize)]
+        struct Heaped {
+            text: String,
+        }
+        impl Drop for Heaped {
+            fn drop(&mut self) {
+                DROPS.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let mut world = World::new();
+        let mut codecs = CodecRegistry::new();
+        codecs.register_as::<Heaped>("heaped", &mut world).unwrap();
+        let ty = std::any::TypeId::of::<Heaped>();
+        let item_size = std::mem::size_of::<Heaped>();
+
+        // Serialize one value, then decode it into a native byte buffer (one row).
+        let value = Heaped {
+            text: "armed-heap-value".to_owned(),
+        };
+        let mut bytes = Vec::new();
+        unsafe {
+            codecs
+                .serialize_by_type(ty, std::ptr::from_ref(&value).cast::<u8>(), &mut bytes)
+                .expect("codec exists")
+                .expect("serialize ok");
+        }
+        drop(value); // serialize only read it; drop the original owner before snapshot
+
+        let native = codecs
+            .deserialize_by_type(ty, &bytes)
+            .expect("codec exists")
+            .expect("deserialize ok");
+        assert_eq!(native.len(), item_size, "one native row");
+
+        let guard = guard_column(
+            native,
+            crate::schema::StorageKind::Serialized,
+            Some(ty),
+            item_size,
+            &codecs,
+        )
+        .expect("guard built");
+        assert!(guard.armed.is_some(), "serialized column must be armed");
+
+        let before = DROPS.load(Ordering::SeqCst);
+        drop(guard); // simulated import-error path: armed guard frees the heap value
+        let delta = DROPS.load(Ordering::SeqCst) - before;
+        assert_eq!(
+            delta, 1,
+            "armed guard must drop the reconstructed value once"
+        );
+    }
+
+    /// `disarm()` (called after `import_page` transfers ownership) must prevent the
+    /// guard from also dropping the value — otherwise the column AND the guard free
+    /// the same `String` → double free. After disarm exactly one owner remains.
+    #[test]
+    fn decoded_column_guard_disarm_prevents_double_free() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static DROPS: AtomicUsize = AtomicUsize::new(0);
+
+        #[derive(Clone, Archive, Serialize, Deserialize)]
+        struct Heaped {
+            text: String,
+        }
+        impl Drop for Heaped {
+            fn drop(&mut self) {
+                DROPS.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let mut world = World::new();
+        let mut codecs = CodecRegistry::new();
+        codecs.register_as::<Heaped>("heaped", &mut world).unwrap();
+        let ty = std::any::TypeId::of::<Heaped>();
+        let item_size = std::mem::size_of::<Heaped>();
+
+        let value = Heaped {
+            text: "disarm-heap-value".to_owned(),
+        };
+        let mut bytes = Vec::new();
+        unsafe {
+            codecs
+                .serialize_by_type(ty, std::ptr::from_ref(&value).cast::<u8>(), &mut bytes)
+                .expect("codec exists")
+                .expect("serialize ok");
+        }
+        drop(value); // serialize only read it; drop the original owner before snapshot
+
+        let native = codecs
+            .deserialize_by_type(ty, &bytes)
+            .expect("codec exists")
+            .expect("deserialize ok");
+
+        let mut guard = guard_column(
+            native,
+            crate::schema::StorageKind::Serialized,
+            Some(ty),
+            item_size,
+            &codecs,
+        )
+        .expect("guard built");
+
+        let before = DROPS.load(Ordering::SeqCst);
+        guard.disarm(); // success path: ownership transferred to a World column
+        // Simulate the column taking ownership: read the value out so exactly one
+        // owner remains (the guard's bytes are now logically moved-from).
+        // SAFETY: `guard.bytes` byte-owns a valid `Heaped`; read it out unaligned
+        // (the guard buffer isn't aligned to Heaped). After disarm the guard will
+        // NOT element-drop, so reading the value out leaves exactly one owner.
+        let owned = unsafe { std::ptr::read_unaligned(guard.as_slice().as_ptr().cast::<Heaped>()) };
+        drop(guard); // disarmed → drops only the byte buffer, no element drop
+        drop(owned); // the sole remaining owner frees the String exactly once
+        let delta = DROPS.load(Ordering::SeqCst) - before;
+        assert_eq!(
+            delta, 1,
+            "disarmed guard must not double-free: exactly one drop across the sequence"
+        );
+    }
+
+    /// RawCopy/POD columns hold no heap values, so the guard is constructed unarmed
+    /// (no element drop on the error path) — dropping it is a plain byte-buffer free.
+    #[test]
+    fn raw_copy_column_guard_is_unarmed() {
+        #[derive(Clone, Copy, Archive, Serialize, Deserialize)]
+        struct Pod {
+            x: u64,
+            y: u64,
+        }
+
+        let mut world = World::new();
+        let mut codecs = CodecRegistry::new();
+        codecs.register_as::<Pod>("pod", &mut world).unwrap();
+        let ty = std::any::TypeId::of::<Pod>();
+        let item_size = std::mem::size_of::<Pod>();
+
+        let bytes = vec![0u8; item_size];
+        let guard = guard_column(
+            bytes,
+            crate::schema::StorageKind::RawCopy,
+            Some(ty),
+            item_size,
+            &codecs,
+        )
+        .expect("guard built");
+        assert!(
+            guard.armed.is_none(),
+            "raw-copy/POD column must be unarmed (no element drop)"
+        );
+        drop(guard); // plain byte-buffer free, no element drop
     }
 
     #[derive(Clone, Copy, Archive, Serialize, Deserialize)]

--- a/crates/minkowski-lsm/src/recovery.rs
+++ b/crates/minkowski-lsm/src/recovery.rs
@@ -86,15 +86,28 @@ struct StoredPage {
 /// RawCopy/POD columns are constructed with `armed: None`.
 struct DecodedColumn {
     bytes: Vec<u8>,
-    /// `Some((drop_fn, item_size))` for Serialized columns owning heap values;
+    /// `Some(HeapDrop)` for Serialized columns owning heap values;
     /// `None` for RawCopy/POD or after `disarm()`.
-    armed: Option<ColumnDrop>,
+    armed: Option<HeapDrop>,
 }
 
-/// `(drop_in_place, native item stride)` for an armed Serialized column guard.
-type ColumnDrop = (unsafe fn(*mut u8), usize);
+/// How to drop one reconstructed native value of an armed Serialized column:
+/// its element drop fn (reads the row out UNALIGNED then drops — the buffer is a
+/// plain `Vec<u8>`, align 1, so it must NOT `drop_in_place` an unaligned pointer)
+/// and the native item stride.
+struct HeapDrop {
+    /// Element drop: `|ptr| { let v = read_unaligned(ptr.cast::<T>()); drop(v); }`.
+    drop_one: unsafe fn(*mut u8),
+    /// Native stride in bytes (`rows = bytes.len() / item_size`).
+    item_size: usize,
+}
 
 impl DecodedColumn {
+    /// Wrap already-decoded native bytes with pre-resolved drop info. Infallible:
+    /// the fallible resolution happened in `column_arm` BEFORE decode.
+    fn new(bytes: Vec<u8>, armed: Option<HeapDrop>) -> Self {
+        Self { bytes, armed }
+    }
     fn as_slice(&self) -> &[u8] {
         &self.bytes
     }
@@ -107,46 +120,51 @@ impl DecodedColumn {
 
 impl Drop for DecodedColumn {
     fn drop(&mut self) {
-        if let Some((drop_fn, item_size)) = self.armed
+        if let Some(HeapDrop {
+            drop_one,
+            item_size,
+        }) = self.armed
             && item_size > 0
         {
             let rows = self.bytes.len() / item_size;
             for i in 0..rows {
                 // SAFETY: `bytes` holds `rows` contiguous byte images of this
                 // column's native type (produced by `native_column_page` for a
-                // Serialized column with this `item_size` stride). `drop_fn` reads
+                // Serialized column with this `item_size` stride). `drop_one` reads
                 // each row out *unaligned* and drops it (the buffer is a plain
                 // `Vec<u8>`, alignment 1, so the rows are not aligned to T). Each
                 // row is dropped exactly once and never read afterward.
-                unsafe { drop_fn(self.bytes.as_mut_ptr().add(i * item_size)) };
+                unsafe { drop_one(self.bytes.as_mut_ptr().add(i * item_size)) };
             }
         }
     }
 }
 
-/// Wrap a decoded column buffer in a drop guard. Serialized columns are armed
-/// with the type's `drop_fn` so heap values are freed if the guard is dropped
-/// before `import_page` takes ownership; RawCopy/POD columns are unarmed.
-fn guard_column(
-    bytes: Vec<u8>,
+/// Resolve the drop info for a column BEFORE decoding it, so the guard can be
+/// constructed infallibly afterward (a decoded heap buffer must never be handed
+/// to a fallible operation that could drop it as plain bytes → leak). Serialized
+/// columns resolve their element drop fn; RawCopy/POD columns are unarmed.
+fn column_arm(
     kind: crate::schema::StorageKind,
     type_id: Option<std::any::TypeId>,
     item_size: usize,
     codecs: &CodecRegistry,
-) -> Result<DecodedColumn, LsmError> {
-    let armed = match kind {
+) -> Result<Option<HeapDrop>, LsmError> {
+    match kind {
         crate::schema::StorageKind::Serialized => {
             let ty = type_id.ok_or_else(|| {
                 LsmError::Format("serialized column has no type for drop guard".to_owned())
             })?;
-            let drop_fn = codecs.drop_fn_by_type(ty).ok_or_else(|| {
+            let drop_one = codecs.drop_fn_by_type(ty).ok_or_else(|| {
                 LsmError::Format("no codec drop_fn for serialized column".to_owned())
             })?;
-            Some((drop_fn, item_size))
+            Ok(Some(HeapDrop {
+                drop_one,
+                item_size,
+            }))
         }
-        crate::schema::StorageKind::RawCopy => None,
-    };
-    Ok(DecodedColumn { bytes, armed })
+        crate::schema::StorageKind::RawCopy => Ok(None),
+    }
 }
 
 #[derive(Clone)]
@@ -787,6 +805,11 @@ fn materialize_world(
                         }
                         let (kind, type_id) = col_kinds[i];
                         let item_size = item_sizes[i];
+                        // Resolve the drop info (fallible) BEFORE decoding, so the
+                        // guard is constructed infallibly after — a decoded heap
+                        // buffer can never be handed to a fallible op that would
+                        // drop it as plain bytes → leak.
+                        let armed = column_arm(kind, type_id, item_size, codecs)?;
                         // All rows alive ⇒ pass `None` (no mask): every row is
                         // materialized.
                         let native = native_column_page(
@@ -813,7 +836,7 @@ fn materialize_world(
                              {row_count} * {item_size}",
                             native.len()
                         );
-                        guard_column(native, kind, type_id, item_size, codecs)
+                        Ok(DecodedColumn::new(native, armed))
                     })
                     .collect::<Result<_, _>>()?;
                     (page_entities.clone(), cols)
@@ -854,6 +877,11 @@ fn materialize_world(
                         // mask skips dead rows entirely, so they are never decoded.
                         let (kind, type_id) = col_kinds[i];
                         let item_size = item_sizes[i];
+                        // Resolve the drop info (fallible) BEFORE decoding, so the
+                        // guard is constructed infallibly after — a decoded heap
+                        // buffer can never be handed to a fallible op that would
+                        // drop it as plain bytes → leak.
+                        let armed = column_arm(kind, type_id, item_size, codecs)?;
                         let buf = native_column_page(
                             page,
                             kind,
@@ -875,7 +903,7 @@ fn materialize_world(
                          {live_count} * {item_size}",
                             buf.len()
                         );
-                        live_cols.push(guard_column(buf, kind, type_id, item_size, codecs)?);
+                        live_cols.push(DecodedColumn::new(buf, armed));
                     }
                     (live_entities, live_cols)
                 };
@@ -896,6 +924,12 @@ fn materialize_world(
                 // has a codec (the flush gate proves it). The source pages passed
                 // per-page CRC validation on read, and every entity in `entities` is
                 // alive per the allocator state restored above (dead rows filtered).
+                // The armed-drop-on-`Err` correctness relies on `World::import_page`
+                // being ALL-OR-NOTHING: it validates every entity (dead/already-placed)
+                // BEFORE any `append_bytes_unchecked`, and its byte-copy loop is
+                // infallible — so an `Err` means zero columns were transferred, and
+                // dropping the still-armed guards frees each heap value exactly once
+                // (no double free with a partially-populated archetype).
                 unsafe { world.import_page(&import_page) }
                     .map_err(|e| LsmError::Format(format!("import_page failed for {sig:?}: {e}")))
                 // col_refs + import_page dropped at block end, releasing the borrow
@@ -1616,14 +1650,16 @@ mod tests {
             .expect("deserialize ok");
         assert_eq!(native.len(), item_size, "one native row");
 
-        let guard = guard_column(
+        let guard = DecodedColumn::new(
             native,
-            crate::schema::StorageKind::Serialized,
-            Some(ty),
-            item_size,
-            &codecs,
-        )
-        .expect("guard built");
+            column_arm(
+                crate::schema::StorageKind::Serialized,
+                Some(ty),
+                item_size,
+                &codecs,
+            )
+            .unwrap(),
+        );
         assert!(guard.armed.is_some(), "serialized column must be armed");
 
         let before = DROPS.load(Ordering::SeqCst);
@@ -1676,14 +1712,16 @@ mod tests {
             .expect("codec exists")
             .expect("deserialize ok");
 
-        let mut guard = guard_column(
+        let mut guard = DecodedColumn::new(
             native,
-            crate::schema::StorageKind::Serialized,
-            Some(ty),
-            item_size,
-            &codecs,
-        )
-        .expect("guard built");
+            column_arm(
+                crate::schema::StorageKind::Serialized,
+                Some(ty),
+                item_size,
+                &codecs,
+            )
+            .unwrap(),
+        );
 
         let before = DROPS.load(Ordering::SeqCst);
         guard.disarm(); // success path: ownership transferred to a World column
@@ -1719,14 +1757,16 @@ mod tests {
         let item_size = std::mem::size_of::<Pod>();
 
         let bytes = vec![0u8; item_size];
-        let guard = guard_column(
+        let guard = DecodedColumn::new(
             bytes,
-            crate::schema::StorageKind::RawCopy,
-            Some(ty),
-            item_size,
-            &codecs,
-        )
-        .expect("guard built");
+            column_arm(
+                crate::schema::StorageKind::RawCopy,
+                Some(ty),
+                item_size,
+                &codecs,
+            )
+            .unwrap(),
+        );
         assert!(
             guard.armed.is_none(),
             "raw-copy/POD column must be unarmed (no element drop)"


### PR DESCRIPTION
Follow-up to #207. Two changes to the LSM recovery decode seam that didn't make the original merge: a drop-safety leak fix (N5, deferred from #207 as out-of-scope there) and a type-design refactor (implemented + reviewed clean in #207's branch but never pushed before merge).

## 1. N5 — free decoded heap columns on the import-error path

A decoded Serialized column `Vec<u8>` byte-owns reconstructed heap values (`String`/`Vec`). If `ImportPage::page` or `world.import_page` **errors** mid-recovery, dropping that buffer as plain bytes frees the `u8` allocation but runs no `String::drop`, **leaking every reconstructed heap value** (both decode paths).

Fix: a `DecodedColumn` drop guard armed with a per-type codec `drop_fn`.
- On the **error path** (either `ImportPage::page()?` or `import_page()?`), the still-`armed` guard's `Drop` runs `drop_fn` on each row, freeing the heap values.
- On the **success path**, `import_page` has bitwise-copied ownership into the archetype column, so `disarm()` is called and the guard drops only its byte buffer — no double free.
- `drop_fn` reads each row out **unaligned** before dropping (the buffer is `Vec<u8>`, alignment 1), so no unaligned reference is ever formed.
- RawCopy/POD columns are constructed unarmed (no heap, no drop).

**Verified with Miri (Tree Borrows)** on three guard tests: armed-frees-once, disarm-prevents-double-free, raw-copy-unarmed.

## 2. Bind the decode proof to its bytes; drop the vestigial `_proof` param

- `validate_page_crc` now returns `(&[u8] proven_slice, CrcProof)`, so recovery stores exactly the proven bytes — the proof↔bytes coupling is structural at the construction site instead of a cross-file equivalence. Also removes the duplicate kind-based slicing (byte-identical at all four call sites).
- `deserialize_unchecked_by_type` drops its unused `_proof` param: the method is `unsafe` (caller asserts validity), and the `CrcProof` remains in `DecodeMode::Unchecked` as the construction gate. No behavior change.

## Testing

244 LSM lib + 922 workspace tests pass; `clippy --workspace --all-targets` clean; Miri (Tree Borrows) clean on the drop-guard tests. An adversarial soundness review confirmed disarm-is-reached-on-every-success (borrow released before the disarm loop; `import_page` is all-or-nothing) and armed-on-every-error, and that the two changes' auto-merge in `native_column_page` is clean (no half-merged hybrid).

## Known follow-up (not in this PR)

Same bug *class* as N5, one level deeper: if `native_column_page` errors **mid-column** (a corrupt row K), its in-progress `buf` leaks rows 0..K's heap. Pre-existing, bounded, on an already-failing recovery — deferred to a focused follow-up so this PR stays scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)